### PR TITLE
Document compression issues with barman-cloud-wal-archive and older python versions

### DIFF
--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -155,7 +155,8 @@ def parse_arguments(args=None):
     compression.add_argument(
         "-z",
         "--gzip",
-        help="gzip-compress the WAL while uploading to the cloud",
+        help="gzip-compress the WAL while uploading to the cloud "
+        "(should not be used with python < 3.2)",
         action="store_const",
         const="gzip",
         dest="compression",
@@ -163,7 +164,8 @@ def parse_arguments(args=None):
     compression.add_argument(
         "-j",
         "--bzip2",
-        help="bzip2-compress the WAL while uploading to the cloud",
+        help="bzip2-compress the WAL while uploading to the cloud "
+        "(should not be used with python < 3.3)",
         action="store_const",
         const="bzip2",
         dest="compression",

--- a/barman/clients/cloud_walrestore.py
+++ b/barman/clients/cloud_walrestore.py
@@ -18,11 +18,13 @@
 
 import logging
 import os
+import sys
 from contextlib import closing
 
 import barman
 from barman.cloud import configure_logging
 from barman.cloud_providers import get_cloud_interface
+from barman.exceptions import BarmanException
 from barman.utils import force_str
 from barman.xlog import hash_dir, is_any_xlog_file, is_backup_file
 
@@ -231,6 +233,12 @@ class CloudWalDownloader(object):
                 "WAL file %s for server %s does not exists", wal_name, self.server_name
             )
             raise SystemExit(1)
+
+        if compression and sys.version_info < (3, 0, 0):
+            raise BarmanException(
+                "Compressed WALs cannot be restored with Python 2.x - "
+                "please upgrade to a supported version of Python 3"
+            )
 
         # Download the file
         logging.debug(

--- a/doc/barman-cloud-wal-archive.1
+++ b/doc/barman-cloud-wal-archive.1
@@ -16,6 +16,12 @@ This script can be used in the \f[C]archive_command\f[] of a PostgreSQL
 server to ship WAL files to the Cloud.
 Currently AWS S3 and Azure Blob Storage are supported.
 .PP
+Note: If you are running python 2 or older unsupported versions of
+python 3 then avoid the compression options \f[C]--gzip\f[R] or
+\f[C]--bzip2\f[R] as barman-cloud-wal-restore is unable to restore
+gzip-compressed WALs on python < 3.2 or bzip2-compressed WALs on python
+< 3.3.
+.PP
 This script and Barman are administration tools for disaster recovery of
 PostgreSQL servers written in Python and maintained by EnterpriseDB.
 .SH POSITIONAL ARGUMENTS
@@ -64,14 +70,12 @@ test connectivity to the cloud destination and exit
 .RE
 .TP
 .B \-z, \[en]gzip
-gzip\-compress the WAL while uploading to the cloud
-.RS
-.RE
+gzip-compress the WAL while uploading to the cloud (should not be used
+with python < 3.2)
 .TP
 .B \-j, \[en]bzip2
-bzip2\-compress the WAL while uploading to the cloud
-.RS
-.RE
+bzip2-compress the WAL while uploading to the cloud (should not be used
+with python < 3.3)
 .TP
 .B \[en]cloud\-provider {aws\-s3,azure\-blob\-storage}
 the cloud provider to which the backup should be uploaded

--- a/doc/barman-cloud-wal-archive.1.md
+++ b/doc/barman-cloud-wal-archive.1.md
@@ -18,6 +18,11 @@ This script can be used in the `archive_command` of a PostgreSQL
 server to ship WAL files to the Cloud. Currently AWS S3 and Azure Blob
 Storage are supported.
 
+Note: If you are running python 2 or older unsupported versions of
+python 3 then avoid the compression options `--gzip` or `--bzip2` as
+barman-cloud-wal-restore is unable to restore gzip-compressed WALs
+on python < 3.2 or bzip2-compressed WALs on python < 3.3.
+
 This script and Barman are administration tools for disaster recovery
 of PostgreSQL servers written in Python and maintained by EnterpriseDB.
 
@@ -55,9 +60,11 @@ WAL_PATH
 
 -z, --gzip
 :    gzip-compress the WAL while uploading to the cloud
+     (should not be used with python < 3.2)
 
 -j, --bzip2
 :    bzip2-compress the WAL while uploading to the cloud
+     (should not be used with python < 3.3)
 
 --cloud-provider {aws-s3,azure-blob-storage}
 :    the cloud provider to which the backup should be uploaded

--- a/doc/manual/55-barman-cli.en.md
+++ b/doc/manual/55-barman-cli.en.md
@@ -66,8 +66,13 @@ and can be installed alongside the PostgreSQL server:
 - `barman-cloud-restore`: script to be used to restore a backup directly
   taken with `barman-cloud-backup` from an S3 object store;
 
-For information on how to setup credentials for the Cloud utilities,
+For information on how to setup credentials for the aws-s3 cloud provider
 please refer to the ["Credentials" section in Boto 3 documentation][boto3creds].
+
+For credentials for the azure-blob-storage cloud provider see the
+["Environment variables for authorization parameters" section in the Azure documentation][azure-storage-auth].
+The following environment variables are supported: `AZURE_STORAGE_CONNECTION_STRING`,
+`AZURE_STORAGE_KEY` and `AZURE_STORAGE_SAS_TOKEN`.
 
 > **WARNING:** Cloud utilities require the appropriate library for the cloud
 > provider you wish to use - either: [boto3][boto3] or

--- a/doc/manual/99-references.en.md
+++ b/doc/manual/99-references.en.md
@@ -31,6 +31,7 @@
   [boto3creds]: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html
   [azure-identity]: https://docs.microsoft.com/en-us/python/api/azure-identity/?view=azure-python
   [azure-storage-blob]: https://docs.microsoft.com/en-us/python/api/azure-storage-blob/?view=azure-python
+  [azure-storage-auth]: https://docs.microsoft.com/en-us/azure/storage/blobs/authorize-data-operations-cli#set-environment-variables-for-authorization-parameters
 
 
   [3]: http://github.com/EnterpriseDB/barman


### PR DESCRIPTION
Adds warnings around using `--gzip` and `--bzip2` on barman-cloud-wal-archive for older python versions due to issue #325.

I stopped short of automatically refusing to run with those options on affected python versions because it's possible someone might want to archive WALs from an old machine running python 2 and restore onto a newer machine running a current python 3 - such a scenario would not be affected by issue #325 at all and would work correctly.