### PR TITLE
Recreate pg_wal if required in barman-cloud-restore

### DIFF
--- a/barman/clients/cloud_restore.py
+++ b/barman/clients/cloud_restore.py
@@ -170,8 +170,8 @@ class CloudBackupDownloader(object):
         """
         Download a backup from cloud storage
 
-        :param str wal_name: Name of the WAL file
-        :param str wal_dest: Full path of the destination WAL file
+        :param str backup_id: The backup id to restore
+        :param str destination_dir: Path to the destination directory
         """
 
         backup_info = self.catalog.get_backup_info(backup_id)
@@ -226,6 +226,14 @@ class CloudBackupDownloader(object):
                 else "no compression",
             )
             self.cloud_interface.extract_tar(file_info.path, target_dir)
+
+        # If we did not restore the pg_wal directory from one of the uploaded
+        # backup files, we must recreate it here. (If pg_wal was originally a
+        # symlink, it would not have been uploaded.)
+
+        wal_path = os.path.join(destination_dir, backup_info.wal_directory())
+        if not os.path.exists(wal_path):
+            os.mkdir(wal_path)
 
 
 if __name__ == "__main__":

--- a/barman/infofile.py
+++ b/barman/infofile.py
@@ -584,6 +584,13 @@ class BackupInfo(FieldListFile):
         else:
             return str(major)
 
+    def wal_directory(self):
+        """
+        Returns "pg_wal" (v10 and above) or "pg_xlog" (v9.6 and below) based on
+        the Postgres version represented by this backup
+        """
+        return "pg_wal" if self.version >= 100000 else "pg_xlog"
+
 
 class LocalBackupInfo(BackupInfo):
     __slots__ = "server", "config", "backup_manager"

--- a/doc/barman-cloud-restore.1
+++ b/doc/barman-cloud-restore.1
@@ -44,6 +44,10 @@ show program\[cq]s version number and exit
 -t, \[en]test
 test connectivity to the cloud destination and exit
 .TP
+\[en]tablespace NAME:LOCATION
+extract the named tablespace to the given directory instead of its
+original location (you may repeat the option for multiple tablespaces)
+.TP
 -P, \[en]profile
 profile name (e.g.\ INI section in AWS credentials file)
 .TP

--- a/doc/barman-cloud-restore.1.md
+++ b/doc/barman-cloud-restore.1.md
@@ -49,6 +49,10 @@ RECOVERY_DIR
 -t, --test
 : test connectivity to the cloud destination and exit
 
+--tablespace NAME:LOCATION
+: extract the named tablespace to the given directory instead of its
+original location (you may repeat the option for multiple tablespaces)
+
 -P, --profile
 : profile name (e.g. INI section in AWS credentials file)
 

--- a/tests/test_infofile.py
+++ b/tests/test_infofile.py
@@ -594,6 +594,8 @@ class TestBackupInfo(object):
         b_info = LocalBackupInfo(server, info_file=infofile.strpath)
         # BASE_BACKUP_INFO has version 90400 so expect 9.4
         assert b_info.pg_major_version() == "9.4"
+        assert b_info.wal_directory() == "pg_xlog"
         # Set backup_info.version to 100600 so expect 10
         b_info.version = 100600
         assert b_info.pg_major_version() == "10"
+        assert b_info.wal_directory() == "pg_wal"


### PR DESCRIPTION
If you run barman-cloud-backup on a data directory where pg_wal is a
symlink, it doesn't include pg_wal in the uploaded tar files, and the
pg_wal directory will not be created if you restore the backup.

We fix this by creating pg_wal in the destination directory if it does
not exist at the end of the backup.

Closes #327