### PR TITLE
remove bogus "WAL archiver" check

### DIFF
--- a/barman/server.py
+++ b/barman/server.py
@@ -338,8 +338,6 @@ class Server(RemoteStatusMixin):
         :param CheckStrategy check_strategy: the strategy for the management
              of the results of the various checks
         """
-        # Check WAL archive
-        self.check_archive(check_strategy)
         # Check postgres configuration
         self.check_postgres(check_strategy)
         # Check barman directories from barman configuration
@@ -361,21 +359,6 @@ class Server(RemoteStatusMixin):
 
         # Check archiver errors
         self.check_archiver_errors(check_strategy)
-
-    def check_archive(self, check_strategy):
-        """
-        Checks WAL archive
-
-        :param CheckStrategy check_strategy: the strategy for the management
-             of the results of the various checks
-        """
-        # Check WAL archiving has been setup
-        # NOTE: This check needs to be only visible if it fails
-        with self.xlogdb() as fxlogdb:
-            if os.fstat(fxlogdb.fileno()).st_size == 0:
-                check_strategy.result(
-                    self.config.name, 'WAL archive', False,
-                    'please make sure WAL shipping is setup')
 
     def check_postgres(self, check_strategy):
         """

--- a/doc/barman-tutorial.en.md
+++ b/doc/barman-tutorial.en.md
@@ -419,11 +419,6 @@ continuous WAL archiving.
 > The `barman check main` command automatically creates all the
 > directories for the continuous backup of the `main` server.
 
-> ** VERY IMPORTANT:**
-> If the check for the WAL archive fails and you receive the hint
-> 'please make sure WAL shipping is setup', rightly do so and set
-> continuous WAL archiving and WAL streaming (see next sections).
-
 ### Continuous WAL archiving
 
 Barman requires that continuous WAL archiving via PostgreSQL's

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -635,34 +635,6 @@ class TestServer(object):
         assert "No switch required for server 'main'" in out
         assert server.postgres.checkpoint.called is False
 
-    def test_check_archive(self, tmpdir):
-        """
-        Test the check_archive method
-        """
-        # Setup temp dir and server
-        server = build_real_server(
-            global_conf={
-                "barman_lock_directory": tmpdir.mkdir('lock').strpath
-            },
-            main_conf={
-                "wals_directory": tmpdir.mkdir('wals').strpath
-            })
-        strategy = CheckStrategy()
-        # Call the check on an empty xlog file. expect it to contain errors.
-        server.check_archive(strategy)
-        assert strategy.has_error is True
-        assert strategy.check_result[0].check == 'WAL archive'
-        assert strategy.check_result[0].status is False
-
-        # Write something in the xlog db file and check for the results
-        with server.xlogdb('w') as fxlogdb:
-            fxlogdb.write("00000000000000000000")
-        # The check strategy should contain no errors.
-        strategy = CheckStrategy()
-        server.check_archive(strategy)
-        assert strategy.has_error is False
-        assert len(strategy.check_result) == 0
-
     def test_replication_status(self, capsys):
         """
         Test management of pg_stat_archiver view output


### PR DESCRIPTION
This check prevents taking the initial backup from an inactive
server, e.g. during initial setup of the whole system. Requiring
activity in the cluster defies the "PITR from the start" principle.
Further, this had been a rather superficial check anyway - having
"something" in the xlogdb does not prove the WAL archive would be
usable (e.g. wrong server, incomplete archive, ...), so there's no
loss of functionality.
NOTE: this basically reverts 91cb846fbcd156dc21faa82619de6ade71fc3b87
except for the typo fix.
