### PR TITLE
barman-cloud-wal-archive runs as pre archive hook

### DIFF
--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -43,7 +43,7 @@ def __is_hook_script():
     if "BARMAN_HOOK" in os.environ and "BARMAN_PHASE" in os.environ:
         if (
             os.getenv("BARMAN_HOOK") in ("archive_script", "archive_retry_script")
-            and os.getenv("BARMAN_PHASE") == "post"
+            and os.getenv("BARMAN_PHASE") == "pre"
         ):
             return True
         else:

--- a/tests/test_barman_cloud_wal_archive.py
+++ b/tests/test_barman_cloud_wal_archive.py
@@ -401,7 +401,7 @@ class TestWalUploaderHookScript(object):
         {
             "AZURE_STORAGE_CONNECTION_STRING": "connection_string",
             "BARMAN_HOOK": "archive_script",
-            "BARMAN_PHASE": "post",
+            "BARMAN_PHASE": "pre",
             "BARMAN_FILE": EXAMPLE_WAL_PATH,
         },
     )
@@ -420,7 +420,7 @@ class TestWalUploaderHookScript(object):
         {
             "AZURE_STORAGE_CONNECTION_STRING": "connection_string",
             "BARMAN_HOOK": "archive_retry_script",
-            "BARMAN_PHASE": "post",
+            "BARMAN_PHASE": "pre",
             "BARMAN_FILE": EXAMPLE_WAL_PATH,
         },
     )
@@ -439,7 +439,7 @@ class TestWalUploaderHookScript(object):
         {
             "AZURE_STORAGE_CONNECTION_STRING": "connection_string",
             "BARMAN_HOOK": "archive_retry_script",
-            "BARMAN_PHASE": "post",
+            "BARMAN_PHASE": "pre",
         },
     )
     @mock.patch("barman.clients.cloud_walarchive.get_cloud_interface")
@@ -458,7 +458,7 @@ class TestWalUploaderHookScript(object):
         {
             "AZURE_STORAGE_CONNECTION_STRING": "connection_string",
             "BARMAN_HOOK": "archive_retry_script",
-            "BARMAN_PHASE": "pre",
+            "BARMAN_PHASE": "post",
             "BARMAN_FILE": EXAMPLE_WAL_PATH,
         },
     )
@@ -480,7 +480,7 @@ class TestWalUploaderHookScript(object):
         {
             "AZURE_STORAGE_CONNECTION_STRING": "connection_string",
             "BARMAN_HOOK": "backup_script",
-            "BARMAN_PHASE": "post",
+            "BARMAN_PHASE": "pre",
             "BARMAN_FILE": EXAMPLE_WAL_PATH,
         },
     )


### PR DESCRIPTION
Updates barman-cloud-wal-archive in hook script mode such that it
supports running as a pre archive hook, not post archive.

This matches what we describe in the documentation and removes a
possible source of errors on restore due to compressing archived
WALs which have already been compressed by Barman. Such
double-compression is no longer possible as the pre archive script
runs before Barman has carried out any compression on the WAL.