### PR TITLE
Add zstd compression via command line utility only.

### DIFF
--- a/barman/compression.py
+++ b/barman/compression.py
@@ -344,6 +344,20 @@ class PyBZip2Compressor(InternalCompressor):
         return bz2.BZ2File(name, mode='rb')
 
 
+class ZstdCompressor(CommandCompressor):
+    """
+    Predefined compressor with Zstd
+    """
+
+    MAGIC = b'\x28\xb5\x2f\xfd'
+
+    def __init__(self, config, compression, path=None):
+        super(ZstdCompressor, self).__init__(
+            config, compression, path)
+        self._compress = self._build_command('zstd -q --single-thread -c')
+        self._decompress = self._build_command('zstd -q --single-thread -c -d')
+
+
 class CustomCompressor(CommandCompressor):
     """
     Custom compressor
@@ -371,6 +385,7 @@ compression_registry = {
     'gzip': GZipCompressor,
     'pigz': PigzCompressor,
     'bzip2': BZip2Compressor,
+    'zstd': ZstdCompressor,
     'pygzip': PyGZipCompressor,
     'pybzip2': PyBZip2Compressor,
     'custom': CustomCompressor,


### PR DESCRIPTION
Zstd is a lot faster than gzip or bzip2, so it should be an option. This patch adds zstd compression via command line utility only because I don't know what's the policy on dependencies to external python libraries. I'm guessing it's not very desirable.

Currently zstd (or any other) compression can be used via custom compression setting, but there's a race problem with that. It seems (to me) that when custom compression is turned on all unidentified WAL files are treated as compressed with custom compression. However, files which are still in the `streaming` directory aren't compressed at all. So if a client requests them (my clients do, this is not theoretical) then the decompression utility spits an error and Postgres doesn't start.

So I'd like to add zstd compression as a first class citizen.