### PR TITLE
Fix recovery target options tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -312,6 +312,7 @@ class TestCli(object):
         args.tablespace = None
         args.target_name = None
         args.target_tli = 3
+        args.target_lsn = None
         args.target_immediate = True
         args.target_time = None
         args.target_xid = None
@@ -357,11 +358,13 @@ class TestCli(object):
         args.target_immediate = True
         args.target_time = None
         args.target_xid = None
+        args.target_lsn = None
         args.target_action = None
 
-        _, err = capsys.readouterr()
         with pytest.raises(SystemExit):
             recover(args)
+
+        _, err = capsys.readouterr()
         assert "" == err
 
     @patch("barman.cli.parse_backup_id")
@@ -396,11 +399,13 @@ class TestCli(object):
         args.target_immediate = None
         args.target_time = None
         args.target_xid = None
+        args.target_lsn = None
         args.target_action = None
 
-        _, err = capsys.readouterr()
         with pytest.raises(SystemExit):
             recover(args)
+
+        _, err = capsys.readouterr()
         assert "" == err
 
     def test_check_target_action(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -311,10 +311,10 @@ class TestCli(object):
         args.destination_directory = "recovery_dir"
         args.tablespace = None
         args.target_name = None
-        args.target_tli = 3
+        args.target_tli = None
         args.target_lsn = None
         args.target_immediate = True
-        args.target_time = None
+        args.target_time = "2021-01-001 00:00:00.000"
         args.target_xid = None
 
         with pytest.raises(SystemExit):


### PR DESCRIPTION
While testing #337 I was expecting the unit tests to break however this was not the case. It turns out there were a a couple of bugs in the unit tests which meant they were passing for the wrong reasons. This PR fixes those bugs and also updates the unit tests for the change merged in #337.