### PR TITLE
Hold the xlogdb lock while replacing the contents of xlog.db

### DIFF
--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -212,7 +212,7 @@ class TestBackup(object):
             "00000004.history\t42\t43\tNone\n"
         )
         backup_manager.server.xlogdb.return_value.__enter__.return_value = (
-            xlog_db.open()
+            xlog_db.open(mode="r+")
         )
         backup_manager.server.config.basebackups_directory = base_dir.strpath
         backup_manager.server.config.wals_directory = wal_dir.strpath


### PR DESCRIPTION
BackupManager.rebuild_xlogdb() would open the server.xlogdb() as fxlogdb
and then loop over the files on disk, writing an entry for each one into
fxlogdb_new. At the end, it would replace xlog.db with xlog.db.new using
shutil.move.

The problem is that it replaced the old xlog.db after the `with …` block
that held ServerXLOGDBLock, which led to the problem reported in #328:

    The archive-wal process (PID:4011354) was running. (forked from
    barman cron)

    The backup process (PID:4015392) started deleting WAL segments.
    (forked from barman backup)

    This process opened xlog.db (inode: 1613568054) and xlog.db.new
    (inode: 7058292408)

    Then the archive-wal process (PID:4011354) opened xlog.db (inode:
    1613568054) and wrote the line of 000000020002E59C000000BF to (old)
    xlog.db file.

Because we replaced xlog.db with xlog.db.new after releasing the lock,
the sequence of events above could lose valid new entries in xlog.db.

The reporter proposed to solve this problem in PR #329 by just calling
shutil.move() while holding the lock, but I was not comfortable mixing
this call with server.xlogdb()'s flush/fsync operations (which would be
on the original fxlogdb fd).

Although there shouldn't be a problem in practice, because we were not
writing to fxlogdb in the loop, I chose a slightly different fix:

1. Convert fxlogdb_new into an unnamed TemporaryFile in the same
   directory (which we don't need to worry about removing, nor
   about fsync'ing the parent directory afterwards)

2. Accumulate new entries in fxlogdb_new as before (we don't want to do
   this in memory because xlog.db could be large)

3. At the end of the loop, copy the contents of fxlogdb_new into fxlogdb
   directly using shutil.copyfileobj instead of shutil.move; this is the
   same function that .move would use internally, but after reopening
   both source and destination files.

With this arrangement of the code, it doesn't matter that server.xlogdb
would flush/fsync the "old" fd when exiting the context, because that's
the file we will continue to use anyway.

With thanks to KUWAZAWA Takuya for the report and original analysis.

Closes #328

(This is a proposed replacement for PR #329)