### PR TITLE
Nagios enhancements: performance data, last_wal_maximum_age, last_backup_minimum_size

### DIFF
--- a/barman/backup.py
+++ b/barman/backup.py
@@ -851,6 +851,32 @@ class BackupManager(RemoteStatusMixin):
             # If no backup is available return false
             return False, "No available backups"
 
+    def validate_last_backup_min_size(self, last_backup_minimum_size):
+        """
+        Evaluate the size of the last available backup in a catalogue.
+        If the last backup is smaller than the specified size
+        the function returns False.
+        Otherwise, the function returns True.
+
+        :param last_backup_minimum_size: size in bytes
+            representing the maximum allowed age for the last backup
+            in a server catalogue
+        :return tuple: a tuple containing the boolean result of the check and
+            auxiliary information about the last backup current age
+        """
+        # Get the ID of the last available backup
+        backup_id = self.get_last_backup_id()
+        if backup_id:
+            # Get the backup object
+            backup = BackupInfo(self.server, backup_id=backup_id)
+            if backup.size < last_backup_minimum_size:
+                return False, backup.size
+            else:
+                return True, backup.size
+        else:
+            # If no backup is available return false
+            return False, 0
+
     def backup_fsync_and_set_sizes(self, backup_info):
         """
         Fsync all files in a backup and set the actual size on disk

--- a/barman/config.py
+++ b/barman/config.py
@@ -53,9 +53,11 @@ _TRUE_RE = re.compile(r"""^(true|t|yes|1|on)$""", re.IGNORECASE)
 _FALSE_RE = re.compile(r"""^(false|f|no|0|off)$""", re.IGNORECASE)
 _TIME_INTERVAL_RE = re.compile(r"""
       ^\s*
-      (\d+)\s+(day|month|week)s?  # N (day|month|week) with optional 's'
+      # N (day|month|week|hour) with optional 's'
+      (\d+)\s+(day|month|week|hour)s?
       \s*$
       """, re.IGNORECASE | re.VERBOSE)
+_SI_SUFFIX_RE = re.compile(r"""(\d+)\s*(k|Ki|M|Mi|G|Gi|T|Ti)?\s*$""")
 
 REUSE_BACKUP_VALUES = ('copy', 'link', 'off')
 
@@ -204,11 +206,56 @@ def parse_time_interval(value):
         time_delta = datetime.timedelta(weeks=value)
     elif unit == 'm':
         time_delta = datetime.timedelta(days=(31 * value))
+    elif unit == 'h':
+        time_delta = datetime.timedelta(hours=value)
     else:
         # This should never happen
         raise ValueError("Invalid unit time %s" % unit)
 
     return time_delta
+
+
+def parse_si_suffix(value):
+    """
+    Parse a string, transforming it into integer and multiplying by
+    the SI or IEC suffix
+    eg a suffix of Ki multiplies the integer value by 1024
+    and returns the new value
+
+    Accepted format: N (k|Ki|M|Mi|G|Gi|T|Ti)
+
+    :param str value: the string to evaluate
+    """
+    # if empty string or none return none
+    if value is None or value == '':
+        return None
+    result = _SI_SUFFIX_RE.match(value)
+    if not result:
+        raise ValueError("Invalid value for a number %s" %
+                         value)
+    # if the int conversion
+    value = int(result.groups()[0])
+    unit = result.groups()[1]
+
+    # Calculates the value
+    if unit == 'k':
+        value *= 1000
+    elif unit == 'Ki':
+        value *= 1024
+    elif unit == 'M':
+        value *= 1000000
+    elif unit == 'Mi':
+        value *= 1048576
+    elif unit == 'G':
+        value *= 1000000000
+    elif unit == 'Gi':
+        value *= 1073741824
+    elif unit == 'T':
+        value *= 1000000000000
+    elif unit == 'Ti':
+        value *= 1099511627776
+
+    return value
 
 
 def parse_reuse_backup(value):
@@ -274,6 +321,8 @@ class ServerConfig(object):
         'immediate_checkpoint',
         'incoming_wals_directory',
         'last_backup_maximum_age',
+        'last_backup_minimum_size',
+        'last_wal_maximum_age',
         'max_incoming_wals_queue',
         'minimum_redundancy',
         'network_compression',
@@ -319,6 +368,8 @@ class ServerConfig(object):
         'custom_decompression_filter',
         'immediate_checkpoint',
         'last_backup_maximum_age',
+        'last_backup_minimum_size',
+        'last_wal_maximum_age',
         'max_incoming_wals_queue',
         'minimum_redundancy',
         'network_compression',
@@ -391,6 +442,8 @@ class ServerConfig(object):
         'disabled': parse_boolean,
         'immediate_checkpoint': parse_boolean,
         'last_backup_maximum_age': parse_time_interval,
+        'last_backup_minimum_size': parse_si_suffix,
+        'last_wal_maximum_age': parse_time_interval,
         'max_incoming_wals_queue': int,
         'network_compression': parse_boolean,
         'parallel_jobs': int,

--- a/barman/server.py
+++ b/barman/server.py
@@ -20,6 +20,7 @@ This module represents a Server.
 Barman is able to manage multiple servers.
 """
 
+import datetime
 import logging
 import os
 import shutil
@@ -29,6 +30,8 @@ from collections import namedtuple
 from contextlib import contextmanager
 from glob import glob
 from tempfile import NamedTemporaryFile
+
+import dateutil.tz
 
 import barman
 from barman import output, xlog
@@ -78,12 +81,14 @@ class CheckStrategy(object):
     # Default list used as a filter to identify non-critical checks
     NON_CRITICAL_CHECKS = ['minimum redundancy requirements',
                            'backup maximum age',
+                           'backup minimum size',
                            'failed backups',
                            'archiver errors',
                            'empty incoming directory',
                            'empty streaming directory',
                            'incoming WALs directory',
                            'streaming WALs directory',
+                           'wal maximum age',
                            ]
 
     def __init__(self, ignore_checks=NON_CRITICAL_CHECKS):
@@ -112,7 +117,8 @@ class CheckStrategy(object):
         assert check
         return check
 
-    def result(self, server_name, status, hint=None, check=None):
+    def result(self, server_name, status, hint=None, check=None,
+               perfdata=None):
         """
         Store the result of a check (with no output).
         Log any check result (error or debug level).
@@ -162,7 +168,8 @@ class CheckOutputStrategy(CheckStrategy):
         """
         super(CheckOutputStrategy, self).__init__(ignore_checks=())
 
-    def result(self, server_name, status, hint=None, check=None):
+    def result(self, server_name, status, hint=None, check=None,
+               perfdata=None):
         """
         Store the result of a check.
         Log any check result (error or debug level).
@@ -175,9 +182,9 @@ class CheckOutputStrategy(CheckStrategy):
         """
         check = self._check_name(check)
         super(CheckOutputStrategy, self).result(
-            server_name, status, hint, check)
+            server_name, status, hint, check, perfdata)
         # Send result to output
-        output.result('check', server_name, check, status, hint)
+        output.result('check', server_name, check, status, hint, perfdata)
 
 
 class Server(RemoteStatusMixin):
@@ -439,6 +446,8 @@ class Server(RemoteStatusMixin):
                 self.check_retention_policy_settings(check_strategy)
                 # Check for backup validity
                 self.check_backup_validity(check_strategy)
+                # Check WAL archiving is happening
+                self.check_wal_validity(check_strategy)
                 # Executes the backup manager set of checks
                 self.backup_manager.check(check_strategy)
                 # Check if the msg_list of the server
@@ -749,6 +758,86 @@ class Server(RemoteStatusMixin):
                 self.config.name,
                 True,
                 hint="no last_backup_maximum_age provided")
+
+        # second check: check backup minimum size
+        check_strategy.init_check('backup minimum size')
+        if self.config.last_backup_minimum_size is not None:
+            backup_size = self.backup_manager.validate_last_backup_min_size(
+              self.config.last_backup_minimum_size)
+            gtlt = '>' if backup_size[0] else '<'
+            check_strategy.result(
+                self.config.name,
+                backup_size[0],
+                hint="last backup size %s %s %s minimum" % (
+                     pretty_size(backup_size[1]),
+                     gtlt,
+                     pretty_size(self.config.last_backup_minimum_size)),
+                perfdata=backup_size[1])
+        else:
+            # no last_backup_minimum_size provided by the user
+            backup_size = self.backup_manager.validate_last_backup_min_size(
+              0)
+            check_strategy.result(
+                self.config.name,
+                True,
+                hint=pretty_size(backup_size[1]),
+                perfdata=backup_size[1])
+
+    def check_wal_validity(self, check_strategy):
+        """
+        Check if wal archiving requirements are satisfied
+        """
+        check_strategy.init_check('wal maximum age')
+        backup_id = self.backup_manager.get_last_backup_id()
+        backup_info = self.get_backup(backup_id)
+        if backup_info is not None:
+            wal_info = self.get_wal_info(backup_info)
+        # first check: check wal maximum age
+        if self.config.last_wal_maximum_age is not None:
+            # get maximum age information
+            if backup_info is None or wal_info['wal_last_timestamp'] is None:
+                # No WAL files received
+                # (we should have the .backup file, as a minimum)
+                # This may also be an indication that 'barman cron' is not
+                # running
+                wal_age_isok = False
+                wal_message = 'No WAL files archived for last backup'
+                wal_size = 0
+            else:
+                wal_last = datetime.datetime.fromtimestamp(
+                                                wal_info['wal_last_timestamp'],
+                                                dateutil.tz.tzlocal())
+                now = datetime.datetime.now(dateutil.tz.tzlocal())
+                wal_age = now - wal_last
+                if wal_age <= self.config.last_wal_maximum_age:
+                    wal_age_isok = True
+                else:
+                    wal_age_isok = False
+                wal_message = "interval provided: %s, latest wal age: %s" % (
+                    human_readable_timedelta(self.config.last_wal_maximum_age),
+                    human_readable_timedelta(wal_age))
+                if wal_info['wal_until_next_size'] is None:
+                    wal_size = 0
+                else:
+                    wal_size = wal_info['wal_until_next_size']
+            # format the output
+            check_strategy.result(self.config.name,
+                                  wal_age_isok,
+                                  hint=wal_message)
+        else:
+            # no last_wal_maximum_age provided by the user
+            if backup_info is None or wal_info['wal_until_next_size'] is None:
+                wal_size = 0
+            else:
+                wal_size = wal_info['wal_until_next_size']
+            check_strategy.result(self.config.name,
+                                  True,
+                                  hint="no last_wal_maximum_age provided")
+
+        check_strategy.init_check('wal size')
+        check_strategy.result(
+            self.config.name, True,
+            pretty_size(wal_size), perfdata=wal_size)
 
     def check_archiver_errors(self, check_strategy):
         """

--- a/doc/barman.5
+++ b/doc/barman.5
@@ -506,6 +506,43 @@ Server.
 .RS
 .RE
 .TP
+.B last_backup_maximum_age
+This option identifies a time frame that must contain the latest backup.
+If the latest backup is older than the time frame, barman check command
+will report an error to the user.
+If empty (default), latest backup is always considered valid.
+Syntax for this option is: "i (DAYS | WEEKS | MONTHS | HOURS)" where i
+is an integer greater than zero, representing the number of hours | days
+| weeks | months of the time frame.
+Global/Server.
+.RS
+.RE
+.TP
+.B last_backup_minimum_size
+This option identifies lower limit to the acceptable size of the latest
+successful backup If the latest backup is smaller than the specified
+size, barman check command will report an error to the user.
+If empty (default), latest backup is always considered valid.
+Syntax for this option is: "i (k|Ki|M|Mi|G|Gi|T|Ti)" where i is an
+integer.
+greater than zero, with an optional SI or IEC suffix.
+k=kilo=1000, Ki=Kibi=1024 and so forth.
+Note that the suffix is case\-sensitive.
+Global/Server.
+.RS
+.RE
+.TP
+.B last_wal_maximum_age
+This option identifies a time frame that must contain the latest WAL
+file archived.
+If the latest WAL file is older than the time frame, barman check
+command will report an error to the user.
+If empty (default), the age of the WAL files is not checked.
+Syntax is the same as last_backup_maximum_age (above).
+Global/Server.
+.RS
+.RE
+.TP
 .B streaming_wals_directory
 Directory where WAL files are streamed from the PostgreSQL server to
 Barman.

--- a/doc/barman.5.md
+++ b/doc/barman.5.md
@@ -277,6 +277,33 @@ retention_policy
 retention_policy_mode
 :   Currently only "auto" is implemented. Global/Server.
 
+last_backup_maximum_age
+:   This option identifies a time frame that must contain the latest backup.
+    If the latest backup is older than the time frame, barman check command will
+    report an error to the user.
+    If empty (default), latest backup is always considered valid.
+    Syntax for this option is: "i (DAYS | WEEKS | MONTHS | HOURS)" where i is an integer
+    greater than zero, representing the number of hours | days | weeks | months
+    of the time frame. Global/Server.
+
+last_backup_minimum_size
+:   This option identifies lower limit to the acceptable size of the latest successful backup
+    If the latest backup is smaller than the specified size, barman check command will
+    report an error to the user.
+    If empty (default), latest backup is always considered valid.
+    Syntax for this option is: "i (k|Ki|M|Mi|G|Gi|T|Ti)" where i is an integer
+    greater than zero, with an optional SI or IEC suffix. k=kilo=1000, Ki=Kibi=1024 and so forth.
+    Note that the suffix is case-sensitive.
+    Global/Server.
+
+last_wal_maximum_age
+:   This option identifies a time frame that must contain the latest WAL file archived.
+    If the latest WAL file is older than the time frame, barman check command
+    will report an error to the user.
+    If empty (default), the age of the WAL files is not checked.
+    Syntax is the same as last_backup_maximum_age (above).
+    Global/Server.
+
 reuse_backup
 :   This option controls incremental backup support. Global/Server.
     Possible values are:

--- a/doc/barman.conf
+++ b/doc/barman.conf
@@ -67,10 +67,17 @@ log_level = INFO
 ; If the latest backup is older than the time frame, barman check
 ; command will report an error to the user.
 ; If empty, the latest backup is always considered valid.
-; Syntax for this option is: "i (DAYS | WEEKS | MONTHS)" where i is an
+; Syntax for this option is: "i (DAYS | WEEKS | MONTHS | HOURS)" where i is an
 ; integer > 0 which identifies the number of days | weeks | months of
 ; validity of the latest backup for this check. Also known as 'smelly backup'.
 ;last_backup_maximum_age =
+
+; Time frame that must contain the latest WAL file
+; If the latest WAL file is older than the time frame, barman check
+; command will report an error to the user.
+; Syntax for this option is: "i (DAYS | WEEKS | MONTHS | HOURS)" where i is an
+; integer > 0
+;last_wal_maximum_age =
 
 ; Minimum number of required backups (redundancy)
 ;minimum_redundancy = 1

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1188,7 +1188,7 @@ class TestNagiosWriter(object):
         writer.close()
         (out, err) = capsys.readouterr()
         assert out == 'BARMAN OK - Ready to serve the Espresso backup ' \
-                      'for a\n'
+                      'for a|\n'
         assert err == ''
         assert not output.error_occurred
 
@@ -1200,11 +1200,13 @@ class TestNagiosWriter(object):
         writer.result_check('a', 'test', True, None)
         writer.result_check('b', 'test', True, None)
         writer.result_check('c', 'test', True, None)
+        writer.result_check('c', 'backup minimum size', True,
+                            789, perfdata=789)
 
         writer.close()
         (out, err) = capsys.readouterr()
         assert out == 'BARMAN OK - Ready to serve the Espresso backup ' \
-                      'for 3 server(s) * a * b * c\n'
+                      'for 3 server(s) * a * b * c|c=789B\n'
         assert err == ''
         assert not output.error_occurred
 
@@ -1218,7 +1220,7 @@ class TestNagiosWriter(object):
         writer.close()
         (out, err) = capsys.readouterr()
         assert out == 'BARMAN CRITICAL - server a has issues * ' \
-                      'a FAILED: test\na.test: FAILED\n'
+                      'a FAILED: test|\na.test: FAILED\n'
         assert err == ''
         assert output.error_occurred
         assert output.error_exit_code == 2
@@ -1231,11 +1233,12 @@ class TestNagiosWriter(object):
         writer.result_check('a', 'test', True, None)
         writer.result_check('b', 'test', False, None)
         writer.result_check('c', 'test', True, None)
+        writer.result_check('c', 'wal size', True, 789, perfdata=789)
 
         writer.close()
         (out, err) = capsys.readouterr()
         assert out == 'BARMAN CRITICAL - 1 server out of 3 have issues * ' \
-                      'b FAILED: test\nb.test: FAILED\n'
+                      'b FAILED: test|c_wals=789B\nb.test: FAILED\n'
         assert err == ''
         assert output.error_occurred
         assert output.error_exit_code == 2

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -274,6 +274,8 @@ def build_config_dictionary(config_keys=None):
         'post_archive_retry_script': None,
         'pre_archive_retry_script': None,
         'last_backup_maximum_age': None,
+        'last_backup_minimum_size': None,
+        'last_wal_maximum_age': None,
         'disabled': False,
         'msg_list': [],
         'path_prefix': None,


### PR DESCRIPTION
The command 'barman check ...' allows the age of the most recent backup to be checked using `last_backup_maximum_age` in /etc/barman.conf

This change adds a similar option `last_wal_maximum_age` for checking the age of the most recent WAL file archived for the most recent backup.

This change also outputs the following performance data:
- last backup size in bytes (per server)
- size of wals since last backup (per server)