### PR TITLE
Fix pg major version in barman-cloud-backup hook script

### DIFF
--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -1214,7 +1214,7 @@ class CloudBackupUploaderBarman(CloudBackupUploader):
                 controller,
                 backup_info,
                 os.path.join(self.backup_dir, "data"),
-                int(backup_info.version / 10000),
+                backup_info.pg_major_version(),
             )
 
             # Closing the controller will finalize all the running uploads

--- a/barman/infofile.py
+++ b/barman/infofile.py
@@ -571,6 +571,19 @@ class BackupInfo(FieldListFile):
         # Instantiate a BackupInfo object using the converted fields
         return cls(server, **data)
 
+    def pg_major_version(self):
+        """
+        Returns the major version of the PostgreSQL instance from which the
+        backup was made taking into account the change in versioning scheme
+        between PostgreSQL < 10.0 and PostgreSQL >= 10.0.
+        """
+        major = int(self.version / 10000)
+        if major < 10:
+            minor = int(self.version / 100 % 100)
+            return "%d.%d" % (major, minor)
+        else:
+            return str(major)
+
 
 class LocalBackupInfo(BackupInfo):
     __slots__ = "server", "config", "backup_manager"

--- a/tests/test_infofile.py
+++ b/tests/test_infofile.py
@@ -583,3 +583,17 @@ class TestBackupInfo(object):
         # The following constructor will raise a RuntimeError if we are
         # needing a PostgreSQL connection
         LocalBackupInfo(server, backup_id="fake_backup_id")
+
+    def test_pg_version(self, tmpdir):
+        """
+        Test handling of postgres version in BackupInfo object
+        """
+        infofile = tmpdir.join("backup.info")
+        infofile.write(BASE_BACKUP_INFO)
+        server = build_mocked_server()
+        b_info = LocalBackupInfo(server, info_file=infofile.strpath)
+        # BASE_BACKUP_INFO has version 90400 so expect 9.4
+        assert b_info.pg_major_version() == "9.4"
+        # Set backup_info.version to 100600 so expect 10
+        b_info.version = 100600
+        assert b_info.pg_major_version() == "10"


### PR DESCRIPTION
Adds a method named pg_major_version to BackupInfo which returns
the major version of the PostgreSQL instance from which a backup
was taken.

We deliberately avoid using a property here because we do not
want pg_major_version to be included in the backup.info fields.
It is just a convenience function.

This replaces the in-line use of `int(self.version / 10000)` in
CloudBackupUploaderBarman which only produced the correct major
version for PostgreSQL >= 10.0.

This fixes an issue where barman-cloud-backup would not copy
tablespaces when running as a hook script against backups of
PostgreSQL < 10.0..