### PR TITLE
Support encryption scopes in Azure

### DIFF
--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -114,15 +114,7 @@ def main(args=None):
         # Create any temporary file in the `tempdir` subdirectory
         tempfile.tempdir = tempdir
 
-        cloud_interface = get_cloud_interface(
-            url=config.destination_url,
-            encryption=config.encryption,
-            jobs=config.jobs,
-            profile_name=config.profile,
-            endpoint_url=config.endpoint_url,
-            cloud_provider=config.cloud_provider,
-            encryption_scope=config.encryption_scope,
-        )
+        cloud_interface = get_cloud_interface(config)
 
         if not cloud_interface.test_connectivity():
             raise SystemExit(1)

--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -121,6 +121,7 @@ def main(args=None):
             profile_name=config.profile,
             endpoint_url=config.endpoint_url,
             cloud_provider=config.cloud_provider,
+            encryption_scope=config.encryption_scope,
         )
 
         if not cloud_interface.test_connectivity():
@@ -329,6 +330,14 @@ def parse_arguments(args=None):
         "--dbname",
         help="Database name or conninfo string for Postgres connection (default: postgres)",
         default="postgres",
+    )
+    azure_arguments = parser.add_argument_group(
+        "Extra options for the azure-blob-storage cloud provider"
+    )
+    azure_arguments.add_argument(
+        "--encryption-scope",
+        help="The name of an encryption scope defined in the Azure Blob Storage "
+        "service which is to be used to encrypt the data in Azure",
     )
     return parser.parse_args(args=args)
 

--- a/barman/clients/cloud_backup_list.py
+++ b/barman/clients/cloud_backup_list.py
@@ -43,13 +43,7 @@ def main(args=None):
     configure_logging(config)
 
     try:
-        cloud_interface = get_cloud_interface(
-            url=config.source_url,
-            encryption=config.encryption,
-            profile_name=config.profile,
-            endpoint_url=config.endpoint_url,
-            cloud_provider=config.cloud_provider,
-        )
+        cloud_interface = get_cloud_interface(config)
 
         with closing(cloud_interface):
             catalog = CloudBackupCatalog(

--- a/barman/clients/cloud_restore.py
+++ b/barman/clients/cloud_restore.py
@@ -48,13 +48,7 @@ def main(args=None):
         raise SystemExit(1)
 
     try:
-        cloud_interface = get_cloud_interface(
-            url=config.source_url,
-            encryption=config.encryption,
-            profile_name=config.profile,
-            endpoint_url=config.endpoint_url,
-            cloud_provider=config.cloud_provider,
-        )
+        cloud_interface = get_cloud_interface(config)
 
         with closing(cloud_interface):
             downloader = CloudBackupDownloader(

--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -86,6 +86,7 @@ def main(args=None):
             profile_name=config.profile,
             endpoint_url=config.endpoint_url,
             cloud_provider=config.cloud_provider,
+            encryption_scope=config.encryption_scope,
         )
 
         with closing(cloud_interface):
@@ -206,6 +207,14 @@ def parse_arguments(args=None):
         "Allowed values: 'AES256', 'aws:kms'",
         choices=["AES256", "aws:kms"],
         metavar="ENCRYPTION",
+    )
+    azure_arguments = parser.add_argument_group(
+        "Extra options for the azure-blob-storage cloud provider"
+    )
+    azure_arguments.add_argument(
+        "--encryption-scope",
+        help="The name of an encryption scope defined in the Azure Blob Storage "
+        "service which is to be used to encrypt the data in Azure",
     )
     return parser.parse_args(args=args)
 

--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -80,14 +80,7 @@ def main(args=None):
         raise SystemExit(1)
 
     try:
-        cloud_interface = get_cloud_interface(
-            url=config.destination_url,
-            encryption=config.encryption,
-            profile_name=config.profile,
-            endpoint_url=config.endpoint_url,
-            cloud_provider=config.cloud_provider,
-            encryption_scope=config.encryption_scope,
-        )
+        cloud_interface = get_cloud_interface(config)
 
         with closing(cloud_interface):
             uploader = CloudWalUploader(

--- a/barman/clients/cloud_walrestore.py
+++ b/barman/clients/cloud_walrestore.py
@@ -48,13 +48,7 @@ def main(args=None):
         raise SystemExit(1)
 
     try:
-        cloud_interface = get_cloud_interface(
-            url=config.source_url,
-            encryption=config.encryption,
-            profile_name=config.profile,
-            endpoint_url=config.endpoint_url,
-            cloud_provider=config.cloud_provider,
-        )
+        cloud_interface = get_cloud_interface(config)
 
         with closing(cloud_interface):
             downloader = CloudWalDownloader(

--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -17,18 +17,34 @@
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>
 
 
-def get_cloud_interface(cloud_provider, url, **kwargs):
+def get_cloud_interface(config):
     """
     Create a CloudInterface for the specified cloud_provider
 
     :returns: A CloudInterface for the specified cloud_provider
     :rtype: CloudInterface
     """
-    if cloud_provider == "aws-s3":
+    cloud_interface_kwargs = {
+        "url": config.source_url if "source_url" in config else config.destination_url
+    }
+    if "jobs" in config:
+        cloud_interface_kwargs["jobs"] = config.jobs
+
+    if config.cloud_provider == "aws-s3":
         from barman.cloud_providers.aws_s3 import S3CloudInterface
 
-        return S3CloudInterface(url, **kwargs)
-    elif cloud_provider == "azure-blob-storage":
+        cloud_interface_kwargs.update(
+            {
+                "encryption": config.encryption,
+                "profile_name": config.profile,
+                "endpoint_url": config.endpoint_url,
+            }
+        )
+        return S3CloudInterface(**cloud_interface_kwargs)
+
+    elif config.cloud_provider == "azure-blob-storage":
         from barman.cloud_providers.azure_blob_storage import AzureCloudInterface
 
-        return AzureCloudInterface(url, **kwargs)
+        if "encryption_scope" in config:
+            cloud_interface_kwargs["encryption_scope"] = config.encryption_scope
+        return AzureCloudInterface(**cloud_interface_kwargs)

--- a/barman/cloud_providers/azure_blob_storage.py
+++ b/barman/cloud_providers/azure_blob_storage.py
@@ -98,7 +98,7 @@ class AzureCloudInterface(CloudInterface):
     # MAX_ARCHIVE_SIZE - so we set a maximum of 1TB per file
     MAX_ARCHIVE_SIZE = 1 << 40
 
-    def __init__(self, url, jobs=2, encryption_scope=None, **kwargs):
+    def __init__(self, url, jobs=2, encryption_scope=None):
         """
         Create a new Azure Blob Storage interface given the supplied acccount url
 

--- a/barman/cloud_providers/azure_blob_storage.py
+++ b/barman/cloud_providers/azure_blob_storage.py
@@ -98,7 +98,7 @@ class AzureCloudInterface(CloudInterface):
     # MAX_ARCHIVE_SIZE - so we set a maximum of 1TB per file
     MAX_ARCHIVE_SIZE = 1 << 40
 
-    def __init__(self, url, jobs=2, **kwargs):
+    def __init__(self, url, jobs=2, encryption_scope=None, **kwargs):
         """
         Create a new Azure Blob Storage interface given the supplied acccount url
 
@@ -110,6 +110,7 @@ class AzureCloudInterface(CloudInterface):
             url=url,
             jobs=jobs,
         )
+        self.encryption_scope = encryption_scope
 
         parsed_url = urlparse(url)
         if parsed_url.netloc.endswith(AZURE_BLOB_STORAGE_DOMAIN):
@@ -175,6 +176,13 @@ class AzureCloudInterface(CloudInterface):
                 container_name=self.bucket_name,
             )
         self.container_client = client.get_container_client(self.bucket_name)
+
+    @property
+    def _extra_upload_args(self):
+        optional_args = {}
+        if self.encryption_scope:
+            optional_args["encryption_scope"] = self.encryption_scope
+        return optional_args
 
     def test_connectivity(self):
         """
@@ -284,9 +292,7 @@ class AzureCloudInterface(CloudInterface):
         :param str key: The key to identify the uploaded object
         """
         self.container_client.upload_blob(
-            name=key,
-            data=fileobj,
-            overwrite=True,
+            name=key, data=fileobj, overwrite=True, **self._extra_upload_args
         )
 
     def create_multipart_upload(self, key):
@@ -319,7 +325,7 @@ class AzureCloudInterface(CloudInterface):
         # places.
         block_id = str(part_number).zfill(5)
         blob_client = self.container_client.get_blob_client(key)
-        blob_client.stage_block(block_id, body)
+        blob_client.stage_block(block_id, body, **self._extra_upload_args)
         return {"PartNumber": block_id}
 
     def _complete_multipart_upload(self, upload_metadata, key, parts):
@@ -333,7 +339,7 @@ class AzureCloudInterface(CloudInterface):
         """
         blob_client = self.container_client.get_blob_client(key)
         block_list = [part["PartNumber"] for part in parts]
-        blob_client.commit_block_list(block_list)
+        blob_client.commit_block_list(block_list, **self._extra_upload_args)
 
     def _abort_multipart_upload(self, upload_metadata, key):
         """
@@ -353,5 +359,5 @@ class AzureCloudInterface(CloudInterface):
         # We therefore create an empty blob (thereby discarding all uploaded
         # blocks for that blob) and then delete it.
         blob_client = self.container_client.get_blob_client(key)
-        blob_client.commit_block_list([])
+        blob_client.commit_block_list([], **self._extra_upload_args)
         blob_client.delete_blob()


### PR DESCRIPTION
Adds support for encryption scopes when using barman-cloud with `--cloud-provider=azure-blob-service`.

Docs to follow in a separate PR which will add all the docs for the barman-cloud Azure support.