### PR TITLE
Avoid pickling boto3 client in S3CloudInterface

### DIFF
--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -573,12 +573,17 @@ class CloudInterface(with_metaclass(ABCMeta)):
         self.result_queue = multiprocessing.Queue()
         self.errors_queue = multiprocessing.Queue()
         self.done_queue = multiprocessing.Queue()
+        # Delay assigning the worker_processes list to the object until we have
+        # finished spawning the workers so they do not get pickled by multiprocessing
+        # (pickling the worker process references will fail in Python >= 3.8)
+        worker_processes = []
         for process_number in range(self.worker_processes_count):
             process = multiprocessing.Process(
                 target=self._worker_process_main, args=(process_number,)
             )
             process.start()
-            self.worker_processes.append(process)
+            worker_processes.append(process)
+        self.worker_processes = worker_processes
 
     def _retrieve_results(self):
         """

--- a/barman/cloud_providers/aws_s3.py
+++ b/barman/cloud_providers/aws_s3.py
@@ -66,6 +66,19 @@ class S3CloudInterface(CloudInterface):
     # MAX_ARCHIVE_SIZE - so we set a maximum of 1TB per file
     MAX_ARCHIVE_SIZE = 1 << 40
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Remove boto3 client reference from the state as it cannot be pickled
+        # in Python >= 3.8 and multiprocessing will pickle the object when the
+        # worker processes are created.
+        # The worker processes create their own boto3 sessions so do not need
+        # the boto3 session from the parent process.
+        del state["s3"]
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
     def __init__(
         self, url, encryption=None, jobs=2, profile_name=None, endpoint_url=None
     ):


### PR DESCRIPTION
Excludes the boto3 client from the S3CloudInterface state so that
it is not pickled by multiprocessing.

This fixes barman-cloud-backup with Python >= 3.8. Previously this
would fail with the following error:

    ERROR: Backup failed uploading data (Can't pickle <class 'boto3.resources.factory.s3.ServiceResource'>: attribute lookup s3.ServiceResource on boto3.resources.factory failed)

This is because boto3 cannot be pickled using the default pickle
protocol in Python >= 3.8. See the following boto3 issue:

    https://github.com/boto/boto3/issues/678

The workaround of forcing pickle to use an older version of the
pickle protocol is not available because it is multiprocessing
which invokes pickle and it does not allow us to specify the
protocol version.

We therefore exclude the boto3 client from the pickle operation by
implementing custom `__getstate__` and `__setstate__` methods as
documented here:

    https://docs.python.org/3/library/pickle.html#handling-stateful-objects

This works because the worker processes create their own boto3
session anyway due to race conditions around re-using the boto3
session from the parent process.

It is also necessary to defer the assignment of the
`worker_processes` list until after all worker processes have been
spawned as the references to those worker processes also cannot
be pickled with the default pickle protocol in Python >= 3.8. As
with the boto3 client, the `worker_processes` list was not being
used by the worker processes anyway.