### PR TITLE
BAC-4: Add support for Azure blob storage to barman-cloud

### DIFF
--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -23,7 +23,8 @@ from contextlib import closing
 from shutil import rmtree
 
 import barman
-from barman.cloud import S3CloudInterface, CloudBackupUploader, configure_logging
+from barman.cloud import CloudBackupUploader, configure_logging
+from barman.cloud_providers import S3CloudInterface
 from barman.exceptions import PostgresConnectionError
 from barman.postgres import PostgreSQLConnection
 from barman.utils import check_positive, check_size, force_str

--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -23,7 +23,7 @@ from contextlib import closing
 from shutil import rmtree
 
 import barman
-from barman.cloud import CloudInterface, S3BackupUploader, configure_logging
+from barman.cloud import S3CloudInterface, S3BackupUploader, configure_logging
 from barman.exceptions import PostgresConnectionError
 from barman.postgres import PostgreSQLConnection
 from barman.utils import check_positive, check_size, force_str
@@ -92,7 +92,7 @@ def main(args=None):
             raise SystemExit(1)
 
         with closing(postgres):
-            cloud_interface = CloudInterface(
+            cloud_interface = S3CloudInterface(
                 url=config.destination_url,
                 encryption=config.encryption,
                 jobs=config.jobs,

--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -24,7 +24,7 @@ from shutil import rmtree
 
 import barman
 from barman.cloud import CloudBackupUploader, configure_logging
-from barman.cloud_providers import S3CloudInterface
+from barman.cloud_providers import get_cloud_interface
 from barman.exceptions import PostgresConnectionError
 from barman.postgres import PostgreSQLConnection
 from barman.utils import check_positive, check_size, force_str
@@ -93,12 +93,13 @@ def main(args=None):
             raise SystemExit(1)
 
         with closing(postgres):
-            cloud_interface = S3CloudInterface(
+            cloud_interface = get_cloud_interface(
                 url=config.destination_url,
                 encryption=config.encryption,
                 jobs=config.jobs,
                 profile_name=config.profile,
                 endpoint_url=config.endpoint_url,
+                cloud_provider=config.cloud_provider,
             )
 
             if not cloud_interface.test_connectivity():
@@ -250,6 +251,12 @@ def parse_arguments(args=None):
     parser.add_argument(
         "--endpoint-url",
         help="Override default S3 endpoint URL with the given one",
+    )
+    parser.add_argument(
+        "--cloud-provider",
+        help="The cloud provider to use as a storage backend",
+        choices=["aws-s3"],
+        default="aws-s3",
     )
     return parser.parse_args(args=args)
 

--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -23,7 +23,7 @@ from contextlib import closing
 from shutil import rmtree
 
 import barman
-from barman.cloud import S3CloudInterface, S3BackupUploader, configure_logging
+from barman.cloud import S3CloudInterface, CloudBackupUploader, configure_logging
 from barman.exceptions import PostgresConnectionError
 from barman.postgres import PostgreSQLConnection
 from barman.utils import check_positive, check_size, force_str
@@ -111,7 +111,7 @@ def main(args=None):
                 # TODO: Should the setup be optional?
                 cloud_interface.setup_bucket()
 
-                uploader = S3BackupUploader(
+                uploader = CloudBackupUploader(
                     server_name=config.server_name,
                     compression=config.compression,
                     postgres=postgres,

--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -147,7 +147,7 @@ def parse_arguments(args=None):
         description="This script can be used to perform a backup "
         "of a local PostgreSQL instance and ship "
         "the resulting tarball(s) to the Cloud. "
-        "Currently only AWS S3 is supported.",
+        "Currently AWS S3 and Azure Blob Storage are supported.",
         add_help=False,
     )
     parser.add_argument(
@@ -177,11 +177,6 @@ def parse_arguments(args=None):
         default=0,
         help="decrease output verbosity (e.g., -qq is less than -q)",
     )
-    parser.add_argument(
-        "-P",
-        "--profile",
-        help="profile name (e.g. INI section in AWS credentials file)",
-    )
     compression = parser.add_mutually_exclusive_group()
     compression.add_argument(
         "-z",
@@ -198,13 +193,6 @@ def parse_arguments(args=None):
         action="store_const",
         const="bz2",
         dest="compression",
-    )
-    parser.add_argument(
-        "-e",
-        "--encryption",
-        help="Enable server-side encryption for the transfer. "
-        "Allowed values: 'AES256'|'aws:kms'.",
-        choices=["AES256", "aws:kms"],
     )
     parser.add_argument(
         "-t",
@@ -238,25 +226,41 @@ def parse_arguments(args=None):
         "-J",
         "--jobs",
         type=check_positive,
-        help="number of subprocesses to upload data to S3 " "(default: 2)",
+        help="number of subprocesses to upload data to cloud storage " "(default: 2)",
         default=2,
     )
     parser.add_argument(
         "-S",
         "--max-archive-size",
         type=check_size,
-        help="maximum size of an archive when uploading to S3 " "(default: 100GB)",
+        help="maximum size of an archive when uploading to cloud storage "
+        "(default: 100GB)",
         default="100GB",
-    )
-    parser.add_argument(
-        "--endpoint-url",
-        help="Override default S3 endpoint URL with the given one",
     )
     parser.add_argument(
         "--cloud-provider",
         help="The cloud provider to use as a storage backend",
-        choices=["aws-s3"],
+        choices=["aws-s3", "azure-blob-storage"],
         default="aws-s3",
+    )
+    s3_arguments = parser.add_argument_group(
+        "Extra options for the aws-s3 cloud provider"
+    )
+    s3_arguments.add_argument(
+        "--endpoint-url",
+        help="Override default S3 endpoint URL with the given one",
+    )
+    s3_arguments.add_argument(
+        "-P",
+        "--profile",
+        help="profile name (e.g. INI section in AWS credentials file)",
+    )
+    s3_arguments.add_argument(
+        "-e",
+        "--encryption",
+        help="Enable server-side encryption for the transfer. "
+        "Allowed values: 'AES256'|'aws:kms'.",
+        choices=["AES256", "aws:kms"],
     )
     return parser.parse_args(args=args)
 

--- a/barman/clients/cloud_backup_list.py
+++ b/barman/clients/cloud_backup_list.py
@@ -110,7 +110,7 @@ def parse_arguments(args=None):
     parser = argparse.ArgumentParser(
         description="This script can be used to list backups "
         "made with barman-cloud-backup command. "
-        "Currently only AWS S3 is supported.",
+        "Currently AWS S3 and Azure Blob Storage are supported.",
         add_help=False,
     )
 
@@ -142,19 +142,6 @@ def parse_arguments(args=None):
         help="decrease output verbosity (e.g., -qq is less than -q)",
     )
     parser.add_argument(
-        "-P",
-        "--profile",
-        help="profile name (e.g. INI section in AWS credentials file)",
-    )
-    parser.add_argument(
-        "-e",
-        "--encryption",
-        help="Enable server-side encryption for the transfer. "
-        "Allowed values: 'AES256', 'aws:kms'",
-        choices=["AES256", "aws:kms"],
-        metavar="ENCRYPTION",
-    )
-    parser.add_argument(
         "-t",
         "--test",
         help="Test cloud connectivity and exit",
@@ -167,14 +154,30 @@ def parse_arguments(args=None):
         help="Output format (console or json). Default console.",
     )
     parser.add_argument(
+        "--cloud-provider",
+        help="The cloud provider to use as a storage backend",
+        choices=["aws-s3", "azure-blob-storage"],
+        default="aws-s3",
+    )
+    s3_arguments = parser.add_argument_group(
+        "Extra options for the aws-s3 cloud provider"
+    )
+    s3_arguments.add_argument(
         "--endpoint-url",
         help="Override default S3 endpoint URL with the given one",
     )
-    parser.add_argument(
-        "--cloud-provider",
-        help="The cloud provider to use as a storage backend",
-        choices=["aws-s3"],
-        default="aws-s3",
+    s3_arguments.add_argument(
+        "-P",
+        "--profile",
+        help="profile name (e.g. INI section in AWS credentials file)",
+    )
+    s3_arguments.add_argument(
+        "-e",
+        "--encryption",
+        help="Enable server-side encryption for the transfer. "
+        "Allowed values: 'AES256', 'aws:kms'",
+        choices=["AES256", "aws:kms"],
+        metavar="ENCRYPTION",
     )
     return parser.parse_args(args=args)
 

--- a/barman/clients/cloud_backup_list.py
+++ b/barman/clients/cloud_backup_list.py
@@ -21,7 +21,7 @@ import logging
 from contextlib import closing
 
 import barman
-from barman.cloud import CloudInterface, S3BackupCatalog, configure_logging
+from barman.cloud import S3CloudInterface, S3BackupCatalog, configure_logging
 from barman.infofile import BackupInfo
 from barman.utils import force_str
 
@@ -42,7 +42,7 @@ def main(args=None):
     configure_logging(config)
 
     try:
-        cloud_interface = CloudInterface(
+        cloud_interface = S3CloudInterface(
             url=config.source_url,
             encryption=config.encryption,
             profile_name=config.profile,

--- a/barman/clients/cloud_backup_list.py
+++ b/barman/clients/cloud_backup_list.py
@@ -22,7 +22,7 @@ from contextlib import closing
 
 import barman
 from barman.cloud import CloudBackupCatalog, configure_logging
-from barman.cloud_providers import S3CloudInterface
+from barman.cloud_providers import get_cloud_interface
 from barman.infofile import BackupInfo
 from barman.utils import force_str
 
@@ -43,11 +43,12 @@ def main(args=None):
     configure_logging(config)
 
     try:
-        cloud_interface = S3CloudInterface(
+        cloud_interface = get_cloud_interface(
             url=config.source_url,
             encryption=config.encryption,
             profile_name=config.profile,
             endpoint_url=config.endpoint_url,
+            cloud_provider=config.cloud_provider,
         )
 
         with closing(cloud_interface):
@@ -168,6 +169,12 @@ def parse_arguments(args=None):
     parser.add_argument(
         "--endpoint-url",
         help="Override default S3 endpoint URL with the given one",
+    )
+    parser.add_argument(
+        "--cloud-provider",
+        help="The cloud provider to use as a storage backend",
+        choices=["aws-s3"],
+        default="aws-s3",
     )
     return parser.parse_args(args=args)
 

--- a/barman/clients/cloud_backup_list.py
+++ b/barman/clients/cloud_backup_list.py
@@ -21,7 +21,8 @@ import logging
 from contextlib import closing
 
 import barman
-from barman.cloud import S3CloudInterface, CloudBackupCatalog, configure_logging
+from barman.cloud import CloudBackupCatalog, configure_logging
+from barman.cloud_providers import S3CloudInterface
 from barman.infofile import BackupInfo
 from barman.utils import force_str
 

--- a/barman/clients/cloud_backup_list.py
+++ b/barman/clients/cloud_backup_list.py
@@ -21,7 +21,7 @@ import logging
 from contextlib import closing
 
 import barman
-from barman.cloud import S3CloudInterface, S3BackupCatalog, configure_logging
+from barman.cloud import S3CloudInterface, CloudBackupCatalog, configure_logging
 from barman.infofile import BackupInfo
 from barman.utils import force_str
 
@@ -50,7 +50,7 @@ def main(args=None):
         )
 
         with closing(cloud_interface):
-            catalog = S3BackupCatalog(
+            catalog = CloudBackupCatalog(
                 cloud_interface=cloud_interface, server_name=config.server_name
             )
 

--- a/barman/clients/cloud_restore.py
+++ b/barman/clients/cloud_restore.py
@@ -20,7 +20,7 @@ import os
 from contextlib import closing
 
 import barman
-from barman.cloud import CloudInterface, S3BackupCatalog, configure_logging
+from barman.cloud import S3CloudInterface, S3BackupCatalog, configure_logging
 from barman.utils import force_str
 
 try:
@@ -47,7 +47,7 @@ def main(args=None):
         raise SystemExit(1)
 
     try:
-        cloud_interface = CloudInterface(
+        cloud_interface = S3CloudInterface(
             url=config.source_url,
             encryption=config.encryption,
             profile_name=config.profile,

--- a/barman/clients/cloud_restore.py
+++ b/barman/clients/cloud_restore.py
@@ -20,7 +20,8 @@ import os
 from contextlib import closing
 
 import barman
-from barman.cloud import S3CloudInterface, CloudBackupCatalog, configure_logging
+from barman.cloud import CloudBackupCatalog, configure_logging
+from barman.cloud_providers import S3CloudInterface
 from barman.utils import force_str
 
 try:

--- a/barman/clients/cloud_restore.py
+++ b/barman/clients/cloud_restore.py
@@ -93,7 +93,7 @@ def parse_arguments(args=None):
     parser = argparse.ArgumentParser(
         description="This script can be used to download a backup "
         "previously made with barman-cloud-backup command."
-        "Currently only AWS S3 is supported.",
+        "Currently AWS S3 and Azure Blob Storage are supported.",
         add_help=False,
     )
 
@@ -127,19 +127,6 @@ def parse_arguments(args=None):
         help="decrease output verbosity (e.g., -qq is less than -q)",
     )
     parser.add_argument(
-        "-P",
-        "--profile",
-        help="profile name (e.g. INI section in AWS credentials file)",
-    )
-    parser.add_argument(
-        "-e",
-        "--encryption",
-        help="Enable server-side encryption for the transfer. "
-        "Allowed values: 'AES256', 'aws:kms'",
-        choices=["AES256", "aws:kms"],
-        metavar="ENCRYPTION",
-    )
-    parser.add_argument(
         "-t",
         "--test",
         help="Test cloud connectivity and exit",
@@ -147,16 +134,31 @@ def parse_arguments(args=None):
         default=False,
     )
     parser.add_argument(
+        "--cloud-provider",
+        help="The cloud provider to use as a storage backend",
+        choices=["aws-s3", "azure-blob-storage"],
+        default="aws-s3",
+    )
+    s3_arguments = parser.add_argument_group(
+        "Extra options for the aws-s3 cloud provider"
+    )
+    s3_arguments.add_argument(
         "--endpoint-url",
         help="Override default S3 endpoint URL with the given one",
     )
-    parser.add_argument(
-        "--cloud-provider",
-        help="The cloud provider to use as a storage backend",
-        choices=["aws-s3"],
-        default="aws-s3",
+    s3_arguments.add_argument(
+        "-P",
+        "--profile",
+        help="profile name (e.g. INI section in AWS credentials file)",
     )
-
+    s3_arguments.add_argument(
+        "-e",
+        "--encryption",
+        help="Enable server-side encryption for the transfer. "
+        "Allowed values: 'AES256', 'aws:kms'",
+        choices=["AES256", "aws:kms"],
+        metavar="ENCRYPTION",
+    )
     return parser.parse_args(args=args)
 
 

--- a/barman/clients/cloud_restore.py
+++ b/barman/clients/cloud_restore.py
@@ -21,7 +21,7 @@ from contextlib import closing
 
 import barman
 from barman.cloud import CloudBackupCatalog, configure_logging
-from barman.cloud_providers import S3CloudInterface
+from barman.cloud_providers import get_cloud_interface
 from barman.utils import force_str
 
 try:
@@ -48,11 +48,12 @@ def main(args=None):
         raise SystemExit(1)
 
     try:
-        cloud_interface = S3CloudInterface(
+        cloud_interface = get_cloud_interface(
             url=config.source_url,
             encryption=config.encryption,
             profile_name=config.profile,
             endpoint_url=config.endpoint_url,
+            cloud_provider=config.cloud_provider,
         )
 
         with closing(cloud_interface):
@@ -148,6 +149,12 @@ def parse_arguments(args=None):
     parser.add_argument(
         "--endpoint-url",
         help="Override default S3 endpoint URL with the given one",
+    )
+    parser.add_argument(
+        "--cloud-provider",
+        help="The cloud provider to use as a storage backend",
+        choices=["aws-s3"],
+        default="aws-s3",
     )
 
     return parser.parse_args(args=args)

--- a/barman/clients/cloud_restore.py
+++ b/barman/clients/cloud_restore.py
@@ -20,7 +20,7 @@ import os
 from contextlib import closing
 
 import barman
-from barman.cloud import S3CloudInterface, S3BackupCatalog, configure_logging
+from barman.cloud import S3CloudInterface, CloudBackupCatalog, configure_logging
 from barman.utils import force_str
 
 try:
@@ -55,7 +55,7 @@ def main(args=None):
         )
 
         with closing(cloud_interface):
-            downloader = S3BackupDownloader(
+            downloader = CloudBackupDownloader(
                 cloud_interface=cloud_interface, server_name=config.server_name
             )
 
@@ -152,14 +152,14 @@ def parse_arguments(args=None):
     return parser.parse_args(args=args)
 
 
-class S3BackupDownloader(object):
+class CloudBackupDownloader(object):
     """
-    S3 download client
+    Cloud storage download client
     """
 
     def __init__(self, cloud_interface, server_name):
         """
-        Object responsible for handling interactions with S3
+        Object responsible for handling interactions with cloud storage
 
         :param CloudInterface cloud_interface: The interface to use to
           upload the backup
@@ -168,11 +168,11 @@ class S3BackupDownloader(object):
 
         self.cloud_interface = cloud_interface
         self.server_name = server_name
-        self.catalog = S3BackupCatalog(cloud_interface, server_name)
+        self.catalog = CloudBackupCatalog(cloud_interface, server_name)
 
     def download_backup(self, backup_id, destination_dir):
         """
-        Download a backup from S3
+        Download a backup from cloud storage
 
         :param str wal_name: Name of the WAL file
         :param str wal_dest: Full path of the destination WAL file

--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -27,7 +27,7 @@ from io import BytesIO
 
 import barman
 from barman.cloud import configure_logging
-from barman.cloud_providers import S3CloudInterface
+from barman.cloud_providers import get_cloud_interface
 from barman.utils import force_str
 from barman.xlog import hash_dir, is_any_xlog_file
 
@@ -53,11 +53,12 @@ def main(args=None):
         raise SystemExit(1)
 
     try:
-        cloud_interface = S3CloudInterface(
+        cloud_interface = get_cloud_interface(
             url=config.destination_url,
             encryption=config.encryption,
             profile_name=config.profile,
             endpoint_url=config.endpoint_url,
+            cloud_provider=config.cloud_provider,
         )
 
         with closing(cloud_interface):
@@ -167,6 +168,12 @@ def parse_arguments(args=None):
     parser.add_argument(
         "--endpoint-url",
         help="Override default S3 endpoint URL with the given one",
+    )
+    parser.add_argument(
+        "--cloud-provider",
+        help="The cloud provider to use as a storage backend",
+        choices=["aws-s3"],
+        default="aws-s3",
     )
     return parser.parse_args(args=args)
 

--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -60,7 +60,7 @@ def main(args=None):
         )
 
         with closing(cloud_interface):
-            uploader = S3WalUploader(
+            uploader = CloudWalUploader(
                 cloud_interface=cloud_interface,
                 server_name=config.server_name,
                 compression=config.compression,
@@ -170,14 +170,14 @@ def parse_arguments(args=None):
     return parser.parse_args(args=args)
 
 
-class S3WalUploader(object):
+class CloudWalUploader(object):
     """
-    S3 upload client
+    Cloud storage upload client
     """
 
     def __init__(self, cloud_interface, server_name, compression=None):
         """
-        Object responsible for handling interactions with S3
+        Object responsible for handling interactions with cloud storage
 
         :param CloudInterface cloud_interface: The interface to use to
           upload the backup
@@ -191,7 +191,7 @@ class S3WalUploader(object):
 
     def upload_wal(self, wal_path):
         """
-        Upload a WAL file from postgres to S3
+        Upload a WAL file from postgres to cloud storage
 
         :param str wal_path: Full path of the WAL file
         """
@@ -199,7 +199,7 @@ class S3WalUploader(object):
         wal_name = self.retrieve_wal_name(wal_path)
         # Use the correct file object for the upload (simple|gzip|bz2)
         file_object = self.retrieve_file_obj(wal_path)
-        # Correctly format the destination path on s3
+        # Correctly format the destination path
         destination = os.path.join(
             self.cloud_interface.path,
             self.server_name,

--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -94,7 +94,7 @@ def parse_arguments(args=None):
     parser = argparse.ArgumentParser(
         description="This script can be used in the `archive_command` "
         "of a PostgreSQL server to ship WAL files to the Cloud. "
-        "Currently only AWS S3 is supported.",
+        "Currently AWS S3 and Azure Blob Storage are supported.",
         add_help=False,
     )
     parser.add_argument(
@@ -128,11 +128,6 @@ def parse_arguments(args=None):
         default=0,
         help="decrease output verbosity (e.g., -qq is less than -q)",
     )
-    parser.add_argument(
-        "-P",
-        "--profile",
-        help="profile name (e.g. INI section in AWS credentials file)",
-    )
     compression = parser.add_mutually_exclusive_group()
     compression.add_argument(
         "-z",
@@ -151,14 +146,6 @@ def parse_arguments(args=None):
         dest="compression",
     )
     parser.add_argument(
-        "-e",
-        "--encryption",
-        help="Enable server-side encryption for the transfer. "
-        "Allowed values: 'AES256', 'aws:kms'",
-        choices=["AES256", "aws:kms"],
-        metavar="ENCRYPTION",
-    )
-    parser.add_argument(
         "-t",
         "--test",
         help="Test cloud connectivity and exit",
@@ -166,14 +153,30 @@ def parse_arguments(args=None):
         default=False,
     )
     parser.add_argument(
+        "--cloud-provider",
+        help="The cloud provider to use as a storage backend",
+        choices=["aws-s3", "azure-blob-storage"],
+        default="aws-s3",
+    )
+    s3_arguments = parser.add_argument_group(
+        "Extra options for the aws-s3 cloud provider"
+    )
+    s3_arguments.add_argument(
         "--endpoint-url",
         help="Override default S3 endpoint URL with the given one",
     )
-    parser.add_argument(
-        "--cloud-provider",
-        help="The cloud provider to use as a storage backend",
-        choices=["aws-s3"],
-        default="aws-s3",
+    s3_arguments.add_argument(
+        "-P",
+        "--profile",
+        help="profile name (e.g. INI section in AWS credentials file)",
+    )
+    s3_arguments.add_argument(
+        "-e",
+        "--encryption",
+        help="Enable server-side encryption for the transfer. "
+        "Allowed values: 'AES256', 'aws:kms'",
+        choices=["AES256", "aws:kms"],
+        metavar="ENCRYPTION",
     )
     return parser.parse_args(args=args)
 

--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -26,7 +26,7 @@ from contextlib import closing
 from io import BytesIO
 
 import barman
-from barman.cloud import CloudInterface, configure_logging
+from barman.cloud import S3CloudInterface, configure_logging
 from barman.utils import force_str
 from barman.xlog import hash_dir, is_any_xlog_file
 
@@ -52,7 +52,7 @@ def main(args=None):
         raise SystemExit(1)
 
     try:
-        cloud_interface = CloudInterface(
+        cloud_interface = S3CloudInterface(
             url=config.destination_url,
             encryption=config.encryption,
             profile_name=config.profile,

--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -26,7 +26,8 @@ from contextlib import closing
 from io import BytesIO
 
 import barman
-from barman.cloud import S3CloudInterface, configure_logging
+from barman.cloud import configure_logging
+from barman.cloud_providers import S3CloudInterface
 from barman.utils import force_str
 from barman.xlog import hash_dir, is_any_xlog_file
 

--- a/barman/clients/cloud_walrestore.py
+++ b/barman/clients/cloud_walrestore.py
@@ -21,7 +21,7 @@ import os
 from contextlib import closing
 
 import barman
-from barman.cloud import CloudInterface, configure_logging
+from barman.cloud import S3CloudInterface, configure_logging
 from barman.utils import force_str
 from barman.xlog import hash_dir, is_any_xlog_file, is_backup_file
 
@@ -47,7 +47,7 @@ def main(args=None):
         raise SystemExit(1)
 
     try:
-        cloud_interface = CloudInterface(
+        cloud_interface = S3CloudInterface(
             url=config.source_url,
             encryption=config.encryption,
             profile_name=config.profile,

--- a/barman/clients/cloud_walrestore.py
+++ b/barman/clients/cloud_walrestore.py
@@ -55,7 +55,7 @@ def main(args=None):
         )
 
         with closing(cloud_interface):
-            downloader = S3WalDownloader(
+            downloader = CloudWalDownloader(
                 cloud_interface=cloud_interface, server_name=config.server_name
             )
 
@@ -154,9 +154,9 @@ def parse_arguments(args=None):
     return parser.parse_args(args=args)
 
 
-class S3WalDownloader(object):
+class CloudWalDownloader(object):
     """
-    S3 download client
+    Cloud storage download client
     """
 
     # Allowed compression algorithms
@@ -164,7 +164,7 @@ class S3WalDownloader(object):
 
     def __init__(self, cloud_interface, server_name):
         """
-        Object responsible for handling interactions with S3
+        Object responsible for handling interactions with cloud storage
 
         :param CloudInterface cloud_interface: The interface to use to
           upload the backup
@@ -176,7 +176,7 @@ class S3WalDownloader(object):
 
     def download_wal(self, wal_name, wal_dest):
         """
-        Download a WAL file from S3
+        Download a WAL file from cloud storage
 
         :param str wal_name: Name of the WAL file
         :param str wal_dest: Full path of the destination WAL file

--- a/barman/clients/cloud_walrestore.py
+++ b/barman/clients/cloud_walrestore.py
@@ -22,7 +22,7 @@ from contextlib import closing
 
 import barman
 from barman.cloud import configure_logging
-from barman.cloud_providers import S3CloudInterface
+from barman.cloud_providers import get_cloud_interface
 from barman.utils import force_str
 from barman.xlog import hash_dir, is_any_xlog_file, is_backup_file
 
@@ -48,11 +48,12 @@ def main(args=None):
         raise SystemExit(1)
 
     try:
-        cloud_interface = S3CloudInterface(
+        cloud_interface = get_cloud_interface(
             url=config.source_url,
             encryption=config.encryption,
             profile_name=config.profile,
             endpoint_url=config.endpoint_url,
+            cloud_provider=config.cloud_provider,
         )
 
         with closing(cloud_interface):
@@ -151,6 +152,12 @@ def parse_arguments(args=None):
     parser.add_argument(
         "--endpoint-url",
         help="Override default S3 endpoint URL with the given one",
+    )
+    parser.add_argument(
+        "--cloud-provider",
+        help="The cloud provider to use as a storage backend",
+        choices=["aws-s3"],
+        default="aws-s3",
     )
     return parser.parse_args(args=args)
 

--- a/barman/clients/cloud_walrestore.py
+++ b/barman/clients/cloud_walrestore.py
@@ -21,7 +21,8 @@ import os
 from contextlib import closing
 
 import barman
-from barman.cloud import S3CloudInterface, configure_logging
+from barman.cloud import configure_logging
+from barman.cloud_providers import S3CloudInterface
 from barman.utils import force_str
 from barman.xlog import hash_dir, is_any_xlog_file, is_backup_file
 

--- a/barman/clients/cloud_walrestore.py
+++ b/barman/clients/cloud_walrestore.py
@@ -90,7 +90,7 @@ def parse_arguments(args=None):
         description="This script can be used as a `restore_command` "
         "to download WAL files previously archived with "
         "barman-cloud-wal-archive command. "
-        "Currently only AWS S3 is supported.",
+        "Currently AWS S3 and Azure Blob Storage are supported.",
         add_help=False,
     )
 
@@ -130,19 +130,6 @@ def parse_arguments(args=None):
         help="decrease output verbosity (e.g., -qq is less than -q)",
     )
     parser.add_argument(
-        "-P",
-        "--profile",
-        help="profile name (e.g. INI section in AWS credentials file)",
-    )
-    parser.add_argument(
-        "-e",
-        "--encryption",
-        help="Enable server-side encryption for the transfer. "
-        "Allowed values: 'AES256', 'aws:kms'",
-        choices=["AES256", "aws:kms"],
-        metavar="ENCRYPTION",
-    )
-    parser.add_argument(
         "-t",
         "--test",
         help="Test cloud connectivity and exit",
@@ -150,14 +137,30 @@ def parse_arguments(args=None):
         default=False,
     )
     parser.add_argument(
+        "--cloud-provider",
+        help="The cloud provider to use as a storage backend",
+        choices=["aws-s3", "azure-blob-storage"],
+        default="aws-s3",
+    )
+    s3_arguments = parser.add_argument_group(
+        "Extra options for the aws-s3 cloud provider"
+    )
+    s3_arguments.add_argument(
         "--endpoint-url",
         help="Override default S3 endpoint URL with the given one",
     )
-    parser.add_argument(
-        "--cloud-provider",
-        help="The cloud provider to use as a storage backend",
-        choices=["aws-s3"],
-        default="aws-s3",
+    s3_arguments.add_argument(
+        "-P",
+        "--profile",
+        help="profile name (e.g. INI section in AWS credentials file)",
+    )
+    s3_arguments.add_argument(
+        "-e",
+        "--encryption",
+        help="Enable server-side encryption for the transfer. "
+        "Allowed values: 'AES256', 'aws:kms'",
+        choices=["AES256", "aws:kms"],
+        metavar="ENCRYPTION",
     )
     return parser.parse_args(args=args)
 

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -16,12 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
-import bz2
 import collections
 import copy
 import datetime
 import errno
-import gzip
 import json
 import logging
 import multiprocessing
@@ -32,7 +30,7 @@ import signal
 import tarfile
 from abc import ABCMeta, abstractmethod, abstractproperty
 from functools import partial
-from io import BytesIO, RawIOBase
+from io import BytesIO
 from tempfile import NamedTemporaryFile
 
 from barman.backup_executor import ConcurrentBackupStrategy, ExclusiveBackupStrategy
@@ -47,19 +45,6 @@ from barman.utils import (
     total_seconds,
     with_metaclass,
 )
-
-try:
-    import boto3
-    from botocore.exceptions import ClientError, EndpointConnectionError
-except ImportError:
-    raise SystemExit("Missing required python module: boto3")
-
-try:
-    # Python 3.x
-    from urllib.parse import urlparse
-except ImportError:
-    # Python 2.x
-    from urlparse import urlparse
 
 try:
     # Python 3.x
@@ -467,22 +452,6 @@ class FileUploadStatistics(dict):
     def set_part_start_time(self, part_number, start_time):
         part = self["parts"].setdefault(part_number, {"part_number": part_number})
         part["start_time"] = start_time
-
-
-class StreamingBodyIO(RawIOBase):
-    """
-    Wrap a boto StreamingBody in the IOBase API.
-    """
-
-    def __init__(self, body):
-        self.body = body
-
-    def readable(self):
-        return True
-
-    def read(self, n=-1):
-        n = None if n < 0 else n
-        return self.body.read(n)
 
 
 class CloudInterface(with_metaclass(ABCMeta)):
@@ -1001,270 +970,6 @@ class CloudInterface(with_metaclass(ABCMeta)):
         :param mpu:  The multipart upload handle
         :param str key: The key to use in the cloud service
         """
-
-
-class S3CloudInterface(CloudInterface):
-    # S3 multipart upload limitations
-    # http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html
-    MAX_CHUNKS_PER_FILE = 10000
-    MIN_CHUNK_SIZE = 5 << 20
-
-    # S3 permit a maximum of 5TB per file
-    # https://docs.aws.amazon.com/AmazonS3/latest/dev/UploadingObjects.html
-    # This is a hard limit, while our upload procedure can go over the specified
-    # MAX_ARCHIVE_SIZE - so we set a maximum of 1TB per file
-    MAX_ARCHIVE_SIZE = 1 << 40
-
-    def __init__(self, url, encryption, jobs=2, profile_name=None, endpoint_url=None):
-        """
-        Create a new S3 interface given the S3 destination url and the profile
-        name
-
-        :param str url: Full URL of the cloud destination/source
-        :param str|None encryption: Encryption type string
-        :param int jobs: How many sub-processes to use for asynchronous
-          uploading, defaults to 2.
-        :param str profile_name: Amazon auth profile identifier
-        :param str endpoint_url: override default endpoint detection strategy
-          with this one
-        """
-        super(S3CloudInterface, self).__init__(
-            url=url,
-            jobs=jobs,
-        )
-        self.profile_name = profile_name
-        self.encryption = encryption
-        self.endpoint_url = endpoint_url
-
-        # Extract information from the destination URL
-        parsed_url = urlparse(url)
-        # If netloc is not present, the s3 url is badly formatted.
-        if parsed_url.netloc == "" or parsed_url.scheme != "s3":
-            raise ValueError("Invalid s3 URL address: %s" % url)
-        self.bucket_name = parsed_url.netloc
-        self.bucket_exists = None
-        self.path = parsed_url.path.lstrip("/")
-
-        # Build a session, so we can extract the correct resource
-        self._reinit_session()
-
-    def _reinit_session(self):
-        """
-        Create a new session
-        """
-        session = boto3.Session(profile_name=self.profile_name)
-        self.s3 = session.resource("s3", endpoint_url=self.endpoint_url)
-
-    def test_connectivity(self):
-        """
-        Test AWS connectivity by trying to access a bucket
-        """
-        try:
-            # We are not even interested in the existence of the bucket,
-            # we just want to try if aws is reachable
-            self.bucket_exists = self._check_bucket_existence()
-            return True
-        except EndpointConnectionError as exc:
-            logging.error("Can't connect to cloud provider: %s", exc)
-            return False
-
-    def _check_bucket_existence(self):
-        """
-        Check cloud storage for the target bucket
-
-        :return: True if the bucket exists, False otherwise
-        :rtype: bool
-        """
-        try:
-            # Search the bucket on s3
-            self.s3.meta.client.head_bucket(Bucket=self.bucket_name)
-            return True
-        except ClientError as exc:
-            # If a client error is thrown, then check the error code.
-            # If code was 404, then the bucket does not exist
-            error_code = exc.response["Error"]["Code"]
-            if error_code == "404":
-                return False
-            # Otherwise there is nothing else to do than re-raise the original
-            # exception
-            raise
-
-    def _create_bucket(self):
-        """
-        Create the bucket in cloud storage
-        """
-        # Get the current region from client.
-        # Do not use session.region_name here because it may be None
-        region = self.s3.meta.client.meta.region_name
-        logging.info(
-            "Bucket '%s' does not exist, creating it on region '%s'",
-            self.bucket_name,
-            region,
-        )
-        create_bucket_config = {
-            "ACL": "private",
-        }
-        # The location constraint is required during bucket creation
-        # for all regions outside of us-east-1. This constraint cannot
-        # be specified in us-east-1; specifying it in this region
-        # results in a failure, so we will only
-        # add it if we are deploying outside of us-east-1.
-        # See https://github.com/boto/boto3/issues/125
-        if region != "us-east-1":
-            create_bucket_config["CreateBucketConfiguration"] = {
-                "LocationConstraint": region,
-            }
-        self.s3.Bucket(self.bucket_name).create(**create_bucket_config)
-
-    def list_bucket(self, prefix="", delimiter="/"):
-        """
-        List bucket content in a directory manner
-
-        :param str prefix:
-        :param str delimiter:
-        :return: List of objects and dirs right under the prefix
-        :rtype: List[str]
-        """
-        if prefix.startswith(delimiter):
-            prefix = prefix.lstrip(delimiter)
-
-        res = self.s3.meta.client.list_objects_v2(
-            Bucket=self.bucket_name, Prefix=prefix, Delimiter=delimiter
-        )
-
-        # List "folders"
-        keys = res.get("CommonPrefixes")
-        if keys is not None:
-            for k in keys:
-                yield k.get("Prefix")
-
-        # List "files"
-        objects = res.get("Contents")
-        if objects is not None:
-            for o in objects:
-                yield o.get("Key")
-
-    def download_file(self, key, dest_path, decompress):
-        """
-        Download a file from S3
-
-        :param str key: The S3 key to download
-        :param str dest_path: Where to put the destination file
-        :param bool decompress: Whenever to decompress this file or not
-        """
-        # Open the remote file
-        obj = self.s3.Object(self.bucket_name, key)
-        remote_file = obj.get()["Body"]
-
-        # Write the dest file in binary mode
-        with open(dest_path, "wb") as dest_file:
-            # If the file is not compressed, just copy its content
-            if not decompress:
-                shutil.copyfileobj(remote_file, dest_file)
-                return
-
-            if decompress == "gzip":
-                source_file = gzip.GzipFile(fileobj=remote_file, mode="rb")
-            elif decompress == "bzip2":
-                source_file = bz2.BZ2File(remote_file, "rb")
-            else:
-                raise ValueError("Unknown compression type: %s" % decompress)
-
-            with source_file:
-                shutil.copyfileobj(source_file, dest_file)
-
-    def remote_open(self, key):
-        """
-        Open a remote S3 object and returns a readable stream
-
-        :param str key: The key identifying the object to open
-        :return: A file-like object from which the stream can be read or None if
-          the key does not exist
-        """
-        try:
-            obj = self.s3.Object(self.bucket_name, key)
-            return StreamingBodyIO(obj.get()["Body"])
-        except ClientError as exc:
-            error_code = exc.response["Error"]["Code"]
-            if error_code == "NoSuchKey":
-                return None
-            else:
-                raise
-
-    def upload_fileobj(self, fileobj, key):
-        """
-        Synchronously upload the content of a file-like object to a cloud key
-        :param fileobj IOBase: File-like object to upload
-        :param str key: The key to identify the uploaded object
-        """
-        additional_args = {}
-        if self.encryption:
-            additional_args["ServerSideEncryption"] = self.encryption
-
-        self.s3.meta.client.upload_fileobj(
-            Fileobj=fileobj, Bucket=self.bucket_name, Key=key, ExtraArgs=additional_args
-        )
-
-    def create_multipart_upload(self, key):
-        """
-        Create a new multipart upload
-
-        :param key: The key to use in the cloud service
-        :return: The multipart upload handle
-        :rtype: dict[str, str
-        """
-        return self.s3.meta.client.create_multipart_upload(
-            Bucket=self.bucket_name, Key=key
-        )
-
-    def _upload_part(self, mpu, key, body, part_number):
-        """
-        Upload a part into this multipart upload
-
-        :param mpu: The multipart upload handle
-        :param str key: The key to use in the cloud service
-        :param object body: A stream-like object to upload
-        :param int part_number: Part number, starting from 1
-        :return: The part handle
-        :rtype: dict[str, None|str]
-        """
-        part = self.s3.meta.client.upload_part(
-            Body=body,
-            Bucket=self.bucket_name,
-            Key=key,
-            UploadId=mpu["UploadId"],
-            PartNumber=part_number,
-        )
-        return {
-            "PartNumber": part_number,
-            "ETag": part["ETag"],
-        }
-
-    def _complete_multipart_upload(self, mpu, key, parts):
-        """
-        Finish a certain multipart upload
-
-        :param mpu:  The multipart upload handle
-        :param str key: The key to use in the cloud service
-        :param parts: The list of parts composing the multipart upload
-        """
-        self.s3.meta.client.complete_multipart_upload(
-            Bucket=self.bucket_name,
-            Key=key,
-            UploadId=mpu["UploadId"],
-            MultipartUpload={"Parts": parts},
-        )
-
-    def _abort_multipart_upload(self, mpu, key):
-        """
-        Abort a certain multipart upload
-
-        :param mpu:  The multipart upload handle
-        :param str key: The key to use in the cloud service
-        """
-        self.s3.meta.client.abort_multipart_upload(
-            Bucket=self.bucket_name, Key=key, UploadId=mpu["UploadId"]
-        )
 
 
 class CloudBackupUploader(object):

--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -28,3 +28,7 @@ def get_cloud_interface(cloud_provider, url, **kwargs):
         from barman.cloud_providers.aws_s3 import S3CloudInterface
 
         return S3CloudInterface(url, **kwargs)
+    elif cloud_provider == "azure-blob-storage":
+        from barman.cloud_providers.azure_blob_storage import AzureCloudInterface
+
+        return AzureCloudInterface(url, **kwargs)

--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -1,1 +1,30 @@
-from barman.cloud_providers.aws_s3 import S3CloudInterface
+# -*- coding: utf-8 -*-
+# © Copyright EnterpriseDB UK Limited 2018-2021
+#
+# This file is part of Barman.
+#
+# Barman is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Barman is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Barman.  If not, see <http://www.gnu.org/licenses/>
+
+
+def get_cloud_interface(cloud_provider, url, **kwargs):
+    """
+    Create a CloudInterface for the specified cloud_provider
+
+    :returns: A CloudInterface for the specified cloud_provider
+    :rtype: CloudInterface
+    """
+    if cloud_provider == "aws-s3":
+        from barman.cloud_providers.aws_s3 import S3CloudInterface
+
+        return S3CloudInterface(url, **kwargs)

--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -1,0 +1,1 @@
+from barman.cloud_providers.aws_s3 import S3CloudInterface

--- a/barman/cloud_providers/aws_s3.py
+++ b/barman/cloud_providers/aws_s3.py
@@ -1,0 +1,319 @@
+# -*- coding: utf-8 -*-
+# © Copyright EnterpriseDB UK Limited 2018-2021
+#
+# This file is part of Barman.
+#
+# Barman is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Barman is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Barman.  If not, see <http://www.gnu.org/licenses/>
+
+import bz2
+import gzip
+import logging
+import shutil
+from io import RawIOBase
+
+from barman.cloud import CloudInterface
+
+try:
+    # Python 3.x
+    from urllib.parse import urlparse
+except ImportError:
+    # Python 2.x
+    from urlparse import urlparse
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError, EndpointConnectionError
+except ImportError:
+    raise SystemExit("Missing required python module: boto3")
+
+
+class StreamingBodyIO(RawIOBase):
+    """
+    Wrap a boto StreamingBody in the IOBase API.
+    """
+
+    def __init__(self, body):
+        self.body = body
+
+    def readable(self):
+        return True
+
+    def read(self, n=-1):
+        n = None if n < 0 else n
+        return self.body.read(n)
+
+
+class S3CloudInterface(CloudInterface):
+    # S3 multipart upload limitations
+    # http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html
+    MAX_CHUNKS_PER_FILE = 10000
+    MIN_CHUNK_SIZE = 5 << 20
+
+    # S3 permit a maximum of 5TB per file
+    # https://docs.aws.amazon.com/AmazonS3/latest/dev/UploadingObjects.html
+    # This is a hard limit, while our upload procedure can go over the specified
+    # MAX_ARCHIVE_SIZE - so we set a maximum of 1TB per file
+    MAX_ARCHIVE_SIZE = 1 << 40
+
+    def __init__(self, url, encryption, jobs=2, profile_name=None, endpoint_url=None):
+        """
+        Create a new S3 interface given the S3 destination url and the profile
+        name
+
+        :param str url: Full URL of the cloud destination/source
+        :param str|None encryption: Encryption type string
+        :param int jobs: How many sub-processes to use for asynchronous
+          uploading, defaults to 2.
+        :param str profile_name: Amazon auth profile identifier
+        :param str endpoint_url: override default endpoint detection strategy
+          with this one
+        """
+        super(S3CloudInterface, self).__init__(
+            url=url,
+            jobs=jobs,
+        )
+        self.profile_name = profile_name
+        self.encryption = encryption
+        self.endpoint_url = endpoint_url
+
+        # Extract information from the destination URL
+        parsed_url = urlparse(url)
+        # If netloc is not present, the s3 url is badly formatted.
+        if parsed_url.netloc == "" or parsed_url.scheme != "s3":
+            raise ValueError("Invalid s3 URL address: %s" % url)
+        self.bucket_name = parsed_url.netloc
+        self.bucket_exists = None
+        self.path = parsed_url.path.lstrip("/")
+
+        # Build a session, so we can extract the correct resource
+        self._reinit_session()
+
+    def _reinit_session(self):
+        """
+        Create a new session
+        """
+        session = boto3.Session(profile_name=self.profile_name)
+        self.s3 = session.resource("s3", endpoint_url=self.endpoint_url)
+
+    def test_connectivity(self):
+        """
+        Test AWS connectivity by trying to access a bucket
+        """
+        try:
+            # We are not even interested in the existence of the bucket,
+            # we just want to try if aws is reachable
+            self.bucket_exists = self._check_bucket_existence()
+            return True
+        except EndpointConnectionError as exc:
+            logging.error("Can't connect to cloud provider: %s", exc)
+            return False
+
+    def _check_bucket_existence(self):
+        """
+        Check cloud storage for the target bucket
+
+        :return: True if the bucket exists, False otherwise
+        :rtype: bool
+        """
+        try:
+            # Search the bucket on s3
+            self.s3.meta.client.head_bucket(Bucket=self.bucket_name)
+            return True
+        except ClientError as exc:
+            # If a client error is thrown, then check the error code.
+            # If code was 404, then the bucket does not exist
+            error_code = exc.response["Error"]["Code"]
+            if error_code == "404":
+                return False
+            # Otherwise there is nothing else to do than re-raise the original
+            # exception
+            raise
+
+    def _create_bucket(self):
+        """
+        Create the bucket in cloud storage
+        """
+        # Get the current region from client.
+        # Do not use session.region_name here because it may be None
+        region = self.s3.meta.client.meta.region_name
+        logging.info(
+            "Bucket '%s' does not exist, creating it on region '%s'",
+            self.bucket_name,
+            region,
+        )
+        create_bucket_config = {
+            "ACL": "private",
+        }
+        # The location constraint is required during bucket creation
+        # for all regions outside of us-east-1. This constraint cannot
+        # be specified in us-east-1; specifying it in this region
+        # results in a failure, so we will only
+        # add it if we are deploying outside of us-east-1.
+        # See https://github.com/boto/boto3/issues/125
+        if region != "us-east-1":
+            create_bucket_config["CreateBucketConfiguration"] = {
+                "LocationConstraint": region,
+            }
+        self.s3.Bucket(self.bucket_name).create(**create_bucket_config)
+
+    def list_bucket(self, prefix="", delimiter="/"):
+        """
+        List bucket content in a directory manner
+
+        :param str prefix:
+        :param str delimiter:
+        :return: List of objects and dirs right under the prefix
+        :rtype: List[str]
+        """
+        if prefix.startswith(delimiter):
+            prefix = prefix.lstrip(delimiter)
+
+        res = self.s3.meta.client.list_objects_v2(
+            Bucket=self.bucket_name, Prefix=prefix, Delimiter=delimiter
+        )
+
+        # List "folders"
+        keys = res.get("CommonPrefixes")
+        if keys is not None:
+            for k in keys:
+                yield k.get("Prefix")
+
+        # List "files"
+        objects = res.get("Contents")
+        if objects is not None:
+            for o in objects:
+                yield o.get("Key")
+
+    def download_file(self, key, dest_path, decompress):
+        """
+        Download a file from S3
+
+        :param str key: The S3 key to download
+        :param str dest_path: Where to put the destination file
+        :param bool decompress: Whenever to decompress this file or not
+        """
+        # Open the remote file
+        obj = self.s3.Object(self.bucket_name, key)
+        remote_file = obj.get()["Body"]
+
+        # Write the dest file in binary mode
+        with open(dest_path, "wb") as dest_file:
+            # If the file is not compressed, just copy its content
+            if not decompress:
+                shutil.copyfileobj(remote_file, dest_file)
+                return
+
+            if decompress == "gzip":
+                source_file = gzip.GzipFile(fileobj=remote_file, mode="rb")
+            elif decompress == "bzip2":
+                source_file = bz2.BZ2File(remote_file, "rb")
+            else:
+                raise ValueError("Unknown compression type: %s" % decompress)
+
+            with source_file:
+                shutil.copyfileobj(source_file, dest_file)
+
+    def remote_open(self, key):
+        """
+        Open a remote S3 object and returns a readable stream
+
+        :param str key: The key identifying the object to open
+        :return: A file-like object from which the stream can be read or None if
+          the key does not exist
+        """
+        try:
+            obj = self.s3.Object(self.bucket_name, key)
+            return StreamingBodyIO(obj.get()["Body"])
+        except ClientError as exc:
+            error_code = exc.response["Error"]["Code"]
+            if error_code == "NoSuchKey":
+                return None
+            else:
+                raise
+
+    def upload_fileobj(self, fileobj, key):
+        """
+        Synchronously upload the content of a file-like object to a cloud key
+
+        :param fileobj IOBase: File-like object to upload
+        :param str key: The key to identify the uploaded object
+        """
+        additional_args = {}
+        if self.encryption:
+            additional_args["ServerSideEncryption"] = self.encryption
+
+        self.s3.meta.client.upload_fileobj(
+            Fileobj=fileobj, Bucket=self.bucket_name, Key=key, ExtraArgs=additional_args
+        )
+
+    def create_multipart_upload(self, key):
+        """
+        Create a new multipart upload
+
+        :param key: The key to use in the cloud service
+        :return: The multipart upload handle
+        :rtype: dict[str, str]
+        """
+        return self.s3.meta.client.create_multipart_upload(
+            Bucket=self.bucket_name, Key=key
+        )
+
+    def _upload_part(self, mpu, key, body, part_number):
+        """
+        Upload a part into this multipart upload
+
+        :param mpu: The multipart upload handle
+        :param str key: The key to use in the cloud service
+        :param object body: A stream-like object to upload
+        :param int part_number: Part number, starting from 1
+        :return: The part handle
+        :rtype: dict[str, None|str]
+        """
+        part = self.s3.meta.client.upload_part(
+            Body=body,
+            Bucket=self.bucket_name,
+            Key=key,
+            UploadId=mpu["UploadId"],
+            PartNumber=part_number,
+        )
+        return {
+            "PartNumber": part_number,
+            "ETag": part["ETag"],
+        }
+
+    def _complete_multipart_upload(self, mpu, key, parts):
+        """
+        Finish a certain multipart upload
+
+        :param mpu:  The multipart upload handle
+        :param str key: The key to use in the cloud service
+        :param parts: The list of parts composing the multipart upload
+        """
+        self.s3.meta.client.complete_multipart_upload(
+            Bucket=self.bucket_name,
+            Key=key,
+            UploadId=mpu["UploadId"],
+            MultipartUpload={"Parts": parts},
+        )
+
+    def _abort_multipart_upload(self, mpu, key):
+        """
+        Abort a certain multipart upload
+
+        :param mpu:  The multipart upload handle
+        :param str key: The key to use in the cloud service
+        """
+        self.s3.meta.client.abort_multipart_upload(
+            Bucket=self.bucket_name, Key=key, UploadId=mpu["UploadId"]
+        )

--- a/barman/cloud_providers/aws_s3.py
+++ b/barman/cloud_providers/aws_s3.py
@@ -269,11 +269,11 @@ class S3CloudInterface(CloudInterface):
             Bucket=self.bucket_name, Key=key
         )
 
-    def _upload_part(self, mpu, key, body, part_number):
+    def _upload_part(self, upload_metadata, key, body, part_number):
         """
         Upload a part into this multipart upload
 
-        :param mpu: The multipart upload handle
+        :param dict upload_metadata: The multipart upload handle
         :param str key: The key to use in the cloud service
         :param object body: A stream-like object to upload
         :param int part_number: Part number, starting from 1
@@ -284,7 +284,7 @@ class S3CloudInterface(CloudInterface):
             Body=body,
             Bucket=self.bucket_name,
             Key=key,
-            UploadId=mpu["UploadId"],
+            UploadId=upload_metadata["UploadId"],
             PartNumber=part_number,
         )
         return {
@@ -292,28 +292,28 @@ class S3CloudInterface(CloudInterface):
             "ETag": part["ETag"],
         }
 
-    def _complete_multipart_upload(self, mpu, key, parts):
+    def _complete_multipart_upload(self, upload_metadata, key, parts):
         """
         Finish a certain multipart upload
 
-        :param mpu:  The multipart upload handle
+        :param dict upload_metadata:  The multipart upload handle
         :param str key: The key to use in the cloud service
         :param parts: The list of parts composing the multipart upload
         """
         self.s3.meta.client.complete_multipart_upload(
             Bucket=self.bucket_name,
             Key=key,
-            UploadId=mpu["UploadId"],
+            UploadId=upload_metadata["UploadId"],
             MultipartUpload={"Parts": parts},
         )
 
-    def _abort_multipart_upload(self, mpu, key):
+    def _abort_multipart_upload(self, upload_metadata, key):
         """
         Abort a certain multipart upload
 
-        :param mpu:  The multipart upload handle
+        :param dict upload_metadata:  The multipart upload handle
         :param str key: The key to use in the cloud service
         """
         self.s3.meta.client.abort_multipart_upload(
-            Bucket=self.bucket_name, Key=key, UploadId=mpu["UploadId"]
+            Bucket=self.bucket_name, Key=key, UploadId=upload_metadata["UploadId"]
         )

--- a/barman/cloud_providers/azure_blob_storage.py
+++ b/barman/cloud_providers/azure_blob_storage.py
@@ -1,0 +1,351 @@
+# -*- coding: utf-8 -*-
+# © Copyright EnterpriseDB UK Limited 2018-2021
+#
+# This file is part of Barman.
+#
+# Barman is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Barman is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Barman.  If not, see <http://www.gnu.org/licenses/>
+
+import bz2
+import gzip
+import logging
+import os
+import shutil
+from io import BytesIO, RawIOBase
+
+from barman.cloud import CloudInterface
+
+try:
+    # Python 3.x
+    from urllib.parse import urlparse
+except ImportError:
+    # Python 2.x
+    from urlparse import urlparse
+
+try:
+    from azure.storage.blob import BlobPrefix, BlobServiceClient
+    from azure.core.exceptions import (
+        HttpResponseError,
+        ResourceNotFoundError,
+        ServiceRequestError,
+    )
+except ImportError:
+    raise SystemExit("Missing required python module: azure-storage-blob")
+
+# Domain for azure blob URIs
+# See https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#resource-uri-syntax
+AZURE_BLOB_STORAGE_DOMAIN = "blob.core.windows.net"
+
+
+class StreamingBlobIO(RawIOBase):
+    """
+    Wrap an azure-storage-blob StorageStreamDownloader in the IOBase API.
+
+    Inherits the IOBase defaults of seekable() -> False and writable() -> False.
+    """
+
+    def __init__(self, blob):
+        self._chunks = blob.chunks()
+        self._current_chunk = BytesIO()
+
+    def readable(self):
+        return True
+
+    def read(self, n=1):
+        """
+        Read at most n bytes from the stream.
+
+        Fetches new chunks from the StorageStreamDownloader until the requested
+        number of bytes have been read.
+
+        :param int n: Number of bytes to read from the stream
+        :return: Up to n bytes from the stream
+        :rtype: bytes
+        """
+        n = None if n < 0 else n
+        blob_bytes = self._current_chunk.read(n)
+        bytes_count = len(blob_bytes)
+        try:
+            while bytes_count < n:
+                self._current_chunk = BytesIO(self._chunks.next())
+                new_blob_bytes = self._current_chunk.read(n - bytes_count)
+                bytes_count += len(new_blob_bytes)
+                blob_bytes += new_blob_bytes
+        except StopIteration:
+            pass
+        return blob_bytes
+
+
+class AzureCloudInterface(CloudInterface):
+    # Azure block blob limitations
+    # https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs
+    MAX_CHUNKS_PER_FILE = 50000
+    # Minimum block size allowed in Azure Blob Storage is 64KB
+    MIN_CHUNK_SIZE = 64 << 10
+
+    # Azure Blob Storage permit a maximum of 4.75TB per file
+    # This is a hard limit, while our upload procedure can go over the specified
+    # MAX_ARCHIVE_SIZE - so we set a maximum of 1TB per file
+    MAX_ARCHIVE_SIZE = 1 << 40
+
+    def __init__(self, url, jobs=2, **kwargs):
+        """
+        Create a new Azure Blob Storage interface given the supplied acccount url
+
+        :param str url: Full URL of the cloud destination/source
+        :param int jobs: How many sub-processes to use for asynchronous
+          uploading, defaults to 2.
+        """
+        super(AzureCloudInterface, self).__init__(
+            url=url,
+            jobs=jobs,
+        )
+
+        parsed_url = urlparse(url)
+        if parsed_url.netloc.endswith(AZURE_BLOB_STORAGE_DOMAIN):
+            # We have an Azure Storage URI so we use the following form:
+            # <http|https>://<account-name>.<service-name>.core.windows.net/<resource-path>
+            # where <resource-path> is <container>/<blob>.
+            # Note that although Azure supports an implicit root container, we require
+            # that the container is always included.
+            self.account_url = parsed_url.netloc
+            try:
+                self.bucket_name = parsed_url.path.split("/")[1]
+            except IndexError:
+                raise ValueError("azure blob storage URL %s is malformed" % url)
+            path = parsed_url.path.split("/")[2:]
+        else:
+            # We are dealing with emulated storage so we use the following form:
+            # http://<local-machine-address>:<port>/<account-name>/<resource-path>
+            logging.warn("Using emulated storage URL: %s " % url)
+            if "AZURE_STORAGE_CONNECTION_STRING" not in os.environ:
+                raise ValueError(
+                    "A connection string must be povided when using emulated storage"
+                )
+            try:
+                self.bucket_name = parsed_url.path.split("/")[2]
+            except IndexError:
+                raise ValueError("emulated storage URL %s is malformed" % url)
+            path = parsed_url.path.split("/")[3:]
+
+        self.path = "/".join(path)
+
+        self.bucket_exists = None
+        self._reinit_session()
+
+    def _reinit_session(self):
+        """
+        Create a new session
+        """
+        if "AZURE_STORAGE_CONNECTION_STRING" in os.environ:
+            logging.info("Authenticating to Azure with connection string")
+            client = BlobServiceClient.from_connection_string(
+                conn_str=os.getenv("AZURE_STORAGE_CONNECTION_STRING"),
+                container_name=self.bucket_name,
+            )
+        else:
+            if "AZURE_STORAGE_SAS_TOKEN" in os.environ:
+                logging.info("Authenticating to Azure with SAS token")
+                credential = os.getenv("AZURE_STORAGE_SAS_TOKEN")
+            elif "AZURE_STORAGE_KEY" in os.environ:
+                logging.info("Authenticating to Azure with shared key")
+                credential = os.getenv("AZURE_STORAGE_KEY")
+            else:
+                logging.info("Authenticating to Azure with default credentials")
+                # azure-identity is not part of azure-storage-blob so only import
+                # it if needed
+                try:
+                    from azure.identity import DefaultAzureCredential
+                except ImportError:
+                    raise SystemExit("Missing required python module: azure-identity")
+                credential = DefaultAzureCredential()
+            client = BlobServiceClient(
+                account_url=self.account_url,
+                credential=credential,
+                container_name=self.bucket_name,
+            )
+        self.container_client = client.get_container_client(self.bucket_name)
+
+    def test_connectivity(self):
+        """
+        Test Azure connectivity by trying to access a container
+        """
+        try:
+            # We are not even interested in the existence of the bucket,
+            # we just want to see if Azure blob service is reachable.
+            self.bucket_exists = self._check_bucket_existence()
+            return True
+        except (HttpResponseError, ServiceRequestError) as exc:
+            logging.error("Can't connect to cloud provider: %s", exc)
+            return False
+
+    def _check_bucket_existence(self):
+        """
+        Chck Azure Blob Storage for the target container
+
+        :return: True if the container exists, False otherwise
+        :rtype: bool
+        """
+        return self.container_client.exists()
+
+    def _create_bucket(self):
+        """
+        Create the container in cloud storage
+        """
+        # By default public access is disabled for newly created containers.
+        # Unlike S3 there is no concept of regions for containers (this is at
+        # the storage account level in Azure)
+        self.container_client.create_container()
+
+    def _walk_blob_tree(self, obj, ignore=None):
+        """
+        Walk a blob tree in a directory manner and return a list of directories
+        and files.
+
+        :param ItemPaged[BlobProperties] obj: Iterable response of BlobProperties
+          obtained from ContainerClient.walk_blobs
+        :param str|None ignore: An entry to be excluded from the returned list,
+          typically the top level prefix
+        :return: List of objects and directories in the tree
+        :rtype: List[str]
+        """
+        if obj.name != ignore:
+            yield obj.name
+        if isinstance(obj, BlobPrefix):
+            # We are a prefix and not a leaf so iterate children
+            for child in obj:
+                for v in self._walk_blob_tree(child):
+                    yield v
+
+    def list_bucket(self, prefix="", delimiter="/"):
+        """
+        List bucket content in a directory manner
+
+        :param str prefix:
+        :param str delimiter:
+        :return: List of objects and dirs right under the prefix
+        :rtype: List[str]
+        """
+        res = self.container_client.walk_blobs(
+            name_starts_with=prefix, delimiter=delimiter
+        )
+        return self._walk_blob_tree(res, ignore=prefix)
+
+    def download_file(self, key, dest_path, decompress=None):
+        """
+        Download a file from Azure Blob Storage
+
+        :param str key: The key to download
+        :param str dest_path: Where to put the destination file
+        :param str|None decompress: Compression scheme to use for decompression
+        """
+        obj = self.container_client.download_blob(key)
+        with open(dest_path, "wb") as dest_file:
+            if not decompress:
+                obj.download_to_stream(dest_file)
+                return
+            blob = StreamingBlobIO(obj)
+            if decompress == "gzip":
+                source_file = gzip.GzipFile(fileobj=blob, mode="rb")
+            elif decompress == "bzip2":
+                source_file = bz2.BZ2File(blob, "rb")
+            with source_file:
+                shutil.copyfileobj(source_file, dest_file)
+
+    def remote_open(self, key):
+        """
+        Open a remote Azure Blob Storage object and return a readable stream
+
+        :param str key: The key identifying the object to open
+        :return: A file-like object from which the stream can be read or None if
+          the key does not exist
+        """
+        try:
+            obj = self.container_client.download_blob(key)
+            return StreamingBlobIO(obj)
+        except ResourceNotFoundError:
+            return None
+
+    def upload_fileobj(self, fileobj, key):
+        """
+        Synchronously upload the content of a file-like object to a cloud key
+
+        :param fileobj IOBase: File-like object to upload
+        :param str key: The key to identify the uploaded object
+        """
+        self.container_client.upload_blob(
+            name=key,
+            data=fileobj,
+            overwrite=True,
+        )
+
+    def create_multipart_upload(self, key):
+        """No-op method because Azure has no concept of multipart uploads
+
+        Instead of multipart upload, blob blocks are staged and then committed.
+        However this does not require anything to be created up front.
+        This method therefore does nothing.
+        """
+        pass
+
+    def _upload_part(self, mpu, key, body, part_number):
+        """
+        Upload a single block of this block blob.
+
+        :param mpu: The multipart upload handle (not used with Azure).
+        :param str key: The key to use in the cloud service
+        :param object body: A stream-like object to upload
+        :param int part_number: Part number, starting from 1
+        :return: The part handle
+        :rtype: dict[str, None|str]
+        """
+        # Block IDs must be the same length for all bocks in the blob
+        # and no greater than 64 characters. Given there is a limit of
+        # 50000 blocks per blob we zero-pad the part_number to five
+        # places.
+        block_id = str(part_number).zfill(5)
+        blob_client = self.container_client.get_blob_client(key)
+        blob_client.stage_block(block_id, body)
+        return {"PartNumber": block_id}
+
+    def _complete_multipart_upload(self, mpu, key, parts):
+        """
+        Finish a "multipart upload" by committing all blocks in the blob.
+
+        :param mpu:  The multipart upload handle (not used)
+        :param str key: The key to use in the cloud service
+        :param parts: The list of block IDs for the blocks which compose this blob
+        """
+        blob_client = self.container_client.get_blob_client(key)
+        block_list = [part["PartNumber"] for part in parts]
+        blob_client.commit_block_list(block_list)
+
+    def _abort_multipart_upload(self, mpu, key):
+        """
+        Abort the upload of a block blob
+
+        The objective of this method is to clean up any dangling resources - in
+        this case those resources are uncommitted blocks.
+
+        :param mpu:  The multipart upload handle
+        :param str key: The key to use in the cloud service
+        """
+        # Ideally we would clean up uncommitted blocks at this point
+        # however there is no way of doing that.
+        # Uncommitted blocks will be discarded after 7 days or when
+        # the blob is committed (if they're not included in the commit).
+        # We therefore create an empty blob (thereby discarding all uploaded
+        # blocks for that blob) and then delete it.
+        blob_client = self.container_client.get_blob_client(key)
+        blob_client.commit_block_list([])
+        blob_client.delete_blob()

--- a/barman/cloud_providers/azure_blob_storage.py
+++ b/barman/cloud_providers/azure_blob_storage.py
@@ -298,15 +298,19 @@ class AzureCloudInterface(CloudInterface):
         """
         pass
 
-    def _upload_part(self, mpu, key, body, part_number):
+    def _upload_part(self, upload_metadata, key, body, part_number):
         """
         Upload a single block of this block blob.
 
-        :param mpu: The multipart upload handle (not used with Azure).
+        Uses the supplied part number to generate the block ID and returns it
+        as the "PartNumber" in the part metadata.
+
+        :param dict upload_metadata: Provider-specific metadata about the upload
+          (not used in Azure)
         :param str key: The key to use in the cloud service
         :param object body: A stream-like object to upload
         :param int part_number: Part number, starting from 1
-        :return: The part handle
+        :return: The part metadata
         :rtype: dict[str, None|str]
         """
         # Block IDs must be the same length for all bocks in the blob
@@ -318,11 +322,12 @@ class AzureCloudInterface(CloudInterface):
         blob_client.stage_block(block_id, body)
         return {"PartNumber": block_id}
 
-    def _complete_multipart_upload(self, mpu, key, parts):
+    def _complete_multipart_upload(self, upload_metadata, key, parts):
         """
         Finish a "multipart upload" by committing all blocks in the blob.
 
-        :param mpu:  The multipart upload handle (not used)
+        :param dict upload_metadata: Provider-specific metadata about the upload
+          (not used in Azure)
         :param str key: The key to use in the cloud service
         :param parts: The list of block IDs for the blocks which compose this blob
         """
@@ -330,14 +335,15 @@ class AzureCloudInterface(CloudInterface):
         block_list = [part["PartNumber"] for part in parts]
         blob_client.commit_block_list(block_list)
 
-    def _abort_multipart_upload(self, mpu, key):
+    def _abort_multipart_upload(self, upload_metadata, key):
         """
         Abort the upload of a block blob
 
         The objective of this method is to clean up any dangling resources - in
         this case those resources are uncommitted blocks.
 
-        :param mpu:  The multipart upload handle
+        :param dict upload_metadata: Provider-specific metadata about the upload
+          (not used in Azure)
         :param str key: The key to use in the cloud service
         """
         # Ideally we would clean up uncommitted blocks at this point

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
     extras_require={
         'cloud': ['boto3'],
         'completion': ['argcomplete'],
+        'azure': ['azure-identity', 'azure-storage-blob']
     },
     platforms=['Linux', 'Mac OS X'],
     classifiers=[

--- a/tests/test_barman_cloud_wal_archive.py
+++ b/tests/test_barman_cloud_wal_archive.py
@@ -26,7 +26,7 @@ import pytest
 
 from barman.clients import cloud_walarchive
 from barman.clients.cloud_walarchive import CloudWalUploader
-from barman.cloud_providers import S3CloudInterface
+from barman.cloud_providers.aws_s3 import S3CloudInterface
 from barman.xlog import hash_dir
 
 
@@ -36,7 +36,7 @@ class TestMain(object):
     """
 
     @mock.patch("barman.clients.cloud_walarchive.CloudWalUploader")
-    @mock.patch("barman.clients.cloud_walarchive.S3CloudInterface")
+    @mock.patch("barman.clients.cloud_walarchive.get_cloud_interface")
     def test_ok(self, cloud_interface_mock, uploader_mock):
         uploader_object_mock = uploader_mock.return_value
         cloud_object_interface_mock = cloud_interface_mock.return_value

--- a/tests/test_barman_cloud_wal_archive.py
+++ b/tests/test_barman_cloud_wal_archive.py
@@ -26,7 +26,7 @@ import pytest
 
 from barman.clients import cloud_walarchive
 from barman.clients.cloud_walarchive import S3WalUploader
-from barman.cloud import CloudInterface
+from barman.cloud import S3CloudInterface
 from barman.xlog import hash_dir
 
 
@@ -36,7 +36,7 @@ class TestMain(object):
     """
 
     @mock.patch("barman.clients.cloud_walarchive.S3WalUploader")
-    @mock.patch("barman.clients.cloud_walarchive.CloudInterface")
+    @mock.patch("barman.clients.cloud_walarchive.S3CloudInterface")
     def test_ok(self, cloud_interface_mock, uploader_mock):
         uploader_object_mock = uploader_mock.return_value
         cloud_object_interface_mock = cloud_interface_mock.return_value
@@ -176,7 +176,7 @@ class TestWalUploader(object):
         Test the upload of a WAL
         """
         # Create a simple S3WalUploader obj
-        cloud_interface = CloudInterface("s3://bucket/path/to/dir", encryption=None)
+        cloud_interface = S3CloudInterface("s3://bucket/path/to/dir", encryption=None)
         uploader = S3WalUploader(cloud_interface, "test-server")
         source = "/wal_dir/000000080000ABFF000000C1"
         # Simulate the file object returned by the retrieve_file_obj method
@@ -206,7 +206,9 @@ class TestWalUploader(object):
         Test the upload of a WAL
         """
         # Create a simple S3WalUploader obj
-        cloud_interface = CloudInterface("s3://bucket/path/to/dir", encryption="AES256")
+        cloud_interface = S3CloudInterface(
+            "s3://bucket/path/to/dir", encryption="AES256"
+        )
         uploader = S3WalUploader(cloud_interface, "test-server")
         source = "/wal_dir/000000080000ABFF000000C1"
         # Simulate the file object returned by the retrieve_file_obj method

--- a/tests/test_barman_cloud_wal_archive.py
+++ b/tests/test_barman_cloud_wal_archive.py
@@ -26,7 +26,7 @@ import pytest
 
 from barman.clients import cloud_walarchive
 from barman.clients.cloud_walarchive import CloudWalUploader
-from barman.cloud import S3CloudInterface
+from barman.cloud_providers import S3CloudInterface
 from barman.xlog import hash_dir
 
 
@@ -169,7 +169,7 @@ class TestWalUploader(object):
     Test the CloudWalUploader class
     """
 
-    @mock.patch("barman.cloud.boto3")
+    @mock.patch("barman.cloud_providers.aws_s3.boto3")
     @mock.patch("barman.clients.cloud_walarchive.CloudWalUploader." "retrieve_file_obj")
     def test_upload_wal(self, rfo_mock, boto_mock):
         """
@@ -199,7 +199,7 @@ class TestWalUploader(object):
             ExtraArgs={},
         )
 
-    @mock.patch("barman.cloud.boto3")
+    @mock.patch("barman.cloud_providers.aws_s3.boto3")
     @mock.patch("barman.clients.cloud_walarchive.CloudWalUploader." "retrieve_file_obj")
     def test_encrypted_upload_wal(self, rfo_mock, boto_mock):
         """
@@ -230,7 +230,7 @@ class TestWalUploader(object):
             ExtraArgs={"ServerSideEncryption": "AES256"},
         )
 
-    @mock.patch("barman.cloud.boto3")
+    @mock.patch("barman.cloud_providers.aws_s3.boto3")
     def test_retrieve_normal_file_obj(self, boto_mock, tmpdir):
         """
         Test the retrieve_file_obj method with an uncompressed file
@@ -246,7 +246,7 @@ class TestWalUploader(object):
         # Check content
         assert open_file.read() == "something".encode("utf-8")
 
-    @mock.patch("barman.cloud.boto3")
+    @mock.patch("barman.cloud_providers.aws_s3.boto3")
     def test_retrieve_gzip_file_obj(self, boto_mock, tmpdir):
         """
         Test the retrieve_file_obj method with a gzip file
@@ -262,7 +262,7 @@ class TestWalUploader(object):
         # Decompress on the fly to check content
         assert gzip.GzipFile(fileobj=open_file).read() == "something".encode("utf-8")
 
-    @mock.patch("barman.cloud.boto3")
+    @mock.patch("barman.cloud_providers.aws_s3.boto3")
     def test_retrieve_bz2_file_obj(self, boto_mock, tmpdir):
         """
         Test the retrieve_file_obj method with a bz2 file

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -25,7 +25,7 @@ from boto3.exceptions import Boto3Error
 from botocore.exceptions import ClientError, EndpointConnectionError
 
 from barman.cloud import CloudUploadingError, FileUploadStatistics
-from barman.cloud_providers import S3CloudInterface
+from barman.cloud_providers.aws_s3 import S3CloudInterface
 
 try:
     from queue import Queue
@@ -224,8 +224,10 @@ class TestCloudInterface(object):
 
     @mock.patch("barman.cloud.os.unlink")
     @mock.patch("barman.cloud.open")
-    @mock.patch("barman.cloud_providers.S3CloudInterface._complete_multipart_upload")
-    @mock.patch("barman.cloud_providers.S3CloudInterface._upload_part")
+    @mock.patch(
+        "barman.cloud_providers.aws_s3.S3CloudInterface._complete_multipart_upload"
+    )
+    @mock.patch("barman.cloud_providers.aws_s3.S3CloudInterface._upload_part")
     @mock.patch("datetime.datetime")
     def test_worker_process_execute_job(
         self,

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -24,7 +24,8 @@ import pytest
 from boto3.exceptions import Boto3Error
 from botocore.exceptions import ClientError, EndpointConnectionError
 
-from barman.cloud import S3CloudInterface, CloudUploadingError, FileUploadStatistics
+from barman.cloud import CloudUploadingError, FileUploadStatistics
+from barman.cloud_providers import S3CloudInterface
 
 try:
     from queue import Queue
@@ -33,7 +34,7 @@ except ImportError:
 
 
 class TestCloudInterface(object):
-    @mock.patch("barman.cloud.boto3")
+    @mock.patch("barman.cloud_providers.aws_s3.boto3")
     def test_uploader_minimal(self, boto_mock):
         """
         Minimal build of the CloudInterface class
@@ -223,8 +224,8 @@ class TestCloudInterface(object):
 
     @mock.patch("barman.cloud.os.unlink")
     @mock.patch("barman.cloud.open")
-    @mock.patch("barman.cloud.S3CloudInterface._complete_multipart_upload")
-    @mock.patch("barman.cloud.S3CloudInterface._upload_part")
+    @mock.patch("barman.cloud_providers.S3CloudInterface._complete_multipart_upload")
+    @mock.patch("barman.cloud_providers.S3CloudInterface._upload_part")
     @mock.patch("datetime.datetime")
     def test_worker_process_execute_job(
         self,
@@ -365,7 +366,7 @@ class TestCloudInterface(object):
             }
         )
 
-    @mock.patch("barman.cloud.boto3")
+    @mock.patch("barman.cloud_providers.aws_s3.boto3")
     def test_invalid_uploader_minimal(self, boto_mock):
         """
         Minimal build of the CloudInterface class
@@ -376,7 +377,7 @@ class TestCloudInterface(object):
             S3CloudInterface("/bucket/path/to/dir", encryption=None)
         assert str(excinfo.value) == "Invalid s3 URL address: /bucket/path/to/dir"
 
-    @mock.patch("barman.cloud.boto3")
+    @mock.patch("barman.cloud_providers.aws_s3.boto3")
     def test_connectivity(self, boto_mock):
         """
         test the  test_connectivity method
@@ -388,7 +389,7 @@ class TestCloudInterface(object):
         client_mock = s3_mock.meta.client
         client_mock.head_bucket.assert_called_once_with(Bucket="bucket")
 
-    @mock.patch("barman.cloud.boto3")
+    @mock.patch("barman.cloud_providers.aws_s3.boto3")
     def test_connectivity_failure(self, boto_mock):
         """
         test the test_connectivity method in case of failure
@@ -403,7 +404,7 @@ class TestCloudInterface(object):
         )
         assert cloud_interface.test_connectivity() is False
 
-    @mock.patch("barman.cloud.boto3")
+    @mock.patch("barman.cloud_providers.aws_s3.boto3")
     def test_setup_bucket(self, boto_mock):
         """
         Test if a bucket already exists
@@ -418,7 +419,7 @@ class TestCloudInterface(object):
             Bucket=cloud_interface.bucket_name
         )
 
-    @mock.patch("barman.cloud.boto3")
+    @mock.patch("barman.cloud_providers.aws_s3.boto3")
     def test_setup_bucket_create(self, boto_mock):
         """
         Test auto-creation of a bucket if it not exists

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -34,6 +34,13 @@ except ImportError:
 
 
 class TestCloudInterface(object):
+    """
+    Tests of the asychronous upload infrastructure in CloudInterface.
+    S3CloudInterface is used as we cannot instantiate a CloudInterface directly
+    however we do not verify any backend specific functionality of S3CloudInterface,
+    only the asynchronous infrastructure is tested.
+    """
+
     @mock.patch("barman.cloud_providers.aws_s3.boto3")
     def test_uploader_minimal(self, boto_mock):
         """
@@ -42,12 +49,6 @@ class TestCloudInterface(object):
         cloud_interface = S3CloudInterface(
             url="s3://bucket/path/to/dir", encryption=None
         )
-        assert cloud_interface.bucket_name == "bucket"
-        assert cloud_interface.path == "path/to/dir"
-        boto_mock.Session.assert_called_once_with(profile_name=None)
-        session_mock = boto_mock.Session.return_value
-        session_mock.resource.assert_called_once_with("s3", endpoint_url=None)
-        assert cloud_interface.s3 == session_mock.resource.return_value
 
         # Asynchronous uploading infrastructure is not initialized when
         # a new instance is created
@@ -367,6 +368,25 @@ class TestCloudInterface(object):
                 "parts": ["part", "list", "complete"],
             }
         )
+
+
+class TestS3CloudInterface(object):
+    """
+    Tests which verify backend-specific behaviour of S3CloudInterface.
+    """
+
+    @mock.patch("barman.cloud_providers.aws_s3.boto3")
+    def test_uploader_minimal(self, boto_mock):
+        cloud_interface = S3CloudInterface(
+            url="s3://bucket/path/to/dir", encryption=None
+        )
+
+        assert cloud_interface.bucket_name == "bucket"
+        assert cloud_interface.path == "path/to/dir"
+        boto_mock.Session.assert_called_once_with(profile_name=None)
+        session_mock = boto_mock.Session.return_value
+        session_mock.resource.assert_called_once_with("s3", endpoint_url=None)
+        assert cloud_interface.s3 == session_mock.resource.return_value
 
     @mock.patch("barman.cloud_providers.aws_s3.boto3")
     def test_invalid_uploader_minimal(self, boto_mock):


### PR DESCRIPTION
This is quite a lengthy PR so apologies in advance.

The PR makes the following changes:

1. Refactors barman-cloud so that we can more-easily add additional cloud storage backends.
2. Adds the Azure blob storage cloud provider.
3. Adds unit tests.
4. Attempts to clarify some implementation weirdness due to the differences between S3 and Azure blob storage.

The refactor commits have been split into 6 so that each stage of the process can be viewed individually - this is intended to help the reviewer and the commits can be squashed if we merge this work.

There are working integration tests in a branch of the (currently private) barman-testing repo however they can be improved so are not quite ready for PR yet.

Closes #346 