### PR TITLE
Treat encryption as optional config parameter

### DIFF
--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -35,11 +35,12 @@ def get_cloud_interface(config):
 
         cloud_interface_kwargs.update(
             {
-                "encryption": config.encryption,
                 "profile_name": config.profile,
                 "endpoint_url": config.endpoint_url,
             }
         )
+        if "encryption" in config:
+            cloud_interface_kwargs["encryption"] = config.encryption
         return S3CloudInterface(**cloud_interface_kwargs)
 
     elif config.cloud_provider == "azure-blob-storage":

--- a/barman/cloud_providers/aws_s3.py
+++ b/barman/cloud_providers/aws_s3.py
@@ -66,7 +66,9 @@ class S3CloudInterface(CloudInterface):
     # MAX_ARCHIVE_SIZE - so we set a maximum of 1TB per file
     MAX_ARCHIVE_SIZE = 1 << 40
 
-    def __init__(self, url, encryption, jobs=2, profile_name=None, endpoint_url=None):
+    def __init__(
+        self, url, encryption=None, jobs=2, profile_name=None, endpoint_url=None
+    ):
         """
         Create a new S3 interface given the S3 destination url and the profile
         name


### PR DESCRIPTION
Tests for the encryption parameter before passing it to
S3CloudInterface and makes it optional in the S3CloudInterface
constructor.

This is necessary because of the removal of the encryption
parameter from barman-cloud-restore, barman-cloud-wal-restore
and barman-cloud-backup-list in commit:

    6f47759382063e7c452350d46f8ae4e8cf938495