### PR TITLE
Don't try to store a top-level PGDATA symlink in data.tar

### DIFF
--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -1128,7 +1128,11 @@ class CloudBackupUploader(with_metaclass(ABCMeta)):
                     include=["/PG_%s_*" % server_major_version],
                 )
 
-        # Copy PGDATA directory
+        # Copy PGDATA directory (or if that is itself a symlink, just follow it
+        # and copy whatever it points to; we won't store the symlink in the tar
+        # file)
+        if os.path.islink(pgdata_dir):
+            pgdata_dir = os.path.realpath(pgdata_dir)
         controller.upload_directory(
             label="pgdata",
             src=pgdata_dir,


### PR DESCRIPTION
It's perfectly valid to have PGDATA, say /var/lib/postgresql/13/main, be
a symlink to /mnt/somedir. But there were two significant problems with
how barman-cloud-backup handled this case.

1. If you run `barman-cloud-restore … /some/dir`, you would expect that
   directory to BE your data directory, not a symlink to somewhere else.
   Even if you were OK with the symlink, there would be no way to allow
   you to specify a different directory, the way it is now possible to
   do for tablespaces.

2. As reported in #351, there are Python-version-dependent problems with
   extracting from a tarfile that contains symlinks.

   Using Python 3.8.10 or newer may fix the problem or some part of it,
   but barman-cloud-restore can still trigger the "seeking backwards is
   not allowed" error under 3.8.10 with a backup from a server where
   PGDATA is a symlink.

The existing behaviour being unreasonable and problematic—and clearly
not anticipated by the code—we change _backup_copy to check if PGDATA
is a symlink, and if so, just backup whatever it points to.

Closes #351