### PR TITLE
Don't raise error if alarm handler is ignored fix 2ndquadrant-it/barman#272

### DIFF
--- a/barman/utils.py
+++ b/barman/utils.py
@@ -415,7 +415,8 @@ def timeout(timeout_duration):
 
     # set the timeout handler
     previous_handler = signal.signal(signal.SIGALRM, handler)
-    if previous_handler != signal.SIG_DFL and previous_handler != signal.SIG_IGN:
+    if previous_handler != signal.SIG_DFL \
+            and previous_handler != signal.SIG_IGN:
         signal.signal(signal.SIGALRM, previous_handler)
         raise AssertionError("Another timeout is already defined")
     # set the timeout duration

--- a/barman/utils.py
+++ b/barman/utils.py
@@ -415,7 +415,7 @@ def timeout(timeout_duration):
 
     # set the timeout handler
     previous_handler = signal.signal(signal.SIGALRM, handler)
-    if previous_handler != signal.SIG_DFL:
+    if previous_handler != signal.SIG_DFL and previous_handler != signal.SIG_IGN:
         signal.signal(signal.SIGALRM, previous_handler)
         raise AssertionError("Another timeout is already defined")
     # set the timeout duration


### PR DESCRIPTION
This patch should permit barman to be called by process managers like gnu parallel who set the SIGALRM handler to ignore. SIG_IGN should be as safe as SIG_DFL in this case as the function tries to know if the signal handler has already be set.