### PR TITLE
Update flake8 for black formatting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,8 @@ deps = flake8
 
 [flake8]
 select = E,F,W,C
-ignore =
+ignore = E203, E501, W503
+max-line-length = 88
 copyright-check = True
 copyright-regexp = © Copyright %(author)s (\d{4}-)2021
 copyright-author = EnterpriseDB UK Limited


### PR DESCRIPTION
Fixes the build which was failing due to flake8 not being
configured to accept the formatting applied by black.

https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html