### PR TITLE
Stop backup.info errors from breaking barman-cloud-backup-list

### DIFF
--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -1496,7 +1496,13 @@ class CloudBackupCatalog(object):
                 if backup_dir[-1] != "/":
                     continue
                 backup_id = os.path.basename(backup_dir.rstrip("/"))
-                backup_info = self.get_backup_info(backup_id)
+                try:
+                    backup_info = self.get_backup_info(backup_id)
+                except Exception as exc:
+                    logging.warning(
+                        "Unable to open backup.info file for %s: %s" % (backup_id, exc)
+                    )
+                    continue
 
                 if backup_info:
                     backup_list[backup_id] = backup_info


### PR DESCRIPTION
Catches exceptions encountered when reading backup.info files
during backup list operations. A warning is logged and we continue
iterating through backup files.

This fixes a problem where a single unreadable backup.info file
would break barman-cloud-backup-list entirely, preventing users
from finding any backups in cloud storage. The specific example
reported was when a backup.info file has the AWS S3 Glacier
storage class however there are other reasons why a backup.info
file might not be readable. In these scenarios we would still
want to list the backup.info files that were readable, so we
therefore catch `Exception`s rather than anything more specific.

Closes #332