### PR TITLE
Allow barman-cloud to run as hook scripts on the barman server

### DIFF
--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -17,15 +17,24 @@
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import os
 import re
 import tempfile
 from contextlib import closing
 from shutil import rmtree
 
 import barman
-from barman.cloud import CloudBackupUploader, configure_logging
+from barman.cloud import (
+    CloudBackupUploaderBarman,
+    CloudBackupUploaderPostgres,
+    configure_logging,
+)
 from barman.cloud_providers import get_cloud_interface
-from barman.exceptions import PostgresConnectionError
+from barman.exceptions import (
+    BarmanException,
+    PostgresConnectionError,
+    UnrecoverableHookScriptError,
+)
 from barman.postgres import PostgreSQLConnection
 from barman.utils import check_positive, check_size, force_str
 
@@ -35,6 +44,23 @@ except ImportError:
     raise SystemExit("Missing required python module: argparse")
 
 _find_space = re.compile(r"[\s]").search
+
+
+def __is_hook_script():
+    """Check the environment and determine if we are running as a hook script"""
+    if "BARMAN_HOOK" in os.environ and "BARMAN_PHASE" in os.environ:
+        if (
+            os.getenv("BARMAN_HOOK") in ("backup_script", "backup_retry_script")
+            and os.getenv("BARMAN_PHASE") == "post"
+        ):
+            return True
+        else:
+            raise BarmanException(
+                "barman-cloud-backup called as unsupported hook script: %s_%s"
+                % (os.getenv("BARMAN_PHASE"), os.getenv("BARMAN_HOOK"))
+            )
+    else:
+        return False
 
 
 def quote_conninfo(value):
@@ -79,54 +105,81 @@ def main(args=None):
         # Create any temporary file in the `tempdir` subdirectory
         tempfile.tempdir = tempdir
 
-        conninfo = build_conninfo(config)
-        postgres = PostgreSQLConnection(
-            conninfo,
-            config.immediate_checkpoint,
-            application_name="barman_cloud_backup",
+        cloud_interface = get_cloud_interface(
+            url=config.destination_url,
+            encryption=config.encryption,
+            jobs=config.jobs,
+            profile_name=config.profile,
+            endpoint_url=config.endpoint_url,
+            cloud_provider=config.cloud_provider,
         )
-        try:
-            postgres.connect()
-        except PostgresConnectionError as exc:
-            logging.error("Cannot connect to postgres: %s", force_str(exc))
-            logging.debug("Exception details:", exc_info=exc)
+
+        if not cloud_interface.test_connectivity():
             raise SystemExit(1)
+        # If test is requested, just exit after connectivity test
+        elif config.test:
+            raise SystemExit(0)
 
-        with closing(postgres):
-            cloud_interface = get_cloud_interface(
-                url=config.destination_url,
-                encryption=config.encryption,
-                jobs=config.jobs,
-                profile_name=config.profile,
-                endpoint_url=config.endpoint_url,
-                cloud_provider=config.cloud_provider,
-            )
+        with closing(cloud_interface):
 
-            if not cloud_interface.test_connectivity():
-                raise SystemExit(1)
-            # If test is requested, just exit after connectivity test
-            elif config.test:
-                raise SystemExit(0)
+            # TODO: Should the setup be optional?
+            cloud_interface.setup_bucket()
 
-            with closing(cloud_interface):
-
-                # TODO: Should the setup be optional?
-                cloud_interface.setup_bucket()
-
-                uploader = CloudBackupUploader(
-                    server_name=config.server_name,
-                    compression=config.compression,
-                    postgres=postgres,
-                    max_archive_size=config.max_archive_size,
-                    cloud_interface=cloud_interface,
+            # Perform the backup
+            uploader_kwargs = {
+                "server_name": config.server_name,
+                "compression": config.compression,
+                "max_archive_size": config.max_archive_size,
+                "cloud_interface": cloud_interface,
+            }
+            if __is_hook_script():
+                if "BARMAN_BACKUP_DIR" not in os.environ:
+                    raise BarmanException(
+                        "BARMAN_BACKUP_DIR environment variable not set"
+                    )
+                if "BARMAN_BACKUP_ID" not in os.environ:
+                    raise BarmanException(
+                        "BARMAN_BACKUP_ID environment variable not set"
+                    )
+                if os.getenv("BARMAN_STATUS") != "DONE":
+                    raise UnrecoverableHookScriptError(
+                        "backup in '%s' has status '%s' (status should be: DONE)"
+                        % (os.getenv("BARMAN_BACKUP_DIR"), os.getenv("BARMAN_STATUS"))
+                    )
+                uploader = CloudBackupUploaderBarman(
+                    backup_dir=os.getenv("BARMAN_BACKUP_DIR"),
+                    backup_id=os.getenv("BARMAN_BACKUP_ID"),
+                    **uploader_kwargs
                 )
-
-                # Perform the backup
                 uploader.backup()
+            else:
+                conninfo = build_conninfo(config)
+                postgres = PostgreSQLConnection(
+                    conninfo,
+                    config.immediate_checkpoint,
+                    application_name="barman_cloud_backup",
+                )
+                try:
+                    postgres.connect()
+                except PostgresConnectionError as exc:
+                    logging.error("Cannot connect to postgres: %s", force_str(exc))
+                    logging.debug("Exception details:", exc_info=exc)
+                    raise SystemExit(1)
+
+                with closing(postgres):
+                    uploader = CloudBackupUploaderPostgres(
+                        postgres=postgres, **uploader_kwargs
+                    )
+                    uploader.backup()
+
     except KeyboardInterrupt as exc:
         logging.error("Barman cloud backup was interrupted by the user")
         logging.debug("Exception details:", exc_info=exc)
         raise SystemExit(1)
+    except UnrecoverableHookScriptError as exc:
+        logging.error("Barman cloud backup exception: %s", force_str(exc))
+        logging.debug("Exception details:", exc_info=exc)
+        raise SystemExit(63)
     except Exception as exc:
         logging.error("Barman cloud backup exception: %s", force_str(exc))
         logging.debug("Exception details:", exc_info=exc)

--- a/barman/exceptions.py
+++ b/barman/exceptions.py
@@ -361,3 +361,9 @@ class RecoveryInvalidTargetException(RecoveryException):
     """
     Exception for a wrong recovery target
     """
+
+
+class UnrecoverableHookScriptError(BarmanException):
+    """
+    Exception for hook script errors which mean the script should not be retried.
+    """

--- a/tests/test_barman_cloud_backup.py
+++ b/tests/test_barman_cloud_backup.py
@@ -1,0 +1,278 @@
+# -*- coding: utf-8 -*-
+# © Copyright EnterpriseDB UK Limited 2013-2021
+#
+# Client Utilities for Barman, Backup and Recovery Manager for PostgreSQL
+#
+# Barman is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Barman is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Barman.  If not, see <http://www.gnu.org/licenses/>.
+
+import mock
+import os
+import pytest
+
+from barman.clients import cloud_backup
+
+EXAMPLE_BACKUP_DIR = "/path/to/backup"
+EXAMPLE_BACKUP_ID = "20210707T132804"
+
+
+@mock.patch("barman.clients.cloud_backup.tempfile")
+@mock.patch("barman.clients.cloud_backup.rmtree")
+class TestCloudBackupHookScript(object):
+    """
+    Test that we get the intended behaviour when called as a hook script
+    """
+
+    @mock.patch.dict(
+        os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
+    )
+    @mock.patch("barman.clients.cloud_backup.PostgreSQLConnection")
+    @mock.patch("barman.clients.cloud_backup.get_cloud_interface")
+    @mock.patch("barman.clients.cloud_backup.CloudBackupUploaderPostgres")
+    def test_uses_postgres_backup_uploader_when_not_running_as_hook(
+        self,
+        uploader_mock,
+        cloud_interface_mock,
+        postgres_connection,
+        rmtree_mock,
+        tempfile_mock,
+    ):
+        uploader = uploader_mock.return_value
+        cloud_backup.main(["cloud_storage_url", "test_server"])
+        postgres_connection.assert_called_once()
+        cloud_interface_mock.assert_called_once()
+        uploader_mock.assert_called_once_with(
+            server_name="test_server",
+            compression=None,
+            postgres=postgres_connection.return_value,
+            max_archive_size=107374182400,
+            cloud_interface=cloud_interface_mock.return_value,
+        )
+        uploader.backup.assert_called_once()
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            "AZURE_STORAGE_CONNECTION_STRING": "connection_string",
+            "BARMAN_HOOK": "backup_script",
+            "BARMAN_PHASE": "post",
+            "BARMAN_BACKUP_DIR": EXAMPLE_BACKUP_DIR,
+            "BARMAN_BACKUP_ID": EXAMPLE_BACKUP_ID,
+            "BARMAN_STATUS": "DONE",
+        },
+    )
+    @mock.patch("barman.clients.cloud_backup.get_cloud_interface")
+    @mock.patch("barman.clients.cloud_backup.CloudBackupUploaderBarman")
+    def test_uses_barman_backup_uploader_when_running_as_hook(
+        self,
+        uploader_mock,
+        cloud_interface_mock,
+        rmtree_mock,
+        tempfile_mock,
+    ):
+        uploader = uploader_mock.return_value
+        cloud_backup.main(["cloud_storage_url", "test_server"])
+        cloud_interface_mock.assert_called_once()
+        uploader_mock.assert_called_once_with(
+            server_name="test_server",
+            compression=None,
+            max_archive_size=107374182400,
+            cloud_interface=cloud_interface_mock.return_value,
+            backup_dir=EXAMPLE_BACKUP_DIR,
+            backup_id=EXAMPLE_BACKUP_ID,
+        )
+        uploader.backup.assert_called_once()
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            "AZURE_STORAGE_CONNECTION_STRING": "connection_string",
+            "BARMAN_HOOK": "backup_retry_script",
+            "BARMAN_PHASE": "post",
+            "BARMAN_BACKUP_DIR": EXAMPLE_BACKUP_DIR,
+            "BARMAN_BACKUP_ID": EXAMPLE_BACKUP_ID,
+            "BARMAN_STATUS": "DONE",
+        },
+    )
+    @mock.patch("barman.clients.cloud_backup.get_cloud_interface")
+    @mock.patch("barman.clients.cloud_backup.CloudBackupUploaderBarman")
+    def test_uses_barman_backup_uploader_when_running_as_retry_hook(
+        self,
+        uploader_mock,
+        cloud_interface_mock,
+        rmtree_mock,
+        tempfile_mock,
+    ):
+        uploader = uploader_mock.return_value
+        cloud_backup.main(["cloud_storage_url", "test_server"])
+        cloud_interface_mock.assert_called_once()
+        uploader_mock.assert_called_once_with(
+            server_name="test_server",
+            compression=None,
+            max_archive_size=107374182400,
+            cloud_interface=cloud_interface_mock.return_value,
+            backup_dir=EXAMPLE_BACKUP_DIR,
+            backup_id=EXAMPLE_BACKUP_ID,
+        )
+        uploader.backup.assert_called_once()
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            "AZURE_STORAGE_CONNECTION_STRING": "connection_string",
+            "BARMAN_HOOK": "backup_script",
+            "BARMAN_PHASE": "post",
+            "BARMAN_BACKUP_ID": EXAMPLE_BACKUP_ID,
+            "BARMAN_STATUS": "DONE",
+        },
+    )
+    @mock.patch("barman.clients.cloud_backup.get_cloud_interface")
+    @mock.patch("barman.clients.cloud_backup.CloudBackupUploaderBarman")
+    def test_error_if_backup_dir_not_provided(
+        self,
+        uploader_mock,
+        cloud_interface_mock,
+        rmtree_mock,
+        tempfile_mock,
+        caplog,
+    ):
+        with pytest.raises(SystemExit):
+            cloud_backup.main(["cloud_storage_url", "test_server"])
+
+        assert "BARMAN_BACKUP_DIR environment variable not set" in caplog.messages[0]
+        cloud_interface_mock.assert_called_once()
+        uploader_mock.assert_not_called()
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            "AZURE_STORAGE_CONNECTION_STRING": "connection_string",
+            "BARMAN_HOOK": "backup_script",
+            "BARMAN_PHASE": "post",
+            "BARMAN_BACKUP_DIR": EXAMPLE_BACKUP_DIR,
+            "BARMAN_STATUS": "DONE",
+        },
+    )
+    @mock.patch("barman.clients.cloud_backup.get_cloud_interface")
+    @mock.patch("barman.clients.cloud_backup.CloudBackupUploaderBarman")
+    def test_error_if_backup_id_not_provided(
+        self,
+        uploader_mock,
+        cloud_interface_mock,
+        rmtree_mock,
+        tempfile_mock,
+        caplog,
+    ):
+        with pytest.raises(SystemExit):
+            cloud_backup.main(["cloud_storage_url", "test_server"])
+
+        assert "BARMAN_BACKUP_ID environment variable not set" in caplog.messages[0]
+        cloud_interface_mock.assert_called_once()
+        uploader_mock.assert_not_called()
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            "AZURE_STORAGE_CONNECTION_STRING": "connection_string",
+            "BARMAN_HOOK": "backup_script",
+            "BARMAN_PHASE": "pre",
+            "BARMAN_BACKUP_DIR": EXAMPLE_BACKUP_DIR,
+            "BARMAN_BACKUP_ID": EXAMPLE_BACKUP_ID,
+            "BARMAN_STATUS": "DONE",
+        },
+    )
+    @mock.patch("barman.clients.cloud_backup.get_cloud_interface")
+    @mock.patch("barman.clients.cloud_backup.CloudBackupUploaderBarman")
+    def test_error_if_running_as_unsupported_phase(
+        self,
+        uploader_mock,
+        cloud_interface_mock,
+        rmtree_mock,
+        tempfile_mock,
+        caplog,
+    ):
+        with pytest.raises(SystemExit):
+            cloud_backup.main(["cloud_storage_url", "test_server"])
+
+        assert (
+            "barman-cloud-backup called as unsupported hook script"
+            in caplog.messages[0]
+        )
+        cloud_interface_mock.assert_called_once()
+        uploader_mock.assert_not_called()
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            "AZURE_STORAGE_CONNECTION_STRING": "connection_string",
+            "BARMAN_HOOK": "archive_script",
+            "BARMAN_PHASE": "post",
+            "BARMAN_BACKUP_DIR": EXAMPLE_BACKUP_DIR,
+            "BARMAN_BACKUP_ID": EXAMPLE_BACKUP_ID,
+            "BARMAN_STATUS": "DONE",
+        },
+    )
+    @mock.patch("barman.clients.cloud_backup.get_cloud_interface")
+    @mock.patch("barman.clients.cloud_backup.CloudBackupUploaderBarman")
+    def test_error_if_running_as_unsupported_phase(
+        self,
+        uploader_mock,
+        cloud_interface_mock,
+        rmtree_mock,
+        tempfile_mock,
+        caplog,
+    ):
+        with pytest.raises(SystemExit):
+            cloud_backup.main(["cloud_storage_url", "test_server"])
+
+        assert (
+            "barman-cloud-backup called as unsupported hook script"
+            in caplog.messages[0]
+        )
+        cloud_interface_mock.assert_called_once()
+        uploader_mock.assert_not_called()
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            "AZURE_STORAGE_CONNECTION_STRING": "connection_string",
+            "BARMAN_HOOK": "backup_script",
+            "BARMAN_PHASE": "post",
+            "BARMAN_BACKUP_DIR": EXAMPLE_BACKUP_DIR,
+            "BARMAN_BACKUP_ID": EXAMPLE_BACKUP_ID,
+            "BARMAN_STATUS": "WAITING_FOR_WALS",
+        },
+    )
+    @mock.patch("barman.clients.cloud_backup.get_cloud_interface")
+    @mock.patch("barman.clients.cloud_backup.CloudBackupUploaderBarman")
+    def test_error_if_backup_status_is_not_DONE(
+        self,
+        uploader_mock,
+        cloud_interface_mock,
+        rmtree_mock,
+        tempfile_mock,
+        caplog,
+    ):
+        with pytest.raises(SystemExit) as exc:
+            cloud_backup.main(["cloud_storage_url", "test_server"])
+
+        # Barman hook scripts should exit with status 63 if the failure is not
+        # recoverable and barman should not continue.
+        assert exc.value.code == 63
+        expected_error = "backup in '%s' has status '%s' (status should be: DONE)" % (
+            EXAMPLE_BACKUP_DIR,
+            "WAITING_FOR_WALS",
+        )
+        assert expected_error in caplog.messages[0]
+        cloud_interface_mock.assert_called_once()
+        uploader_mock.assert_not_called()

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -622,14 +622,6 @@ class TestAzureCloudInterface(object):
             AzureCloudInterface(url=url)
         assert str(exc.value) == "azure blob storage URL %s is malformed" % url
 
-    # test_connectivity
-
-    # test_connectivity_failure
-
-    # test_setup_bucket
-
-    # test_setup_bucket_create
-
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )


### PR DESCRIPTION
Updates barman-cloud-backup and barman-cloud-wal-archive so that they can run as post backup and post archive scripts respectively.

The implementation for barman-cloud-wal-archive is reasonably straightforward as this is a matter of reading the wal path from the environment rather than the command line.

The implementation for barman-cloud-backup is a little more involved as the original CloudBackupUploader class was written to run against a live PostgreSQL server. Rather than try and have a single backup upload method which handles both cases, the core logic for copying the backup to cloud storage is moved into a superclass and then any specific co-ordination is carried out in a different CloudBackupUploader subclass depending on whether we are running against a live PostgreSQL server or as a hook script on the barman server.

There are a couple of potential gotchas which are described in the commit messages and should also be included when we update the docs.

Relates to issue #348 