### PR TITLE
Add storage class configuration for cloud uploads

### DIFF
--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -94,7 +94,8 @@ def main(args=None):
                 encryption=config.encryption,
                 jobs=config.jobs,
                 profile_name=config.profile,
-                endpoint_url=config.endpoint_url)
+                endpoint_url=config.endpoint_url,
+                storage_class=config.storage_class)
 
             if not cloud_interface.test_connectivity():
                 raise SystemExit(1)
@@ -195,6 +196,12 @@ def parse_arguments(args=None):
         help="Enable server-side encryption for the transfer. "
              "Allowed values: 'AES256'|'aws:kms'.",
         choices=['AES256', 'aws:kms'],
+    )
+    parser.add_argument(
+        "-s", "--storage-class",
+        help="Configure storage class for objects stored in cloud"
+             "Allowed values depend on your S3 provider",
+        default="STANDARD",
     )
     parser.add_argument(
         "-t", "--test",

--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -56,7 +56,8 @@ def main(args=None):
             url=config.destination_url,
             encryption=config.encryption,
             profile_name=config.profile,
-            endpoint_url=config.endpoint_url)
+            endpoint_url=config.endpoint_url,
+            storage_class=config.storage_class)
 
         with closing(cloud_interface):
             uploader = S3WalUploader(
@@ -152,6 +153,12 @@ def parse_arguments(args=None):
              "Allowed values: 'AES256', 'aws:kms'",
         choices=['AES256', 'aws:kms'],
         metavar="ENCRYPTION",
+    )
+    parser.add_argument(
+        "-s", "--storage-class",
+        help="Configure storage class for objects stored in cloud"
+             "Allowed values depend on your S3 provider",
+        default="STANDARD",
     )
     parser.add_argument(
         "-t", "--test",


### PR DESCRIPTION
Add storage class configuration for cloud uploads
- Add new `--storage-class` flag to `cloud_backup` and `cloud_walarchive` to allow configuration of S3 provider storage classes for uploaded objects.
- This allows storing backup objects directly in the desired final StorageClass (e.g. IA/Glacier).
- The storage classes allowed vary from provider to provider, so we accept an arbitrary string rather than using choices=[]