### PR TITLE
Stop backups failing due to idle transactions

### DIFF
--- a/barman/postgres.py
+++ b/barman/postgres.py
@@ -21,6 +21,7 @@ This module represents the interface towards a PostgreSQL server.
 """
 
 import atexit
+from contextlib import contextmanager
 import logging
 from abc import ABCMeta
 
@@ -217,20 +218,21 @@ class PostgreSQL(with_metaclass(ABCMeta, RemoteStatusMixin)):
             self._conn = None
             _live_connections.remove(self)
 
+    @contextmanager
     def _cursor(self, *args, **kwargs):
         """
         Return a cursor
         """
-        conn = self.connect()
-        return conn.cursor(*args, **kwargs)
+        with self.connect() as conn:
+            yield conn.cursor(*args, **kwargs)
 
     @property
     def server_version(self):
         """
         Version of PostgreSQL (returned by psycopg2)
         """
-        conn = self.connect()
-        return conn.server_version
+        with self.connect() as conn:
+            return conn.server_version
 
     @property
     def server_txt_version(self):
@@ -240,19 +242,19 @@ class PostgreSQL(with_metaclass(ABCMeta, RemoteStatusMixin)):
         :rtype: str|None
         """
         try:
-            conn = self.connect()
-            major = int(conn.server_version / 10000)
-            minor = int(conn.server_version / 100 % 100)
-            patch = int(conn.server_version % 100)
-            if major < 10:
-                return "%d.%d.%d" % (major, minor, patch)
-            if minor != 0:
-                _logger.warning(
-                    "Unexpected non zero minor version %s in %s",
-                    minor,
-                    conn.server_version,
-                )
-            return "%d.%d" % (major, patch)
+            with self.connect() as conn:
+                major = int(conn.server_version / 10000)
+                minor = int(conn.server_version / 100 % 100)
+                patch = int(conn.server_version % 100)
+                if major < 10:
+                    return "%d.%d.%d" % (major, minor, patch)
+                if minor != 0:
+                    _logger.warning(
+                        "Unexpected non zero minor version %s in %s",
+                        minor,
+                        conn.server_version,
+                    )
+                return "%d.%d" % (major, patch)
         except PostgresConnectionError as e:
             _logger.debug(
                 "Error retrieving PostgreSQL version: %s", force_str(e).strip()
@@ -343,19 +345,19 @@ class StreamingConnection(PostgreSQL):
                 return result
             result["streaming_supported"] = True
             # Execute a IDENTIFY_SYSYEM to check the connection
-            cursor = self._cursor()
-            cursor.execute("IDENTIFY_SYSTEM")
-            row = cursor.fetchone()
-            # If something has been returned, barman is connected
-            # to a replication backend
-            if row:
-                result["streaming"] = True
-                # IDENTIFY_SYSTEM always returns at least two values
-                result["streaming_systemid"] = row[0]
-                result["timeline"] = row[1]
-                # PostgreSQL 9.1+ returns also the current xlog flush location
-                if len(row) > 2:
-                    result["xlogpos"] = row[2]
+            with self._cursor() as cursor:
+                cursor.execute("IDENTIFY_SYSTEM")
+                row = cursor.fetchone()
+                # If something has been returned, barman is connected
+                # to a replication backend
+                if row:
+                    result["streaming"] = True
+                    # IDENTIFY_SYSTEM always returns at least two values
+                    result["streaming_systemid"] = row[0]
+                    result["timeline"] = row[1]
+                    # PostgreSQL 9.1+ returns also the current xlog flush location
+                    if len(row) > 2:
+                        result["xlogpos"] = row[2]
         except psycopg2.ProgrammingError:
             # This is not a streaming connection
             result["streaming"] = False
@@ -371,49 +373,49 @@ class StreamingConnection(PostgreSQL):
         Create a physical replication slot using the streaming connection
         :param str slot_name: Replication slot name
         """
-        cursor = self._cursor()
-        try:
-            # In the following query, the slot name is directly passed
-            # to the CREATE_REPLICATION_SLOT command, without any
-            # quoting. This is a characteristic of the streaming
-            # connection, otherwise if will fail with a generic
-            # "syntax error"
-            cursor.execute("CREATE_REPLICATION_SLOT %s PHYSICAL" % slot_name)
-            _logger.info("Replication slot '%s' successfully created", slot_name)
-        except psycopg2.DatabaseError as exc:
-            if exc.pgcode == DUPLICATE_OBJECT:
-                # A replication slot with the same name exists
-                raise PostgresDuplicateReplicationSlot()
-            elif exc.pgcode == CONFIGURATION_LIMIT_EXCEEDED:
-                # Unable to create a new physical replication slot.
-                # All slots are full.
-                raise PostgresReplicationSlotsFull()
-            else:
-                raise PostgresException(force_str(exc).strip())
+        with self._cursor() as cursor:
+            try:
+                # In the following query, the slot name is directly passed
+                # to the CREATE_REPLICATION_SLOT command, without any
+                # quoting. This is a characteristic of the streaming
+                # connection, otherwise if will fail with a generic
+                # "syntax error"
+                cursor.execute("CREATE_REPLICATION_SLOT %s PHYSICAL" % slot_name)
+                _logger.info("Replication slot '%s' successfully created", slot_name)
+            except psycopg2.DatabaseError as exc:
+                if exc.pgcode == DUPLICATE_OBJECT:
+                    # A replication slot with the same name exists
+                    raise PostgresDuplicateReplicationSlot()
+                elif exc.pgcode == CONFIGURATION_LIMIT_EXCEEDED:
+                    # Unable to create a new physical replication slot.
+                    # All slots are full.
+                    raise PostgresReplicationSlotsFull()
+                else:
+                    raise PostgresException(force_str(exc).strip())
 
     def drop_repslot(self, slot_name):
         """
         Drop a physical replication slot using the streaming connection
         :param str slot_name: Replication slot name
         """
-        cursor = self._cursor()
-        try:
-            # In the following query, the slot name is directly passed
-            # to the DROP_REPLICATION_SLOT command, without any
-            # quoting. This is a characteristic of the streaming
-            # connection, otherwise if will fail with a generic
-            # "syntax error"
-            cursor.execute("DROP_REPLICATION_SLOT %s" % slot_name)
-            _logger.info("Replication slot '%s' successfully dropped", slot_name)
-        except psycopg2.DatabaseError as exc:
-            if exc.pgcode == UNDEFINED_OBJECT:
-                # A replication slot with the that name does not exist
-                raise PostgresInvalidReplicationSlot()
-            if exc.pgcode == OBJECT_IN_USE:
-                # The replication slot is still in use
-                raise PostgresReplicationSlotInUse()
-            else:
-                raise PostgresException(force_str(exc).strip())
+        with self._cursor() as cursor:
+            try:
+                # In the following query, the slot name is directly passed
+                # to the DROP_REPLICATION_SLOT command, without any
+                # quoting. This is a characteristic of the streaming
+                # connection, otherwise if will fail with a generic
+                # "syntax error"
+                cursor.execute("DROP_REPLICATION_SLOT %s" % slot_name)
+                _logger.info("Replication slot '%s' successfully dropped", slot_name)
+            except psycopg2.DatabaseError as exc:
+                if exc.pgcode == UNDEFINED_OBJECT:
+                    # A replication slot with the that name does not exist
+                    raise PostgresInvalidReplicationSlot()
+                if exc.pgcode == OBJECT_IN_USE:
+                    # The replication slot is still in use
+                    raise PostgresReplicationSlotInUse()
+                else:
+                    raise PostgresException(force_str(exc).strip())
 
 
 class PostgreSQLConnection(PostgreSQL):
@@ -475,9 +477,9 @@ class PostgreSQLConnection(PostgreSQL):
         Human readable version of PostgreSQL (returned by the server)
         """
         try:
-            cur = self._cursor()
-            cur.execute("SELECT version()")
-            return cur.fetchone()[0].split()[1]
+            with self._cursor() as cur:
+                cur.execute("SELECT version()")
+                return cur.fetchone()[0].split()[1]
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
                 "Error retrieving PostgreSQL version: %s", force_str(e).strip()
@@ -493,12 +495,12 @@ class PostgreSQLConnection(PostgreSQL):
             # pg_extension is only available from Postgres 9.1+
             if self.server_version < 90100:
                 return False
-            cur = self._cursor()
-            cur.execute(
-                "SELECT count(*) FROM pg_extension " "WHERE extname = 'pgespresso'"
-            )
-            q_result = cur.fetchone()[0]
-            return q_result > 0
+            with self._cursor() as cur:
+                cur.execute(
+                    "SELECT count(*) FROM pg_extension " "WHERE extname = 'pgespresso'"
+                )
+                q_result = cur.fetchone()[0]
+                return q_result > 0
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
                 "Error retrieving pgespresso information: %s", force_str(e).strip()
@@ -514,9 +516,9 @@ class PostgreSQLConnection(PostgreSQL):
             # pg_is_in_recovery is only available from Postgres 9.0+
             if self.server_version < 90000:
                 return False
-            cur = self._cursor()
-            cur.execute("SELECT pg_is_in_recovery()")
-            return cur.fetchone()[0]
+            with self._cursor() as cur:
+                cur.execute("SELECT pg_is_in_recovery()")
+                return cur.fetchone()[0]
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
                 "Error calling pg_is_in_recovery() function: %s", force_str(e).strip()
@@ -529,9 +531,11 @@ class PostgreSQLConnection(PostgreSQL):
         Returns true if current user has superuser privileges
         """
         try:
-            cur = self._cursor()
-            cur.execute("SELECT usesuper FROM pg_user " "WHERE usename = CURRENT_USER")
-            return cur.fetchone()[0]
+            with self._cursor() as cur:
+                cur.execute(
+                    "SELECT usesuper FROM pg_user " "WHERE usename = CURRENT_USER"
+                )
+                return cur.fetchone()[0]
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
                 "Error calling is_superuser() function: %s", force_str(e).strip()
@@ -585,9 +589,9 @@ class PostgreSQLConnection(PostgreSQL):
           usename = CURRENT_USER
         """
         try:
-            cur = self._cursor()
-            cur.execute(backup_check_query)
-            return cur.fetchone()[0]
+            with self._cursor() as cur:
+                cur.execute(backup_check_query)
+                return cur.fetchone()[0]
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
                 "Error checking privileges for functions " "needed for backups: %s",
@@ -613,26 +617,28 @@ class PostgreSQLConnection(PostgreSQL):
         :rtype: psycopg2.extras.DictRow
         """
         try:
-            cur = self._cursor(cursor_factory=DictCursor)
-            if not self.is_in_recovery:
-                cur.execute(
-                    "SELECT location, "
-                    "({pg_walfile_name_offset}(location)).*, "
-                    "CURRENT_TIMESTAMP AS timestamp "
-                    "FROM {pg_current_wal_lsn}() AS location".format(**self.name_map)
-                )
-                return cur.fetchone()
-            else:
-                cur.execute(
-                    "SELECT location, "
-                    "NULL AS file_name, "
-                    "NULL AS file_offset, "
-                    "CURRENT_TIMESTAMP AS timestamp "
-                    "FROM {pg_last_wal_replay_lsn}() AS location".format(
-                        **self.name_map
+            with self._cursor(cursor_factory=DictCursor) as cur:
+                if not self.is_in_recovery:
+                    cur.execute(
+                        "SELECT location, "
+                        "({pg_walfile_name_offset}(location)).*, "
+                        "CURRENT_TIMESTAMP AS timestamp "
+                        "FROM {pg_current_wal_lsn}() AS location".format(
+                            **self.name_map
+                        )
                     )
-                )
-                return cur.fetchone()
+                    return cur.fetchone()
+                else:
+                    cur.execute(
+                        "SELECT location, "
+                        "NULL AS file_name, "
+                        "NULL AS file_offset, "
+                        "CURRENT_TIMESTAMP AS timestamp "
+                        "FROM {pg_last_wal_replay_lsn}() AS location".format(
+                            **self.name_map
+                        )
+                    )
+                    return cur.fetchone()
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
                 "Error retrieving current xlog " "detailed information: %s",
@@ -670,28 +676,32 @@ class PostgreSQLConnection(PostgreSQL):
             return DEFAULT_XLOG_SEG_SIZE
 
         try:
-            cur = self._cursor(cursor_factory=DictCursor)
-            # We can't use the `get_setting` method here, because it
-            # use `SHOW`, returning an human readable value such as "16MB",
-            # while we prefer a raw value such as 16777216.
-            cur.execute(
-                "SELECT setting " "FROM pg_settings " "WHERE name='wal_segment_size'"
-            )
-            result = cur.fetchone()
-            wal_segment_size = int(result[0])
-
-            # Prior to PostgreSQL 11, the wal segment size is returned in
-            # blocks
-            if self.server_version < 110000:
+            with self._cursor(cursor_factory=DictCursor) as cur:
+                # We can't use the `get_setting` method here, because it
+                # use `SHOW`, returning an human readable value such as "16MB",
+                # while we prefer a raw value such as 16777216.
                 cur.execute(
-                    "SELECT setting " "FROM pg_settings " "WHERE name='wal_block_size'"
+                    "SELECT setting "
+                    "FROM pg_settings "
+                    "WHERE name='wal_segment_size'"
                 )
                 result = cur.fetchone()
-                wal_block_size = int(result[0])
+                wal_segment_size = int(result[0])
 
-                wal_segment_size *= wal_block_size
+                # Prior to PostgreSQL 11, the wal segment size is returned in
+                # blocks
+                if self.server_version < 110000:
+                    cur.execute(
+                        "SELECT setting "
+                        "FROM pg_settings "
+                        "WHERE name='wal_block_size'"
+                    )
+                    result = cur.fetchone()
+                    wal_block_size = int(result[0])
 
-            return wal_segment_size
+                    wal_segment_size *= wal_block_size
+
+                return wal_segment_size
         except ValueError as e:
             _logger.error(
                 "Error retrieving current xlog " "segment size: %s",
@@ -721,9 +731,9 @@ class PostgreSQLConnection(PostgreSQL):
             return None
 
         try:
-            cur = self._cursor()
-            cur.execute("SELECT sum(pg_tablespace_size(oid)) " "FROM pg_tablespace")
-            return cur.fetchone()[0]
+            with self._cursor() as cur:
+                cur.execute("SELECT sum(pg_tablespace_size(oid)) " "FROM pg_tablespace")
+                return cur.fetchone()[0]
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
                 "Error retrieving PostgreSQL total size: %s", force_str(e).strip()
@@ -738,17 +748,17 @@ class PostgreSQLConnection(PostgreSQL):
         :return: The archive timeout (in seconds)
         """
         try:
-            cur = self._cursor(cursor_factory=DictCursor)
-            # We can't use the `get_setting` method here, because it
-            # uses `SHOW`, returning an human readable value such as "5min",
-            # while we prefer a raw value such as 300.
-            cur.execute(
-                "SELECT setting " "FROM pg_settings " "WHERE name='archive_timeout'"
-            )
-            result = cur.fetchone()
-            archive_timeout = int(result[0])
+            with self._cursor(cursor_factory=DictCursor) as cur:
+                # We can't use the `get_setting` method here, because it
+                # uses `SHOW`, returning an human readable value such as "5min",
+                # while we prefer a raw value such as 300.
+                cur.execute(
+                    "SELECT setting " "FROM pg_settings " "WHERE name='archive_timeout'"
+                )
+                result = cur.fetchone()
+                archive_timeout = int(result[0])
 
-            return archive_timeout
+                return archive_timeout
         except ValueError as e:
             _logger.error("Error retrieving archive_timeout: %s", force_str(e).strip())
             return None
@@ -761,17 +771,19 @@ class PostgreSQLConnection(PostgreSQL):
         :return: The checkpoint timeout (in seconds)
         """
         try:
-            cur = self._cursor(cursor_factory=DictCursor)
-            # We can't use the `get_setting` method here, because it
-            # uses `SHOW`, returning an human readable value such as "5min",
-            # while we prefer a raw value such as 300.
-            cur.execute(
-                "SELECT setting " "FROM pg_settings " "WHERE name='checkpoint_timeout'"
-            )
-            result = cur.fetchone()
-            checkpoint_timeout = int(result[0])
+            with self._cursor(cursor_factory=DictCursor) as cur:
+                # We can't use the `get_setting` method here, because it
+                # uses `SHOW`, returning an human readable value such as "5min",
+                # while we prefer a raw value such as 300.
+                cur.execute(
+                    "SELECT setting "
+                    "FROM pg_settings "
+                    "WHERE name='checkpoint_timeout'"
+                )
+                result = cur.fetchone()
+                checkpoint_timeout = int(result[0])
 
-            return checkpoint_timeout
+                return checkpoint_timeout
         except ValueError as e:
             _logger.error(
                 "Error retrieving checkpoint_timeout: %s", force_str(e).strip()
@@ -790,31 +802,31 @@ class PostgreSQLConnection(PostgreSQL):
             # pg_stat_archiver is only available from Postgres 9.4+
             if self.server_version < 90400:
                 return None
-            cur = self._cursor(cursor_factory=DictCursor)
-            # Select from pg_stat_archiver statistics view,
-            # retrieving statistics about WAL archiver process activity,
-            # also evaluating if the server is archiving without issues
-            # and the archived WALs per second rate.
-            #
-            # We are using current_settings to check for archive_mode=always.
-            # current_setting does normalise its output so we can just
-            # check for 'always' settings using a direct string
-            # comparison
-            cur.execute(
-                "SELECT *, "
-                "current_setting('archive_mode') IN ('on', 'always') "
-                "AND (last_failed_wal IS NULL "
-                "OR last_failed_wal LIKE '%.history' "
-                "AND substring(last_failed_wal from 1 for 8) "
-                "<= substring(last_archived_wal from 1 for 8) "
-                "OR last_failed_time <= last_archived_time) "
-                "AS is_archiving, "
-                "CAST (archived_count AS NUMERIC) "
-                "/ EXTRACT (EPOCH FROM age(now(), stats_reset)) "
-                "AS current_archived_wals_per_second "
-                "FROM pg_stat_archiver"
-            )
-            return cur.fetchone()
+            with self._cursor(cursor_factory=DictCursor) as cur:
+                # Select from pg_stat_archiver statistics view,
+                # retrieving statistics about WAL archiver process activity,
+                # also evaluating if the server is archiving without issues
+                # and the archived WALs per second rate.
+                #
+                # We are using current_settings to check for archive_mode=always.
+                # current_setting does normalise its output so we can just
+                # check for 'always' settings using a direct string
+                # comparison
+                cur.execute(
+                    "SELECT *, "
+                    "current_setting('archive_mode') IN ('on', 'always') "
+                    "AND (last_failed_wal IS NULL "
+                    "OR last_failed_wal LIKE '%.history' "
+                    "AND substring(last_failed_wal from 1 for 8) "
+                    "<= substring(last_archived_wal from 1 for 8) "
+                    "OR last_failed_time <= last_archived_time) "
+                    "AS is_archiving, "
+                    "CAST (archived_count AS NUMERIC) "
+                    "/ EXTRACT (EPOCH FROM age(now(), stats_reset)) "
+                    "AS current_archived_wals_per_second "
+                    "FROM pg_stat_archiver"
+                )
+                return cur.fetchone()
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
                 "Error retrieving pg_stat_archive data: %s", force_str(e).strip()
@@ -932,9 +944,9 @@ class PostgreSQLConnection(PostgreSQL):
             return
 
         try:
-            cur = self._cursor()
-            cur.execute("SELECT system_identifier::text FROM pg_control_system()")
-            return cur.fetchone()[0]
+            with self._cursor() as cur:
+                cur.execute("SELECT system_identifier::text FROM pg_control_system()")
+                return cur.fetchone()[0]
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
                 "Error retrieving PostgreSQL system Id: %s", force_str(e).strip()
@@ -948,9 +960,9 @@ class PostgreSQLConnection(PostgreSQL):
         :param name: a parameter name
         """
         try:
-            cur = self._cursor()
-            cur.execute('SHOW "%s"' % name.replace('"', '""'))
-            return cur.fetchone()[0]
+            with self._cursor() as cur:
+                cur.execute('SHOW "%s"' % name.replace('"', '""'))
+                return cur.fetchone()[0]
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
                 "Error retrieving PostgreSQL setting '%s': %s",
@@ -964,21 +976,21 @@ class PostgreSQLConnection(PostgreSQL):
         Returns a list of tablespaces or None if not present
         """
         try:
-            cur = self._cursor()
-            if self.server_version >= 90200:
-                cur.execute(
-                    "SELECT spcname, oid, "
-                    "pg_tablespace_location(oid) AS spclocation "
-                    "FROM pg_tablespace "
-                    "WHERE pg_tablespace_location(oid) != ''"
-                )
-            else:
-                cur.execute(
-                    "SELECT spcname, oid, spclocation "
-                    "FROM pg_tablespace WHERE spclocation != ''"
-                )
-            # Generate a list of tablespace objects
-            return [Tablespace._make(item) for item in cur.fetchall()]
+            with self._cursor() as cur:
+                if self.server_version >= 90200:
+                    cur.execute(
+                        "SELECT spcname, oid, "
+                        "pg_tablespace_location(oid) AS spclocation "
+                        "FROM pg_tablespace "
+                        "WHERE pg_tablespace_location(oid) != ''"
+                    )
+                else:
+                    cur.execute(
+                        "SELECT spcname, oid, spclocation "
+                        "FROM pg_tablespace WHERE spclocation != ''"
+                    )
+                # Generate a list of tablespace objects
+                return [Tablespace._make(item) for item in cur.fetchall()]
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
                 "Error retrieving PostgreSQL tablespaces: %s", force_str(e).strip()
@@ -996,30 +1008,32 @@ class PostgreSQLConnection(PostgreSQL):
             return self.configuration_files
         try:
             self.configuration_files = {}
-            cur = self._cursor()
-            cur.execute(
-                "SELECT name, setting FROM pg_settings "
-                "WHERE name IN ('config_file', 'hba_file', 'ident_file')"
-            )
-            for cname, cpath in cur.fetchall():
-                self.configuration_files[cname] = cpath
-
-            # Retrieve additional configuration files
-            # If PostgreSQL is older than 8.4 disable this check
-            if self.server_version >= 80400:
+            with self._cursor() as cur:
                 cur.execute(
-                    "SELECT DISTINCT sourcefile AS included_file "
-                    "FROM pg_settings "
-                    "WHERE sourcefile IS NOT NULL "
-                    "AND sourcefile NOT IN "
-                    "(SELECT setting FROM pg_settings "
-                    "WHERE name = 'config_file') "
-                    "ORDER BY 1"
+                    "SELECT name, setting FROM pg_settings "
+                    "WHERE name IN ('config_file', 'hba_file', 'ident_file')"
                 )
-                # Extract the values from the containing single element tuples
-                included_files = [included_file for included_file, in cur.fetchall()]
-                if len(included_files) > 0:
-                    self.configuration_files["included_files"] = included_files
+                for cname, cpath in cur.fetchall():
+                    self.configuration_files[cname] = cpath
+
+                # Retrieve additional configuration files
+                # If PostgreSQL is older than 8.4 disable this check
+                if self.server_version >= 80400:
+                    cur.execute(
+                        "SELECT DISTINCT sourcefile AS included_file "
+                        "FROM pg_settings "
+                        "WHERE sourcefile IS NOT NULL "
+                        "AND sourcefile NOT IN "
+                        "(SELECT setting FROM pg_settings "
+                        "WHERE name = 'config_file') "
+                        "ORDER BY 1"
+                    )
+                    # Extract the values from the containing single element tuples
+                    included_files = [
+                        included_file for included_file, in cur.fetchall()
+                    ]
+                    if len(included_files) > 0:
+                        self.configuration_files["included_files"] = included_files
 
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
@@ -1054,10 +1068,10 @@ class PostgreSQLConnection(PostgreSQL):
             return None
 
         try:
-            cur = self._cursor()
-            cur.execute("SELECT pg_create_restore_point(%s)", [target_name])
-            _logger.info("Restore point '%s' successfully created", target_name)
-            return cur.fetchone()[0]
+            with self._cursor() as cur:
+                cur.execute("SELECT pg_create_restore_point(%s)", [target_name])
+                _logger.info("Restore point '%s' successfully created", target_name)
+                return cur.fetchone()[0]
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
                 "Error issuing pg_create_restore_point()" "command: %s",
@@ -1328,36 +1342,38 @@ class PostgreSQLConnection(PostgreSQL):
         :rtype: str|None
         """
         try:
-            conn = self.connect()
-            # Requires superuser privilege
-            if not self.has_backup_privileges:
-                raise BackupFunctionsAccessRequired()
+            with self.connect() as conn:
+                # Requires superuser privilege
+                if not self.has_backup_privileges:
+                    raise BackupFunctionsAccessRequired()
 
-            # If this server is in recovery there is nothing to do
-            if self.is_in_recovery:
-                raise PostgresIsInRecovery()
+                # If this server is in recovery there is nothing to do
+                if self.is_in_recovery:
+                    raise PostgresIsInRecovery()
 
-            cur = conn.cursor()
-            # Collect the xlog file name before the switch
-            cur.execute(
-                "SELECT {pg_walfile_name}("
-                "{pg_current_wal_insert_lsn}())".format(**self.name_map)
-            )
-            pre_switch = cur.fetchone()[0]
-            # Switch
-            cur.execute(
-                "SELECT {pg_walfile_name}({pg_switch_wal}())".format(**self.name_map)
-            )
-            # Collect the xlog file name after the switch
-            cur.execute(
-                "SELECT {pg_walfile_name}("
-                "{pg_current_wal_insert_lsn}())".format(**self.name_map)
-            )
-            post_switch = cur.fetchone()[0]
-            if pre_switch < post_switch:
-                return pre_switch
-            else:
-                return ""
+                cur = conn.cursor()
+                # Collect the xlog file name before the switch
+                cur.execute(
+                    "SELECT {pg_walfile_name}("
+                    "{pg_current_wal_insert_lsn}())".format(**self.name_map)
+                )
+                pre_switch = cur.fetchone()[0]
+                # Switch
+                cur.execute(
+                    "SELECT {pg_walfile_name}({pg_switch_wal}())".format(
+                        **self.name_map
+                    )
+                )
+                # Collect the xlog file name after the switch
+                cur.execute(
+                    "SELECT {pg_walfile_name}("
+                    "{pg_current_wal_insert_lsn}())".format(**self.name_map)
+                )
+                post_switch = cur.fetchone()[0]
+                if pre_switch < post_switch:
+                    return pre_switch
+                else:
+                    return ""
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
                 "Error issuing {pg_switch_wal}() command: %s".format(**self.name_map),
@@ -1370,14 +1386,13 @@ class PostgreSQLConnection(PostgreSQL):
         Execute a checkpoint
         """
         try:
-            conn = self.connect()
+            with self.connect() as conn:
+                # Requires superuser privilege
+                if not self.is_superuser:
+                    raise PostgresSuperuserRequired()
 
-            # Requires superuser privilege
-            if not self.is_superuser:
-                raise PostgresSuperuserRequired()
-
-            cur = conn.cursor()
-            cur.execute("CHECKPOINT")
+                cur = conn.cursor()
+                cur.execute("CHECKPOINT")
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug("Error issuing CHECKPOINT: %s", force_str(e).strip())
 
@@ -1386,168 +1401,172 @@ class PostgreSQLConnection(PostgreSQL):
         Returns streaming replication information
         """
         try:
-            cur = self._cursor(cursor_factory=NamedTupleCursor)
+            with self._cursor(cursor_factory=NamedTupleCursor) as cur:
 
-            if not self.has_backup_privileges:
-                raise BackupFunctionsAccessRequired()
+                if not self.has_backup_privileges:
+                    raise BackupFunctionsAccessRequired()
 
-            # pg_stat_replication is a system view that contains one
-            # row per WAL sender process with information about the
-            # replication status of a standby server. It has been
-            # introduced in PostgreSQL 9.1. Current fields are:
-            #
-            # - pid (procpid in 9.1)
-            # - usesysid
-            # - usename
-            # - application_name
-            # - client_addr
-            # - client_hostname
-            # - client_port
-            # - backend_start
-            # - backend_xmin (9.4+)
-            # - state
-            # - sent_lsn (sent_location before 10)
-            # - write_lsn (write_location before 10)
-            # - flush_lsn (flush_location before 10)
-            # - replay_lsn (replay_location before 10)
-            # - sync_priority
-            # - sync_state
-            #
+                # pg_stat_replication is a system view that contains one
+                # row per WAL sender process with information about the
+                # replication status of a standby server. It has been
+                # introduced in PostgreSQL 9.1. Current fields are:
+                #
+                # - pid (procpid in 9.1)
+                # - usesysid
+                # - usename
+                # - application_name
+                # - client_addr
+                # - client_hostname
+                # - client_port
+                # - backend_start
+                # - backend_xmin (9.4+)
+                # - state
+                # - sent_lsn (sent_location before 10)
+                # - write_lsn (write_location before 10)
+                # - flush_lsn (flush_location before 10)
+                # - replay_lsn (replay_location before 10)
+                # - sync_priority
+                # - sync_state
+                #
 
-            if self.server_version < 90100:
-                raise PostgresUnsupportedFeature("9.1")
+                if self.server_version < 90100:
+                    raise PostgresUnsupportedFeature("9.1")
 
-            from_repslot = ""
-            where_clauses = []
-            if self.server_version >= 100000:
-                # Current implementation (10+)
-                what = "r.*, rs.slot_name"
-                # Look for replication slot name
-                from_repslot = (
-                    "LEFT JOIN pg_replication_slots rs " "ON (r.pid = rs.active_pid) "
+                from_repslot = ""
+                where_clauses = []
+                if self.server_version >= 100000:
+                    # Current implementation (10+)
+                    what = "r.*, rs.slot_name"
+                    # Look for replication slot name
+                    from_repslot = (
+                        "LEFT JOIN pg_replication_slots rs "
+                        "ON (r.pid = rs.active_pid) "
+                    )
+                    where_clauses += [
+                        "(rs.slot_type IS NULL OR " "rs.slot_type = 'physical')"
+                    ]
+                elif self.server_version >= 90500:
+                    # PostgreSQL 9.5/9.6
+                    what = (
+                        "pid, "
+                        "usesysid, "
+                        "usename, "
+                        "application_name, "
+                        "client_addr, "
+                        "client_hostname, "
+                        "client_port, "
+                        "backend_start, "
+                        "backend_xmin, "
+                        "state, "
+                        "sent_location AS sent_lsn, "
+                        "write_location AS write_lsn, "
+                        "flush_location AS flush_lsn, "
+                        "replay_location AS replay_lsn, "
+                        "sync_priority, "
+                        "sync_state, "
+                        "rs.slot_name"
+                    )
+                    # Look for replication slot name
+                    from_repslot = (
+                        "LEFT JOIN pg_replication_slots rs "
+                        "ON (r.pid = rs.active_pid) "
+                    )
+                    where_clauses += [
+                        "(rs.slot_type IS NULL OR " "rs.slot_type = 'physical')"
+                    ]
+                elif self.server_version >= 90400:
+                    # PostgreSQL 9.4
+                    what = (
+                        "pid, "
+                        "usesysid, "
+                        "usename, "
+                        "application_name, "
+                        "client_addr, "
+                        "client_hostname, "
+                        "client_port, "
+                        "backend_start, "
+                        "backend_xmin, "
+                        "state, "
+                        "sent_location AS sent_lsn, "
+                        "write_location AS write_lsn, "
+                        "flush_location AS flush_lsn, "
+                        "replay_location AS replay_lsn, "
+                        "sync_priority, "
+                        "sync_state"
+                    )
+                elif self.server_version >= 90200:
+                    # PostgreSQL 9.2/9.3
+                    what = (
+                        "pid, "
+                        "usesysid, "
+                        "usename, "
+                        "application_name, "
+                        "client_addr, "
+                        "client_hostname, "
+                        "client_port, "
+                        "backend_start, "
+                        "CAST (NULL AS xid) AS backend_xmin, "
+                        "state, "
+                        "sent_location AS sent_lsn, "
+                        "write_location AS write_lsn, "
+                        "flush_location AS flush_lsn, "
+                        "replay_location AS replay_lsn, "
+                        "sync_priority, "
+                        "sync_state"
+                    )
+                else:
+                    # PostgreSQL 9.1
+                    what = (
+                        "procpid AS pid, "
+                        "usesysid, "
+                        "usename, "
+                        "application_name, "
+                        "client_addr, "
+                        "client_hostname, "
+                        "client_port, "
+                        "backend_start, "
+                        "CAST (NULL AS xid) AS backend_xmin, "
+                        "state, "
+                        "sent_location AS sent_lsn, "
+                        "write_location AS write_lsn, "
+                        "flush_location AS flush_lsn, "
+                        "replay_location AS replay_lsn, "
+                        "sync_priority, "
+                        "sync_state"
+                    )
+
+                # Streaming client
+                if client_type == self.STANDBY:
+                    # Standby server
+                    where_clauses += [
+                        "{replay_lsn} IS NOT NULL".format(**self.name_map)
+                    ]
+                elif client_type == self.WALSTREAMER:
+                    # WAL streamer
+                    where_clauses += ["{replay_lsn} IS NULL".format(**self.name_map)]
+
+                if where_clauses:
+                    where = "WHERE %s " % " AND ".join(where_clauses)
+                else:
+                    where = ""
+
+                # Execute the query
+                cur.execute(
+                    "SELECT %s, "
+                    "pg_is_in_recovery() AS is_in_recovery, "
+                    "CASE WHEN pg_is_in_recovery() "
+                    "  THEN {pg_last_wal_receive_lsn}() "
+                    "  ELSE {pg_current_wal_lsn}() "
+                    "END AS current_lsn "
+                    "FROM pg_stat_replication r "
+                    "%s"
+                    "%s"
+                    "ORDER BY sync_state DESC, sync_priority".format(**self.name_map)
+                    % (what, from_repslot, where)
                 )
-                where_clauses += [
-                    "(rs.slot_type IS NULL OR " "rs.slot_type = 'physical')"
-                ]
-            elif self.server_version >= 90500:
-                # PostgreSQL 9.5/9.6
-                what = (
-                    "pid, "
-                    "usesysid, "
-                    "usename, "
-                    "application_name, "
-                    "client_addr, "
-                    "client_hostname, "
-                    "client_port, "
-                    "backend_start, "
-                    "backend_xmin, "
-                    "state, "
-                    "sent_location AS sent_lsn, "
-                    "write_location AS write_lsn, "
-                    "flush_location AS flush_lsn, "
-                    "replay_location AS replay_lsn, "
-                    "sync_priority, "
-                    "sync_state, "
-                    "rs.slot_name"
-                )
-                # Look for replication slot name
-                from_repslot = (
-                    "LEFT JOIN pg_replication_slots rs " "ON (r.pid = rs.active_pid) "
-                )
-                where_clauses += [
-                    "(rs.slot_type IS NULL OR " "rs.slot_type = 'physical')"
-                ]
-            elif self.server_version >= 90400:
-                # PostgreSQL 9.4
-                what = (
-                    "pid, "
-                    "usesysid, "
-                    "usename, "
-                    "application_name, "
-                    "client_addr, "
-                    "client_hostname, "
-                    "client_port, "
-                    "backend_start, "
-                    "backend_xmin, "
-                    "state, "
-                    "sent_location AS sent_lsn, "
-                    "write_location AS write_lsn, "
-                    "flush_location AS flush_lsn, "
-                    "replay_location AS replay_lsn, "
-                    "sync_priority, "
-                    "sync_state"
-                )
-            elif self.server_version >= 90200:
-                # PostgreSQL 9.2/9.3
-                what = (
-                    "pid, "
-                    "usesysid, "
-                    "usename, "
-                    "application_name, "
-                    "client_addr, "
-                    "client_hostname, "
-                    "client_port, "
-                    "backend_start, "
-                    "CAST (NULL AS xid) AS backend_xmin, "
-                    "state, "
-                    "sent_location AS sent_lsn, "
-                    "write_location AS write_lsn, "
-                    "flush_location AS flush_lsn, "
-                    "replay_location AS replay_lsn, "
-                    "sync_priority, "
-                    "sync_state"
-                )
-            else:
-                # PostgreSQL 9.1
-                what = (
-                    "procpid AS pid, "
-                    "usesysid, "
-                    "usename, "
-                    "application_name, "
-                    "client_addr, "
-                    "client_hostname, "
-                    "client_port, "
-                    "backend_start, "
-                    "CAST (NULL AS xid) AS backend_xmin, "
-                    "state, "
-                    "sent_location AS sent_lsn, "
-                    "write_location AS write_lsn, "
-                    "flush_location AS flush_lsn, "
-                    "replay_location AS replay_lsn, "
-                    "sync_priority, "
-                    "sync_state"
-                )
 
-            # Streaming client
-            if client_type == self.STANDBY:
-                # Standby server
-                where_clauses += ["{replay_lsn} IS NOT NULL".format(**self.name_map)]
-            elif client_type == self.WALSTREAMER:
-                # WAL streamer
-                where_clauses += ["{replay_lsn} IS NULL".format(**self.name_map)]
-
-            if where_clauses:
-                where = "WHERE %s " % " AND ".join(where_clauses)
-            else:
-                where = ""
-
-            # Execute the query
-            cur.execute(
-                "SELECT %s, "
-                "pg_is_in_recovery() AS is_in_recovery, "
-                "CASE WHEN pg_is_in_recovery() "
-                "  THEN {pg_last_wal_receive_lsn}() "
-                "  ELSE {pg_current_wal_lsn}() "
-                "END AS current_lsn "
-                "FROM pg_stat_replication r "
-                "%s"
-                "%s"
-                "ORDER BY sync_state DESC, sync_priority".format(**self.name_map)
-                % (what, from_repslot, where)
-            )
-
-            # Generate a list of standby objects
-            return cur.fetchall()
+                # Generate a list of standby objects
+                return cur.fetchall()
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
                 "Error retrieving status of standby servers: %s", force_str(e).strip()
@@ -1573,23 +1592,23 @@ class PostgreSQLConnection(PostgreSQL):
             # by PostgreSQL version
             raise PostgresUnsupportedFeature("9.4")
         else:
-            cur = self._cursor(cursor_factory=NamedTupleCursor)
-            try:
-                cur.execute(
-                    "SELECT slot_name, "
-                    "active, "
-                    "restart_lsn "
-                    "FROM pg_replication_slots "
-                    "WHERE slot_type = 'physical' "
-                    "AND slot_name = '%s'" % slot_name
-                )
-                # Retrieve the replication slot information
-                return cur.fetchone()
-            except (PostgresConnectionError, psycopg2.Error) as e:
-                _logger.debug(
-                    "Error retrieving replication_slots: %s", force_str(e).strip()
-                )
-                raise
+            with self._cursor(cursor_factory=NamedTupleCursor) as cur:
+                try:
+                    cur.execute(
+                        "SELECT slot_name, "
+                        "active, "
+                        "restart_lsn "
+                        "FROM pg_replication_slots "
+                        "WHERE slot_type = 'physical' "
+                        "AND slot_name = '%s'" % slot_name
+                    )
+                    # Retrieve the replication slot information
+                    return cur.fetchone()
+                except (PostgresConnectionError, psycopg2.Error) as e:
+                    _logger.debug(
+                        "Error retrieving replication_slots: %s", force_str(e).strip()
+                    )
+                    raise
 
     def get_synchronous_standby_names(self):
         """

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -161,7 +161,7 @@ class TestPostgres(object):
         """
         # Build a server
         server = build_real_server()
-        cursor_mock = conn_mock.return_value.cursor.return_value
+        cursor_mock = conn_mock.return_value.__enter__.return_value.cursor.return_value
 
         # Connection error
         conn_mock.side_effect = PostgresConnectionError
@@ -195,7 +195,7 @@ class TestPostgres(object):
 
         server = build_real_server()
         # Test 1: Postgres 9.0 expect None as result
-        conn_mock.return_value.server_version = 90000
+        conn_mock.return_value.__enter__.return_value.server_version = 90000
 
         restore_point = server.postgres.create_restore_point("Test_20151026T092241")
         assert restore_point is None
@@ -204,7 +204,7 @@ class TestPostgres(object):
         is_in_recovery_mock.return_value = True
 
         # Test 2: Postgres 9.1 in recovery (standby) expect None as result
-        conn_mock.return_value.server_version = 90100
+        conn_mock.return_value.__enter__.return_value.server_version = 90100
 
         restore_point = server.postgres.create_restore_point("Test_20151026T092241")
         assert restore_point is None
@@ -214,7 +214,7 @@ class TestPostgres(object):
 
         assert server.postgres.create_restore_point("Test_20151026T092241")
 
-        cursor_mock = conn_mock.return_value.cursor.return_value
+        cursor_mock = conn_mock.return_value.__enter__.return_value.cursor.return_value
         cursor_mock.execute.assert_called_with(
             "SELECT pg_create_restore_point(%s)", ["Test_20151026T092241"]
         )
@@ -235,7 +235,7 @@ class TestPostgres(object):
         server = build_real_server()
 
         # Test call on master, PostgreSQL older than 10
-        conn_mock.return_value.server_version = 90300
+        conn_mock.return_value.__enter__.return_value.server_version = 90300
         # Expect no errors on normal call
         assert server.postgres.stop_exclusive_backup()
         # check the correct invocation of the execute method
@@ -249,7 +249,7 @@ class TestPostgres(object):
 
         # Test call on master, PostgreSQL 10
         conn_mock.reset_mock()
-        conn_mock.return_value.server_version = 100000
+        conn_mock.return_value.__enter__.return_value.server_version = 100000
         # Expect no errors on normal call
         assert server.postgres.stop_exclusive_backup()
         # check the correct invocation of the execute method
@@ -340,7 +340,7 @@ class TestPostgres(object):
         backup_label = "test label"
 
         # Expect no errors
-        conn.return_value.server_version = 90300
+        conn.return_value.__enter__.return_value.server_version = 90300
         assert server.postgres.start_exclusive_backup(backup_label)
 
         # check for the correct call on the execute method
@@ -357,7 +357,7 @@ class TestPostgres(object):
         conn.reset_mock()
 
         # 8.3 test
-        conn.return_value.server_version = 80300
+        conn.return_value.__enter__.return_value.server_version = 80300
         assert server.postgres.start_exclusive_backup(backup_label)
         # check for the correct call on the execute method
         cursor_mock.execute.assert_called_once_with(
@@ -372,7 +372,7 @@ class TestPostgres(object):
         conn.reset_mock()
 
         # 10 test
-        conn.return_value.server_version = 100000
+        conn.return_value.__enter__.return_value.server_version = 100000
         assert server.postgres.start_exclusive_backup(backup_label)
         # check for the correct call on the execute method
         cursor_mock.execute.assert_called_once_with(
@@ -466,7 +466,7 @@ class TestPostgres(object):
 
         # expect no errors
         server.postgres.get_setting("test_setting")
-        cursor_mock = conn.return_value.cursor.return_value
+        cursor_mock = conn.return_value.__enter__.return_value.cursor.return_value
         cursor_mock.execute.assert_called_once_with(
             'SHOW "%s"' % "test_setting".replace('"', '""')
         )
@@ -486,11 +486,11 @@ class TestPostgres(object):
         """
         # Build and configure a server
         server = build_real_server()
-        conn.return_value.server_version = 90600
+        conn.return_value.__enter__.return_value.server_version = 90600
 
         # expect no errors
         server.postgres.get_systemid()
-        cursor_mock = conn.return_value.cursor.return_value
+        cursor_mock = conn.return_value.__enter__.return_value.cursor.return_value
         cursor_mock.execute.assert_called_once_with(
             "SELECT system_identifier::text FROM pg_control_system()"
         )
@@ -507,7 +507,7 @@ class TestPostgres(object):
 
         # Test 3: setup the mock to return a PostgreSQL version that
         # don't support pg_control_system()
-        conn.return_value.server_version = 90500
+        conn.return_value.__enter__.return_value.server_version = 90500
         assert server.postgres.get_systemid() is None
 
     @patch("barman.postgres.PostgreSQLConnection.connect")
@@ -517,10 +517,10 @@ class TestPostgres(object):
         """
         # Build a server
         server = build_real_server()
-        cursor_mock = conn.return_value.cursor.return_value
+        cursor_mock = conn.return_value.__enter__.return_value.cursor.return_value
         cursor_mock.fetchall.return_value = [("tbs1", "1234", "/tmp")]
         # Expect no errors
-        conn.return_value.server_version = 90400
+        conn.return_value.__enter__.return_value.server_version = 90400
         tbs = server.postgres.get_tablespaces()
         # check for the correct call on the execute method
         cursor_mock.execute.assert_called_once_with(
@@ -533,7 +533,7 @@ class TestPostgres(object):
         conn.reset_mock()
 
         # 8.3 test
-        conn.return_value.server_version = 80300
+        conn.return_value.__enter__.return_value.server_version = 80300
         cursor_mock.fetchall.return_value = [("tbs2", "5234", "/tmp1")]
         tbs = server.postgres.get_tablespaces()
         # check for the correct call on the execute method
@@ -555,14 +555,14 @@ class TestPostgres(object):
         """
         # Build a server
         server = build_real_server()
-        cursor_mock = conn.return_value.cursor.return_value
+        cursor_mock = conn.return_value.__enter__.return_value.cursor.return_value
         # expect None as result for server version <9.4
-        conn.return_value.server_version = 80300
+        conn.return_value.__enter__.return_value.server_version = 80300
         assert server.postgres.get_archiver_stats() is None
 
         # expect no errors with version >= 9.4
         conn.reset_mock()
-        conn.return_value.server_version = 90400
+        conn.return_value.__enter__.return_value.server_version = 90400
         cursor_mock.fetchone.return_value = {"a": "b"}
         assert server.postgres.get_archiver_stats() == {"a": "b"}
         # check for the correct call on the execute method
@@ -593,8 +593,8 @@ class TestPostgres(object):
         """
         # Build a server
         server = build_real_server()
-        conn_mock.return_value.server_version = 80400
-        cursor_mock = conn_mock.return_value.cursor.return_value
+        conn_mock.return_value.__enter__.return_value.server_version = 80400
+        cursor_mock = conn_mock.return_value.__enter__.return_value.cursor.return_value
         test_conf_files = [
             ("config_file", "/tmp/postgresql.conf"),
             ("hba_file", "/tmp/pg_hba.conf"),
@@ -645,14 +645,14 @@ class TestPostgres(object):
         """
         # Build a server
         server = build_real_server()
-        cursor_mock = conn_mock.return_value.cursor.return_value
+        cursor_mock = conn_mock.return_value.__enter__.return_value.cursor.return_value
 
         # Too old
-        conn_mock.return_value.server_version = 90000
+        conn_mock.return_value.__enter__.return_value.server_version = 90000
         assert not server.postgres.has_pgespresso
 
         # Extension present
-        conn_mock.return_value.server_version = 90100
+        conn_mock.return_value.__enter__.return_value.server_version = 90100
         cursor_mock.fetchone.return_value = [1]
         assert server.postgres.has_pgespresso
         cursor_mock.execute.assert_called_once_with(
@@ -680,14 +680,14 @@ class TestPostgres(object):
         """
         # Build a server
         server = build_real_server()
-        cursor_mock = conn_mock.return_value.cursor.return_value
+        cursor_mock = conn_mock.return_value.__enter__.return_value.cursor.return_value
 
         # Too old
-        conn_mock.return_value.server_version = 80400
+        conn_mock.return_value.__enter__.return_value.server_version = 80400
         assert not server.postgres.is_in_recovery
 
         # In recovery
-        conn_mock.return_value.server_version = 90100
+        conn_mock.return_value.__enter__.return_value.server_version = 90100
         cursor_mock.fetchone.return_value = [True]
         assert server.postgres.is_in_recovery
         cursor_mock.execute.assert_called_once_with("SELECT pg_is_in_recovery()")
@@ -716,7 +716,7 @@ class TestPostgres(object):
         """
         # Build and configure a server using a mock
         server = build_real_server()
-        cursor_mock = conn_mock.return_value.cursor.return_value
+        cursor_mock = conn_mock.return_value.__enter__.return_value.cursor.return_value
         timestamp = datetime.datetime(2016, 3, 30, 17, 4, 20, 271376)
         current_xlog_info = dict(
             location="0/35000528",
@@ -727,7 +727,7 @@ class TestPostgres(object):
         cursor_mock.fetchone.return_value = current_xlog_info
 
         # Test call on master, PostgreSQL older than 10
-        conn_mock.return_value.server_version = 90300
+        conn_mock.return_value.__enter__.return_value.server_version = 90300
         is_in_recovery_mock.return_value = False
         remote_loc = server.postgres.current_xlog_info
         assert remote_loc == current_xlog_info
@@ -739,7 +739,7 @@ class TestPostgres(object):
 
         # Check call on standby, PostgreSQL older than 10
         conn_mock.reset_mock()
-        conn_mock.return_value.server_version = 90300
+        conn_mock.return_value.__enter__.return_value.server_version = 90300
         is_in_recovery_mock.return_value = True
         current_xlog_info["file_name"] = None
         current_xlog_info["file_offset"] = None
@@ -753,7 +753,7 @@ class TestPostgres(object):
 
         # Test call on master, PostgreSQL 10
         conn_mock.reset_mock()
-        conn_mock.return_value.server_version = 100000
+        conn_mock.return_value.__enter__.return_value.server_version = 100000
         is_in_recovery_mock.return_value = False
         remote_loc = server.postgres.current_xlog_info
         assert remote_loc == current_xlog_info
@@ -765,7 +765,7 @@ class TestPostgres(object):
 
         # Check call on standby, PostgreSQL 10
         conn_mock.reset_mock()
-        conn_mock.return_value.server_version = 100000
+        conn_mock.return_value.__enter__.return_value.server_version = 100000
         is_in_recovery_mock.return_value = True
         current_xlog_info["file_name"] = None
         current_xlog_info["file_offset"] = None
@@ -797,8 +797,8 @@ class TestPostgres(object):
         """
         # Build a server
         server = build_real_server()
-        conn_mock.return_value.server_version = 90300
-        cursor_mock = conn_mock.return_value.cursor.return_value
+        conn_mock.return_value.__enter__.return_value.server_version = 90300
+        cursor_mock = conn_mock.return_value.__enter__.return_value.cursor.return_value
 
         timestamp = datetime.datetime(2016, 3, 30, 17, 4, 20, 271376)
         cursor_mock.fetchone.return_value = dict(
@@ -900,11 +900,15 @@ class TestPostgres(object):
         is_superuser_mock.return_value = True
         get_configuration_files_mock.return_value = {"a": "b"}
         get_synchronous_standby_names_mock.return_value = []
-        conn_mock.return_value.server_version = 90500
         archive_timeout_mock.return_value = 300
         checkpoint_timeout_mock.return_value = 600
         xlog_segment_size.return_value = 2 << 22
         get_systemid_mock.return_value = 6721602258895701769
+
+        # The connection is used both with and without the context manager so
+        # mock both cases
+        conn_mock.return_value.server_version = 90500
+        conn_mock.return_value.__enter__.return_value.server_version = 90500
 
         settings = {
             "data_directory": "a directory",
@@ -950,7 +954,7 @@ class TestPostgres(object):
         }
 
         # Test PostgreSQL 9.6
-        conn_mock.return_value.server_version = 90600
+        conn_mock.return_value.__enter__.return_value.server_version = 90600
         result = server.postgres.fetch_remote_status()
         assert result == {
             "a": "b",
@@ -980,7 +984,7 @@ class TestPostgres(object):
         }
 
         # Test PostgreSQL 13
-        conn_mock.return_value.server_version = 130000
+        conn_mock.return_value.__enter__.return_value.server_version = 130000
         result = server.postgres.fetch_remote_status()
         assert result == {
             "a": "b",
@@ -1052,7 +1056,7 @@ class TestPostgres(object):
         """
         # Build a server
         server = build_real_server()
-        cursor_mock = conn_mock.return_value.cursor.return_value
+        cursor_mock = conn_mock.return_value.__enter__.return_value.cursor.return_value
         is_in_recovery_mock.return_value = False
         is_superuser_mock.return_value = True
         # Execute the checkpoint method
@@ -1084,12 +1088,12 @@ class TestPostgres(object):
         """
         # Build a server
         server = build_real_server()
-        cursor_mock = conn_mock.return_value.cursor.return_value
+        cursor_mock = conn_mock.return_value.__enter__.return_value.cursor.return_value
         is_in_recovery_mock.return_value = False
         has_backup_privileges_mock.return_value = True
 
         # Test for the response of a correct switch for PostgreSQL < 10
-        conn_mock.return_value.server_version = 90100
+        conn_mock.return_value.__enter__.return_value.server_version = 90100
         cursor_mock.fetchone.side_effect = [
             ("000000010000000000000001",),
             ("000000010000000000000002",),
@@ -1107,7 +1111,7 @@ class TestPostgres(object):
         )
 
         # Test for the response of a correct switch for PostgreSQL 10
-        conn_mock.return_value.server_version = 100000
+        conn_mock.return_value.__enter__.return_value.server_version = 100000
         cursor_mock.reset_mock()
         cursor_mock.fetchone.side_effect = [
             ("000000010000000000000001",),
@@ -1169,7 +1173,7 @@ class TestPostgres(object):
         """
         # Build a server
         server = build_real_server()
-        cursor_mock = conn_mock.return_value.cursor.return_value
+        cursor_mock = conn_mock.return_value.__enter__.return_value.cursor.return_value
         has_backup_privileges_mock.return_value = True
 
         # 10 ALL
@@ -1535,7 +1539,7 @@ class TestPostgres(object):
         # Build a server
         server = build_real_server()
         server.config.slot_name = "test"
-        cursor_mock = conn_mock.return_value.cursor.return_value
+        cursor_mock = conn_mock.return_value.__enter__.return_value.cursor.return_value
         is_superuser_mock.return_value = True
 
         # Supported version 9.4
@@ -1567,13 +1571,13 @@ class TestPostgres(object):
         server = build_real_server()
 
         # Unsupported version: 9.0
-        conn_mock.return_value.server_version = 90000
+        conn_mock.return_value.__enter__.return_value.server_version = 90000
 
         with pytest.raises(PostgresUnsupportedFeature):
             server.postgres.get_synchronous_standby_names()
 
         # Supported version: 9.1
-        conn_mock.return_value.server_version = 90100
+        conn_mock.return_value.__enter__.return_value.server_version = 90100
 
         setting_mock.return_value = "a, bc, def"
         names = server.postgres.get_synchronous_standby_names()
@@ -1638,8 +1642,8 @@ class TestPostgres(object):
 
         # Build a server
         server = build_real_server()
-        conn_mock.return_value.server_version = 110000
-        cursor_mock = conn_mock.return_value.cursor.return_value
+        conn_mock.return_value.__enter__.return_value.server_version = 110000
+        cursor_mock = conn_mock.return_value.__enter__.return_value.cursor.return_value
         cursor_mock.fetchone.side_effect = [[str(default_wal_file_size)]]
 
         result = server.postgres.xlog_segment_size
@@ -1662,8 +1666,8 @@ class TestPostgres(object):
 
         # Build a server
         server = build_real_server()
-        conn_mock.return_value.server_version = 100000
-        cursor_mock = conn_mock.return_value.cursor.return_value
+        conn_mock.return_value.__enter__.return_value.server_version = 100000
+        cursor_mock = conn_mock.return_value.__enter__.return_value.cursor.return_value
         cursor_mock.fetchone.side_effect = [
             [str(default_wal_segments_number)],
             [str(default_wal_block_size)],
@@ -1688,8 +1692,8 @@ class TestPostgres(object):
 
         # Build a server
         server = build_real_server()
-        conn_mock.return_value.server_version = 80300
-        cursor_mock = conn_mock.return_value.cursor.return_value
+        conn_mock.return_value.__enter__.return_value.server_version = 80300
+        cursor_mock = conn_mock.return_value.__enter__.return_value.cursor.return_value
 
         result = server.postgres.xlog_segment_size
         assert result == DEFAULT_XLOG_SEG_SIZE
@@ -1704,11 +1708,11 @@ class TestPostgres(object):
         """
         server = build_real_server()
 
-        conn_mock.return_value.server_version = 100000
+        conn_mock.return_value.__enter__.return_value.server_version = 100000
         map_10 = server.postgres.name_map
         assert map_10
 
-        conn_mock.return_value.server_version = 90300
+        conn_mock.return_value.__enter__.return_value.server_version = 90300
         map_93 = server.postgres.name_map
         assert map_93
 
@@ -1724,10 +1728,10 @@ class TestPostgres(object):
         """
         server = build_real_server()
 
-        conn_mock.return_value.server_version = 90300
+        conn_mock.return_value.__enter__.return_value.server_version = 90300
         assert server.postgres.name_map["pg_switch_wal"] == "pg_switch_xlog"
 
-        conn_mock.return_value.server_version = 100000
+        conn_mock.return_value.__enter__.return_value.server_version = 100000
         assert server.postgres.name_map["pg_switch_wal"] == "pg_switch_wal"
 
     @patch("barman.postgres.PostgreSQLConnection.connect")
@@ -1738,10 +1742,10 @@ class TestPostgres(object):
         """
         server = build_real_server()
 
-        conn_mock.return_value.server_version = 90300
+        conn_mock.return_value.__enter__.return_value.server_version = 90300
         assert server.postgres.name_map["pg_walfile_name"] == "pg_xlogfile_name"
 
-        conn_mock.return_value.server_version = 100000
+        conn_mock.return_value.__enter__.return_value.server_version = 100000
         assert server.postgres.name_map["pg_walfile_name"] == "pg_walfile_name"
 
     @patch("barman.postgres.PostgreSQLConnection.connect")
@@ -1752,13 +1756,13 @@ class TestPostgres(object):
         """
         server = build_real_server()
 
-        conn_mock.return_value.server_version = 90300
+        conn_mock.return_value.__enter__.return_value.server_version = 90300
         assert (
             server.postgres.name_map["pg_walfile_name_offset"]
             == "pg_xlogfile_name_offset"
         )
 
-        conn_mock.return_value.server_version = 100000
+        conn_mock.return_value.__enter__.return_value.server_version = 100000
         assert (
             server.postgres.name_map["pg_walfile_name_offset"]
             == "pg_walfile_name_offset"
@@ -1772,10 +1776,10 @@ class TestPostgres(object):
         """
         server = build_real_server()
 
-        conn_mock.return_value.server_version = 90300
+        conn_mock.return_value.__enter__.return_value.server_version = 90300
         assert server.postgres.name_map["pg_wal"] == "pg_xlog"
 
-        conn_mock.return_value.server_version = 100000
+        conn_mock.return_value.__enter__.return_value.server_version = 100000
         assert server.postgres.name_map["pg_wal"] == "pg_wal"
 
     @patch("barman.postgres.PostgreSQLConnection.connect")
@@ -1786,13 +1790,13 @@ class TestPostgres(object):
         """
         server = build_real_server()
 
-        conn_mock.return_value.server_version = 90300
+        conn_mock.return_value.__enter__.return_value.server_version = 90300
         assert (
             server.postgres.name_map["pg_last_wal_replay_lsn"]
             == "pg_last_xlog_replay_location"
         )
 
-        conn_mock.return_value.server_version = 100000
+        conn_mock.return_value.__enter__.return_value.server_version = 100000
         assert (
             server.postgres.name_map["pg_last_wal_replay_lsn"]
             == "pg_last_wal_replay_lsn"
@@ -1806,12 +1810,12 @@ class TestPostgres(object):
         """
         server = build_real_server()
 
-        conn_mock.return_value.server_version = 90300
+        conn_mock.return_value.__enter__.return_value.server_version = 90300
         assert (
             server.postgres.name_map["pg_current_wal_lsn"] == "pg_current_xlog_location"
         )
 
-        conn_mock.return_value.server_version = 100000
+        conn_mock.return_value.__enter__.return_value.server_version = 100000
         assert server.postgres.name_map["pg_current_wal_lsn"] == "pg_current_wal_lsn"
 
     @patch("barman.postgres.PostgreSQLConnection.connect")
@@ -1822,13 +1826,13 @@ class TestPostgres(object):
         """
         server = build_real_server()
 
-        conn_mock.return_value.server_version = 90300
+        conn_mock.return_value.__enter__.return_value.server_version = 90300
         assert (
             server.postgres.name_map["pg_current_wal_insert_lsn"]
             == "pg_current_xlog_insert_location"
         )
 
-        conn_mock.return_value.server_version = 100000
+        conn_mock.return_value.__enter__.return_value.server_version = 100000
         assert (
             server.postgres.name_map["pg_current_wal_insert_lsn"]
             == "pg_current_wal_insert_lsn"
@@ -1842,13 +1846,13 @@ class TestPostgres(object):
         """
         server = build_real_server()
 
-        conn_mock.return_value.server_version = 90300
+        conn_mock.return_value.__enter__.return_value.server_version = 90300
         assert (
             server.postgres.name_map["pg_last_wal_receive_lsn"]
             == "pg_last_xlog_receive_location"
         )
 
-        conn_mock.return_value.server_version = 100000
+        conn_mock.return_value.__enter__.return_value.server_version = 100000
         assert (
             server.postgres.name_map["pg_last_wal_receive_lsn"]
             == "pg_last_wal_receive_lsn"
@@ -1900,14 +1904,14 @@ class TestStreamingConnection(object):
         )
 
         # Too old PostgreSQL
-        conn_mock.return_value.server_version = 90100
+        conn_mock.return_value.__enter__.return_value.server_version = 90100
         result = server.streaming.fetch_remote_status()
         assert result["streaming_supported"] is False
         assert result["streaming"] is None
 
         # Working streaming connection
-        conn_mock.return_value.server_version = 90300
-        cursor_mock = conn_mock.return_value.cursor.return_value
+        conn_mock.return_value.__enter__.return_value.server_version = 90300
+        cursor_mock = conn_mock.return_value.__enter__.return_value.cursor.return_value
         cursor_mock.fetchone.return_value = ("12345", 1, "DE/ADBEEF")
         result = server.streaming.fetch_remote_status()
         cursor_mock.execute.assert_called_with("IDENTIFY_SYSTEM")
@@ -1947,22 +1951,22 @@ class TestStreamingConnection(object):
         # Good connection
         conn_mock.side_effect = None
 
-        conn_mock.return_value.server_version = 80300
+        conn_mock.return_value.__enter__.return_value.server_version = 80300
         assert server.streaming.server_txt_version == "8.3.0"
 
-        conn_mock.return_value.server_version = 90000
+        conn_mock.return_value.__enter__.return_value.server_version = 90000
         assert server.streaming.server_txt_version == "9.0.0"
 
-        conn_mock.return_value.server_version = 90005
+        conn_mock.return_value.__enter__.return_value.server_version = 90005
         assert server.streaming.server_txt_version == "9.0.5"
 
-        conn_mock.return_value.server_version = 100001
+        conn_mock.return_value.__enter__.return_value.server_version = 100001
         assert server.streaming.server_txt_version == "10.1"
 
-        conn_mock.return_value.server_version = 110011
+        conn_mock.return_value.__enter__.return_value.server_version = 110011
         assert server.streaming.server_txt_version == "11.11"
 
-        conn_mock.return_value.server_version = 0
+        conn_mock.return_value.__enter__.return_value.server_version = 0
         assert server.streaming.server_txt_version == "0.0.0"
 
     @patch("barman.postgres.psycopg2.connect")
@@ -1973,14 +1977,18 @@ class TestStreamingConnection(object):
         )
 
         # Test replication slot creation
-        cursor_mock = connect_mock.return_value.cursor.return_value
+        cursor_mock = (
+            connect_mock.return_value.__enter__.return_value.cursor.return_value
+        )
         server.streaming.create_physical_repslot("test_repslot")
         cursor_mock.execute.assert_called_once_with(
             "CREATE_REPLICATION_SLOT test_repslot PHYSICAL"
         )
 
         # Test replication slot already existent
-        cursor_mock = connect_mock.return_value.cursor.return_value
+        cursor_mock = (
+            connect_mock.return_value.__enter__.return_value.cursor.return_value
+        )
         cursor_mock.execute.side_effect = MockProgrammingError(DUPLICATE_OBJECT)
 
         with pytest.raises(PostgresDuplicateReplicationSlot):
@@ -1997,14 +2005,18 @@ class TestStreamingConnection(object):
         )
 
         # Test replication slot creation
-        cursor_mock = connect_mock.return_value.cursor.return_value
+        cursor_mock = (
+            connect_mock.return_value.__enter__.return_value.cursor.return_value
+        )
         server.streaming.drop_repslot("test_repslot")
         cursor_mock.execute.assert_called_once_with(
             "DROP_REPLICATION_SLOT test_repslot"
         )
 
         # Test replication slot already existent
-        cursor_mock = connect_mock.return_value.cursor.return_value
+        cursor_mock = (
+            connect_mock.return_value.__enter__.return_value.cursor.return_value
+        )
         cursor_mock.execute.side_effect = MockProgrammingError(UNDEFINED_OBJECT)
 
         with pytest.raises(PostgresInvalidReplicationSlot):


### PR DESCRIPTION
Uses the psycopg2 connection context manager so that transactions
are committed when barman uses the connection to interact with
postgres for reasons other than starting or stopping the backup.

This prevents the following situation from arising:

1. Barman starts a new transaction, for example to retrieve the
   server version.
2. The transaction is left open putting the session into an
   idle-in-transaction state.
3. The backup lasts longer than the value of
   idle_in_transaction_session_timeout and fails because the
   session is terminated.

Because this patch ensures such transactions are committed,
via the psycopg2 connection context manager, such transactions
are no longer held open during the backup.

Note that in cases where we do not call `self.connect()` directly,
a new context manager is added around the `_cursor` property in
barman.postgres.PostgreSQL which uses with-statement to enter the
connection context manager and then yields the cursor context
manager. When the cursor context manager exits, the connection
context manager will also exit. It is not sufficient to just use
the cursor context manager as this does not commit transactions.

See https://www.psycopg.org/docs/usage.html#with-statement for
more details.

The context manager is deliberately avoided for the functions
which call either `pg_{start,stop}_backup` or
`pgespresso_{start,stop}_backup` as these manage transactions
themselves by explicitly calling `rollback`.

Closes #333

---

Logs from PostgreSQL when testing `PostgreSQLConnection.server_txt_version` with no context manager:

```
Jun 23 14:14:08 mt-primary postgres[86855]: [89-1] 2021-06-23 14:14:08 UTC [barman@172.17.0.1(62348)/barman/postgres:86855]: [78] LOG:  statement: SELECT 1
Jun 23 14:14:08 mt-primary postgres[86855]: [90-1] 2021-06-23 14:14:08 UTC [barman@172.17.0.1(62348)/barman/postgres:86855]: [79] LOG:  statement: SELECT version()
```

with only the cursor context manager:

```
Jun 23 14:16:24 mt-primary postgres[86939]: [87-1] 2021-06-23 14:16:24 UTC [barman@172.17.0.1(62768)/barman/postgres:86939]: [76] LOG:  statement: SELECT 1
Jun 23 14:16:24 mt-primary postgres[86939]: [88-1] 2021-06-23 14:16:24 UTC [barman@172.17.0.1(62768)/barman/postgres:86939]: [77] LOG:  statement: SELECT version()
```

with the context manager around `PostgreSQL._cursor` (i.e. the one in this PR):

```
Jun 23 14:18:15 mt-primary postgres[87008]: [94-1] 2021-06-23 14:18:15 UTC [barman@172.17.0.1(63110)/barman/postgres:87008]: [83] LOG:  statement: BEGIN
Jun 23 14:18:15 mt-primary postgres[87008]: [95-1] 2021-06-23 14:18:15 UTC [barman@172.17.0.1(63110)/barman/postgres:87008]: [84] LOG:  statement: SELECT 1
Jun 23 14:18:15 mt-primary postgres[87008]: [96-1] 2021-06-23 14:18:15 UTC [barman@172.17.0.1(63110)/barman/postgres:87008]: [85] LOG:  statement: ROLLBACK
Jun 23 14:18:15 mt-primary postgres[87008]: [97-1] 2021-06-23 14:18:15 UTC [barman@172.17.0.1(63110)/barman/postgres:87008]: [86] LOG:  statement: BEGIN
Jun 23 14:18:15 mt-primary postgres[87008]: [98-1] 2021-06-23 14:18:15 UTC [barman@172.17.0.1(63110)/barman/postgres:87008]: [87] LOG:  statement: SELECT version()
Jun 23 14:18:15 mt-primary postgres[87008]: [99-1] 2021-06-23 14:18:15 UTC [barman@172.17.0.1(63110)/barman/postgres:87008]: [88] LOG:  statement: COMMIT
```