### PR TITLE
368: Implement barman-cloud-backup-delete

### DIFF
--- a/barman/backup.py
+++ b/barman/backup.py
@@ -178,6 +178,25 @@ class BackupManager(RemoteStatusMixin):
             return available_backups.get(backup_id)
         return None
 
+    @staticmethod
+    def find_previous_backup_in(
+        available_backups, backup_id, status_filter=DEFAULT_STATUS_FILTER
+    ):
+        """
+        Find the next backup (if any) in the supplied dict of BackupInfo objects.
+        """
+        ids = sorted(available_backups.keys())
+        try:
+            current = ids.index(backup_id)
+            while current > 0:
+                res = available_backups[ids[current - 1]]
+                if res.status in status_filter:
+                    return res
+                current -= 1
+            return None
+        except ValueError:
+            raise UnknownBackupIdException("Could not find backup_id %s" % backup_id)
+
     def get_previous_backup(self, backup_id, status_filter=DEFAULT_STATUS_FILTER):
         """
         Get the previous backup (if any) in the catalog
@@ -189,14 +208,23 @@ class BackupManager(RemoteStatusMixin):
             status_filter = tuple(status_filter)
         backup = LocalBackupInfo(self.server, backup_id=backup_id)
         available_backups = self.get_available_backups(status_filter + (backup.status,))
+        return self.find_previous_backup_in(available_backups, backup_id, status_filter)
+
+    @staticmethod
+    def find_next_backup_in(
+        available_backups, backup_id, status_filter=DEFAULT_STATUS_FILTER
+    ):
+        """
+        Find the next backup (if any) in the supplied dict of BackupInfo objects.
+        """
         ids = sorted(available_backups.keys())
         try:
             current = ids.index(backup_id)
-            while current > 0:
-                res = available_backups[ids[current - 1]]
+            while current < (len(ids) - 1):
+                res = available_backups[ids[current + 1]]
                 if res.status in status_filter:
                     return res
-                current -= 1
+                current += 1
             return None
         except ValueError:
             raise UnknownBackupIdException("Could not find backup_id %s" % backup_id)
@@ -212,17 +240,7 @@ class BackupManager(RemoteStatusMixin):
             status_filter = tuple(status_filter)
         backup = LocalBackupInfo(self.server, backup_id=backup_id)
         available_backups = self.get_available_backups(status_filter + (backup.status,))
-        ids = sorted(available_backups.keys())
-        try:
-            current = ids.index(backup_id)
-            while current < (len(ids) - 1):
-                res = available_backups[ids[current + 1]]
-                if res.status in status_filter:
-                    return res
-                current += 1
-            return None
-        except ValueError:
-            raise UnknownBackupIdException("Could not find backup_id %s" % backup_id)
+        return self.find_next_backup_in(available_backups, backup_id, status_filter)
 
     def get_last_backup_id(self, status_filter=DEFAULT_STATUS_FILTER):
         """
@@ -253,6 +271,29 @@ class BackupManager(RemoteStatusMixin):
 
         ids = sorted(available_backups.keys())
         return ids[0]
+
+    @staticmethod
+    def get_timelines_to_protect(remove_until, deleted_backup, available_backups):
+        """
+        Returns all timelines in available_backups which are not associated with
+        the backup at remove_until. This is so that we do not delete WALs on
+        any other timelines.
+        """
+        timelines_to_protect = set()
+        # If remove_until is not set there are no backup left
+        if remove_until:
+            # Retrieve the list of extra timelines that contains at least
+            # a backup. On such timelines we don't want to delete any WAL
+            for value in available_backups.values():
+                # Ignore the backup that is being deleted
+                if value == deleted_backup:
+                    continue
+                timelines_to_protect.add(value.timeline)
+            # Remove the timeline of `remove_until` from the list.
+            # We have enough information to safely delete unused WAL files
+            # on it.
+            timelines_to_protect -= set([remove_until.timeline])
+        return timelines_to_protect
 
     def delete_backup(self, backup):
         """
@@ -321,22 +362,11 @@ class BackupManager(RemoteStatusMixin):
             elif BackupOptions.CONCURRENT_BACKUP in self.config.backup_options:
                 remove_until = backup
 
-            timelines_to_protect = set()
-            # If remove_until is not set there are no backup left
-            if remove_until:
-                # Retrieve the list of extra timelines that contains at least
-                # a backup. On such timelines we don't want to delete any WAL
-                for value in self.get_available_backups(
-                    BackupInfo.STATUS_ARCHIVING
-                ).values():
-                    # Ignore the backup that is being deleted
-                    if value == backup:
-                        continue
-                    timelines_to_protect.add(value.timeline)
-                # Remove the timeline of `remove_until` from the list.
-                # We have enough information to safely delete unused WAL files
-                # on it.
-                timelines_to_protect -= set([remove_until.timeline])
+            timelines_to_protect = self.get_timelines_to_protect(
+                remove_until,
+                backup,
+                self.get_available_backups(BackupInfo.STATUS_ARCHIVING),
+            )
 
             output.info("Delete associated WAL segments:")
             for name in self.remove_wal_before_backup(

--- a/barman/backup.py
+++ b/barman/backup.py
@@ -350,12 +350,15 @@ class BackupManager(RemoteStatusMixin):
             return False
         # Check if we are deleting the first available backup
         if not previous_backup:
-            # In the case of exclusive backup (default), removes any WAL
-            # files associated to the backup being deleted.
-            # In the case of concurrent backup, removes only WAL files
-            # prior to the start of the backup being deleted, as they
-            # might be useful to any concurrent backup started immediately
-            # after.
+            # There is no previous backup so we can remove unused WALs.
+            # If there is a next backup then all WALs up to the begin_wal
+            # of the next backup can be removed.
+            # If there is no next backup then there are no remaining backups so:
+            #   - In the case of exclusive backup (default), remove all WAL files.
+            #   - In the case of concurrent backup, removes only WAL files
+            #     prior to the start of the backup being deleted, as they
+            #     might be useful to any concurrent backup started immediately
+            #     after.
             remove_until = None  # means to remove all WAL files
             if next_backup:
                 remove_until = next_backup

--- a/barman/clients/cloud_backup_delete.py
+++ b/barman/clients/cloud_backup_delete.py
@@ -1,0 +1,322 @@
+# -*- coding: utf-8 -*-
+# © Copyright EnterpriseDB UK Limited 2018-2021
+#
+# This file is part of Barman.
+#
+# Barman is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Barman is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Barman.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+from contextlib import closing
+from operator import attrgetter
+
+import barman
+from barman.backup import BackupManager
+from barman.cloud import CloudBackupCatalog, configure_logging
+from barman.cloud_providers import get_cloud_interface
+from barman.retention_policies import RetentionPolicyFactory
+from barman.utils import force_str
+from barman import xlog
+
+try:
+    import argparse
+except ImportError:
+    raise SystemExit("Missing required python module: argparse")
+
+
+def _get_files_for_backup(catalog, backup_info):
+    backup_files = []
+    # Sort the files by OID so that we always get a stable order. The PGDATA dir
+    # has no OID so we use a -1 for sorting purposes, such that it always sorts
+    # ahead of the tablespaces.
+    for oid, backup_file in sorted(
+        catalog.get_backup_files(backup_info, allow_missing=True).items(),
+        key=lambda x: x[0] if x[0] else -1,
+    ):
+        key = oid or "PGDATA"
+        for file_info in [backup_file] + sorted(
+            backup_file.additional_files, key=attrgetter("path")
+        ):
+            # Silently skip files which could not be found - if they don't exist
+            # then not being able to delete them is not an error condition here
+            if file_info.path is not None:
+                logging.debug(
+                    "Will delete archive for %s at %s" % (key, file_info.path)
+                )
+                backup_files.append(file_info.path)
+
+    return backup_files
+
+
+def _remove_wals_for_backup(cloud_interface, catalog, deleted_backup, dry_run):
+    # An implementation of BackupManager.remove_wal_before_backup which does not
+    # use xlogdb, since xlogdb is not available to barman-cloud
+    previous_backup = BackupManager.find_previous_backup_in(
+        catalog.get_backup_list(), deleted_backup.backup_id
+    )
+    next_backup = BackupManager.find_next_backup_in(
+        catalog.get_backup_list(), deleted_backup.backup_id
+    )
+    should_delete = {}
+    if not previous_backup:
+        # There is no previous backup so we can remove unused WALs.
+        # If there is a next backup then all WALs up to the begin_wal of the next
+        # backup can be removed.
+        # If there is no next backup then there are no remaining backups however
+        # because we must assume non-exclusive backups are taken we can only safely
+        # delete WALs up to begin_wal of the deleted backup.
+        # See comments in barman.backup.BackupManager.delete_backup.
+        if next_backup:
+            remove_until = next_backup
+        else:
+            remove_until = deleted_backup
+        # A WAL is only a candidate for deletion if it is on the same timeline so we
+        # use BackupManager to get a set of all other timelines with backups so that
+        # we can preserve all WALs on other timelines.
+        timelines_to_protect = BackupManager.get_timelines_to_protect(
+            remove_until=remove_until,
+            deleted_backup=deleted_backup,
+            available_backups=catalog.get_backup_list(),
+        )
+        try:
+            wal_paths = catalog.get_wal_paths()
+        except Exception as exc:
+            logging.error(
+                "Cannot clean up WALs for backup %s because an error occurred listing WALs: %s",
+                deleted_backup.backup_id,
+                force_str(exc),
+            )
+            return
+        for wal_name, wal in wal_paths.items():
+            if xlog.is_history_file(wal_name):
+                continue
+            if timelines_to_protect:
+                tli, _, _ = xlog.decode_segment_name(wal_name)
+                if tli in timelines_to_protect:
+                    continue
+            if wal_name < remove_until.begin_wal:
+                should_delete[wal_name] = wal
+    # Explicitly sort because dicts are not ordered in python < 3.6
+    wal_paths_to_delete = sorted(should_delete.values())
+    if len(wal_paths_to_delete) > 0:
+        if not dry_run:
+            try:
+                cloud_interface.delete_objects(wal_paths_to_delete)
+            except Exception as exc:
+                logging.error(
+                    "Could not delete the following WALs for backup %s: %s, Reason: %s",
+                    deleted_backup.backup_id,
+                    wal_paths_to_delete,
+                    force_str(exc),
+                )
+                # Return early so that we leave the WALs in the local cache so they
+                # can be cleaned up should there be a subsequent backup deletion.
+                return
+        else:
+            print(
+                "Skipping deletion of objects %s due to --dry-run option"
+                % wal_paths_to_delete
+            )
+        for wal_name in should_delete.keys():
+            catalog.remove_wal_from_cache(wal_name)
+
+
+def _delete_backup(cloud_interface, catalog, backup_id, dry_run=True):
+    backup_info = catalog.get_backup_info(backup_id)
+    if not backup_info:
+        logging.warning("Backup %s does not exist", backup_id)
+        return
+    objects_to_delete = _get_files_for_backup(catalog, backup_info)
+    backup_info_path = os.path.join(
+        catalog.prefix, backup_info.backup_id, "backup.info"
+    )
+    logging.debug("Will delete backup.info file at %s" % backup_info_path)
+    if not dry_run:
+        try:
+            cloud_interface.delete_objects(objects_to_delete)
+            # Do not try to delete backup.info until we have successfully deleted
+            # everything else so that it is possible to retry the operation should
+            # we fail to delete any backup file
+            cloud_interface.delete_objects([backup_info_path])
+        except Exception as exc:
+            logging.error("Could not delete backup %s: %s", backup_id, force_str(exc))
+            raise SystemExit(2)
+    else:
+        print(
+            "Skipping deletion of objects %s due to --dry-run option"
+            % (objects_to_delete + [backup_info_path])
+        )
+
+    _remove_wals_for_backup(cloud_interface, catalog, backup_info, dry_run)
+    # It is important that the backup is removed from the catalog after cleaning
+    # up the WALs because the code in _remove_wals_for_backup depends on the
+    # deleted backup existing in the backup catalog
+    catalog.remove_backup_from_cache(backup_id)
+
+
+def main(args=None):
+    """
+    The main script entry point
+
+    :param list[str] args: the raw arguments list. When not provided
+        it defaults to sys.args[1:]
+    """
+    config = parse_arguments(args)
+    configure_logging(config)
+
+    try:
+        cloud_interface = get_cloud_interface(config)
+
+        with closing(cloud_interface):
+            if not cloud_interface.test_connectivity():
+                raise SystemExit(1)
+            # If test is requested, just exit after connectivity test
+            elif config.test:
+                raise SystemExit(0)
+
+            if not cloud_interface.bucket_exists:
+                logging.error("Bucket %s does not exist", cloud_interface.bucket_name)
+                raise SystemExit(1)
+
+            catalog = CloudBackupCatalog(
+                cloud_interface=cloud_interface, server_name=config.server_name
+            )
+            # Call catalog.get_backup_list now so we know we can read the whole catalog
+            # (the results are cached so this does not result in extra calls to cloud
+            # storage)
+            catalog.get_backup_list()
+            if len(catalog.unreadable_backups) > 0:
+                logging.error(
+                    "Cannot read the following backups: %s\n"
+                    "Unsafe to proceed with deletion due to failure reading backup catalog"
+                    % catalog.unreadable_backups
+                )
+                raise SystemExit(1)
+
+            if config.backup_id:
+                _delete_backup(
+                    cloud_interface, catalog, config.backup_id, config.dry_run
+                )
+            elif config.retention_policy:
+                retention_policy = RetentionPolicyFactory.create(
+                    "retention_policy",
+                    config.retention_policy,
+                    server_name=config.server_name,
+                    backup_info_list=catalog.get_backup_list(),
+                )
+                # Sort to ensure that we delete the backups in ascending order, that is
+                # from oldest to newest. This ensures that the relevant WALs will be cleaned
+                # up after each backup is deleted.
+                backups_to_delete = sorted(
+                    [
+                        backup_id
+                        for backup_id, status in retention_policy.report().items()
+                        if status == "OBSOLETE"
+                    ]
+                )
+                for backup_id in backups_to_delete:
+                    _delete_backup(cloud_interface, catalog, backup_id, config.dry_run)
+    except Exception as exc:
+        logging.error("Barman cloud backup delete exception: %s", force_str(exc))
+        logging.debug("Exception details:", exc_info=exc)
+        raise SystemExit(1)
+
+
+def parse_arguments(args=None):
+    """
+    Parse command line arguments
+
+    :return: The options parsed
+    """
+    parser = argparse.ArgumentParser(
+        description="This script can be used to delete backups "
+        "made with barman-cloud-backup command. "
+        "Currently AWS S3 and Azure Blob Storage are supported.",
+        add_help=False,
+    )
+    parser.add_argument(
+        "source_url",
+        help="URL of the cloud source, such as a bucket in AWS S3."
+        " For example: `s3://bucket/path/to/folder`.",
+    )
+    parser.add_argument(
+        "server_name", help="the name of the server as configured in Barman."
+    )
+    delete_arguments = parser.add_mutually_exclusive_group(required=True)
+    delete_arguments.add_argument(
+        "-b",
+        "--backup-id",
+        help="Backup ID of the backup to be deleted",
+    )
+    delete_arguments.add_argument(
+        "-r",
+        "--retention-policy",
+        help="If specified, delete all backups eligible for deletion according to the "
+        "supplied retention policy. Syntax: REDUNDANCY value | RECOVERY WINDOW OF "
+        "value {DAYS | WEEKS | MONTHS}",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Find the objects which need to be deleted but do not delete them",
+    )
+    parser.add_argument(
+        "-V", "--version", action="version", version="%%(prog)s %s" % barman.__version__
+    )
+    parser.add_argument("--help", action="help", help="show this help message and exit")
+    verbosity = parser.add_mutually_exclusive_group()
+    verbosity.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="increase output verbosity (e.g., -vv is more than -v)",
+    )
+    verbosity.add_argument(
+        "-q",
+        "--quiet",
+        action="count",
+        default=0,
+        help="decrease output verbosity (e.g., -qq is less than -q)",
+    )
+    parser.add_argument(
+        "-t",
+        "--test",
+        help="Test cloud connectivity and exit",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--cloud-provider",
+        help="The cloud provider to use as a storage backend",
+        choices=["aws-s3", "azure-blob-storage"],
+        default="aws-s3",
+    )
+    s3_arguments = parser.add_argument_group(
+        "Extra options for the aws-s3 cloud provider"
+    )
+    s3_arguments.add_argument(
+        "--endpoint-url",
+        help="Override default S3 endpoint URL with the given one",
+    )
+    s3_arguments.add_argument(
+        "-P",
+        "--profile",
+        help="profile name (e.g. INI section in AWS credentials file)",
+    )
+    return parser.parse_args(args=args)
+
+
+if __name__ == "__main__":
+    main()

--- a/barman/clients/cloud_walrestore.py
+++ b/barman/clients/cloud_walrestore.py
@@ -22,7 +22,7 @@ import sys
 from contextlib import closing
 
 import barman
-from barman.cloud import configure_logging
+from barman.cloud import configure_logging, ALLOWED_COMPRESSIONS
 from barman.cloud_providers import get_cloud_interface
 from barman.exceptions import BarmanException
 from barman.utils import force_str
@@ -158,9 +158,6 @@ class CloudWalDownloader(object):
     Cloud storage download client
     """
 
-    # Allowed compression algorithms
-    ALLOWED_COMPRESSIONS = {".gz": "gzip", ".bz2": "bzip2"}
-
     def __init__(self, cloud_interface, server_name):
         """
         Object responsible for handling interactions with cloud storage
@@ -202,7 +199,7 @@ class CloudWalDownloader(object):
             elif item.startswith(wal_path):
                 # Detect compression
                 basename = item
-                for e, c in self.ALLOWED_COMPRESSIONS.items():
+                for e, c in ALLOWED_COMPRESSIONS.items():
                     if item[-len(e) :] == e:
                         # Strip extension
                         basename = basename[: -len(e)]

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -34,6 +34,7 @@ from io import BytesIO
 from tempfile import NamedTemporaryFile
 
 from barman.backup_executor import ConcurrentBackupStrategy, ExclusiveBackupStrategy
+from barman.exceptions import BarmanException
 from barman.fs import path_allowed
 from barman.infofile import BackupInfo
 from barman.postgres_plumbing import EXCLUDE_LIST, PGDATA_EXCLUDE_LIST
@@ -101,7 +102,14 @@ def copyfileobj_pad_truncate(src, dst, length=None):
             dst.write(tarfile.NUL * (remainder - len(buf)))
 
 
-class CloudUploadingError(Exception):
+class CloudProviderError(BarmanException):
+    """
+    This exception is raised when we get an error in the response from the
+    cloud provider
+    """
+
+
+class CloudUploadingError(BarmanException):
     """
     This exception is raised when there are upload errors
     """
@@ -1009,6 +1017,14 @@ class CloudInterface(with_metaclass(ABCMeta)):
         :param dict upload_metadata: Provider-specific metadata for this upload
           e.g. the multipart upload handle in AWS S3
         :param str key: The key to use in the cloud service
+        """
+
+    @abstractmethod
+    def delete_objects(self, paths):
+        """
+        Delete the objects at the specified paths
+
+        :param List[str] paths:
         """
 
 

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -57,6 +57,9 @@ except ImportError:
 BUFSIZE = 16 * 1024
 LOGGING_FORMAT = "%(asctime)s [%(process)s] %(levelname)s: %(message)s"
 
+# Allowed compression algorithms
+ALLOWED_COMPRESSIONS = {".gz": "gzip", ".bz2": "bzip2"}
+
 
 def configure_logging(config):
     """

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -1502,6 +1502,7 @@ class CloudBackupCatalog(object):
         self.server_name = server_name
         self.prefix = os.path.join(self.cloud_interface.path, self.server_name, "base")
         self._backup_list = None
+        self.unreadable_backups = []
 
     def get_backup_list(self):
         """
@@ -1525,6 +1526,7 @@ class CloudBackupCatalog(object):
                     logging.warning(
                         "Unable to open backup.info file for %s: %s" % (backup_id, exc)
                     )
+                    self.unreadable_backups.append(backup_id)
                     continue
 
                 if backup_info:

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -1539,6 +1539,15 @@ class CloudBackupCatalog(object):
             self._backup_list = backup_list
         return self._backup_list
 
+    def remove_backup_from_cache(self, backup_id):
+        """
+        Remove backup with backup_id from the cached list. This is intended for
+        cases where we want to update the state without firing lots of requests
+        at the bucket.
+        """
+        if self._backup_list:
+            self._backup_list.pop(backup_id)
+
     def get_wal_paths(self):
         """
         Retrieve a dict of WAL paths keyed by the WAL name from cloud storage
@@ -1565,6 +1574,14 @@ class CloudBackupCatalog(object):
 
             self._wal_paths = wal_paths
         return self._wal_paths
+
+    def remove_wal_from_cache(self, wal_name):
+        """
+        Remove named wal from the cached list. This is intended for cases where
+        we want to update the state without firing lots of requests at the bucket.
+        """
+        if self._wal_paths:
+            self._wal_paths.pop(wal_name)
 
     def get_backup_info(self, backup_id):
         """

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -1598,11 +1598,14 @@ class CloudBackupCatalog(object):
         backup_info.load(file_object=backup_info_file)
         return backup_info
 
-    def get_backup_files(self, backup_info):
+    def get_backup_files(self, backup_info, allow_missing=False):
         """
         Get the list of expected files part of a backup
 
         :param BackupInfo backup_info: the backup information
+        :param bool allow_missing: True if missing backup files are allowed, False
+         otherwise. A value of False will cause a SystemExit to be raised if any
+         files expected due to the `backup_info` content cannot be found.
         :rtype: dict[int, BackupFileInfo]
         """
         # Correctly format the source path
@@ -1659,12 +1662,14 @@ class CloudBackupCatalog(object):
                     break
 
         for backup_file in backup_files.values():
+            logging_fun = logging.warning if allow_missing else logging.error
             if backup_file.path is None:
-                logging.error(
+                logging_fun(
                     "Missing file %s.* for server %s",
                     backup_file.base,
                     self.server_name,
                 )
-                raise SystemExit(1)
+                if not allow_missing:
+                    raise SystemExit(1)
 
         return backup_files

--- a/barman/server.py
+++ b/barman/server.py
@@ -444,7 +444,7 @@ class Server(RemoteStatusMixin):
             # Create retention policy objects
             try:
                 rp = RetentionPolicyFactory.create(
-                    self, "retention_policy", self.config.retention_policy
+                    "retention_policy", self.config.retention_policy, server=self
                 )
                 # Reassign the configuration value (we keep it in one place)
                 self.config.retention_policy = rp
@@ -454,7 +454,9 @@ class Server(RemoteStatusMixin):
                 )
                 try:
                     rp = RetentionPolicyFactory.create(
-                        self, "wal_retention_policy", self.config.wal_retention_policy
+                        "wal_retention_policy",
+                        self.config.wal_retention_policy,
+                        server=self,
                     )
                     # Reassign the configuration value
                     # (we keep it in one place)
@@ -470,7 +472,7 @@ class Server(RemoteStatusMixin):
                         % (self.config.wal_retention_policy, self.config.name)
                     )
                     rp = RetentionPolicyFactory.create(
-                        self, "wal_retention_policy", "main"
+                        "wal_retention_policy", "main", server=self
                     )
                     self.config.wal_retention_policy = rp
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,6 +1,7 @@
 MANPAGES=barman.1 barman.5 \
 		barman-wal-archive.1 barman-wal-restore.1 \
     barman-cloud-backup.1 \
+    barman-cloud-backup-delete.1 \
     barman-cloud-backup-list.1 \
     barman-cloud-wal-archive.1 \
     barman-cloud-restore.1 \
@@ -33,6 +34,9 @@ barman-wal-restore.1: barman-wal-restore.1.md
 	pandoc -s -f markdown$(NOSMART_SUFFIX) -t man -o $@ $<
 
 barman-cloud-backup.1: barman-cloud-backup.1.md
+	pandoc -s -f markdown$(nosmart_suffix) -t man -o $@ $<
+
+barman-cloud-backup-delete.1: barman-cloud-backup-delete.1.md
 	pandoc -s -f markdown$(nosmart_suffix) -t man -o $@ $<
 
 barman-cloud-backup-list.1: barman-cloud-backup-list.1.md

--- a/doc/barman-cloud-backup-delete.1.md
+++ b/doc/barman-cloud-backup-delete.1.md
@@ -1,0 +1,145 @@
+% BARMAN-CLOUD-BACKUP-DELETE(1) Barman User manuals | Version 2.13
+% EnterpriseDB <http://www.enterprisedb.com>
+% July 26, 2021
+
+# NAME
+
+barman-cloud-backup-delete - Delete backups stored in the Cloud
+
+
+# SYNOPSIS
+
+barman-cloud-backup-delete [*OPTIONS*] *SOURCE_URL* *SERVER_NAME*
+
+
+# DESCRIPTION
+
+This script can be used to delete backups previously made with the
+`barman-cloud-backup` command. Currently AWS S3 and Azure Blob Storage
+are supported.
+
+The target backups can be specified either using the backup ID (as
+returned by barman-cloud-backup-list) or by retention policy. Retention
+policies are the same as those for Barman server and work as described in
+the Barman manual: all backups not required to meet the specified policy
+will be deleted.
+
+When a backup is succesfully deleted any unused WALs associated with that
+backup are removed. WALs are only considered unused if:
+
+ 1. There are no older backups than the deleted backup.
+ 2. The WALs pre-date the begin_wal value of the oldest remaining backup.
+
+Note: The deletion of each backup involves three separate delete requests
+to the cloud provider (once for the backup files, once for the backup.info
+file and once for any associated WALs). If you have a significant number of
+backups accumulated in cloud storage then deleting by retention policy could
+result in a large number of delete requests.
+
+This script and Barman are administration tools for disaster recovery
+of PostgreSQL servers written in Python and maintained by EnterpriseDB.
+
+
+# POSITIONAL ARGUMENTS
+
+SOURCE_URL
+:    URL of the cloud source, such as a bucket in AWS S3.
+     For example: `s3://BUCKET_NAME/path/to/folder` (where `BUCKET_NAME`
+     is the bucket you have created in AWS).
+
+SERVER_NAME
+:    the name of the server as configured in Barman.
+
+# OPTIONS
+
+-h, --help
+:    show a help message and exit
+
+-V, --version
+:    show program's version number and exit
+
+-v, --verbose
+:    increase output verbosity (e.g., -vv is more than -v)
+
+-q, --quiet
+:    decrease output verbosity (e.g., -qq is less than -q)
+
+-t, --test
+:    test connectivity to the cloud destination and exit
+
+-b *BACKUP_ID*, --backup-id *BACKUP_ID*
+:    a valid Backup ID for a backup in cloud storage which is to be deleted
+
+-r *RETENTION_POLICY*, --retention-policy *RETENTION_POLICY*
+:    used instead of --backup-id, a retention policy for selecting the backups
+     to be deleted, e.g. "REDUNDANCY 3" or "RECOVERY WINDOW OF 2 WEEKS"
+
+--dry-run
+:    run without actually deleting any objects while printing information
+     about the objects which would be deleted to stdout
+
+--cloud-provider {aws-s3,azure-blob-storage}
+:    the cloud provider to which the backup should be uploaded
+
+-P, --profile
+:    profile name (e.g. INI section in AWS credentials file)
+
+--endpoint-url
+:    override the default S3 URL construction mechanism by specifying an endpoint.
+
+# REFERENCES
+
+For Boto:
+
+* https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html
+
+For AWS:
+
+* http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-set-up.html
+* http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html.
+
+For Azure Blob Storage:
+
+* https://docs.microsoft.com/en-us/azure/storage/blobs/authorize-data-operations-cli#set-environment-variables-for-authorization-parameters
+* https://docs.microsoft.com/en-us/python/api/azure-storage-blob/?view=azure-python
+
+# DEPENDENCIES
+
+If using `--cloud-provider=aws-s3`:
+
+* boto3
+
+If using `--cloud-provider=azure-blob-storage`:
+
+* azure-storage-blob
+* azure-identity (optional, if you wish to use DefaultAzureCredential)
+
+# EXIT STATUS
+
+0
+:   Success
+
+Not zero
+:   Failure
+
+
+# BUGS
+
+Barman has been extensively tested, and is currently being used in several
+production environments. However, we cannot exclude the presence of bugs.
+
+Any bug can be reported via the Github issue tracker.
+
+# RESOURCES
+
+* Homepage: <http://www.pgbarman.org/>
+* Documentation: <http://docs.pgbarman.org/>
+* Professional support: <http://www.enterprisedb.com/>
+
+
+# COPYING
+
+Barman is the property of EnterpriseDB UK Limited
+and its code is distributed under GNU General Public License v3.
+
+© Copyright EnterpriseDB UK Limited 2011-2021

--- a/doc/manual/55-barman-cli.en.md
+++ b/doc/manual/55-barman-cli.en.md
@@ -52,19 +52,22 @@ These utilities are distributed in the `barman-cli-cloud` RPM/Debian package,
 and can be installed alongside the PostgreSQL server:
 
 - `barman-cloud-wal-archive`: archiving script to be used as `archive_command`
-  to directly ship WAL files to an S3 object store, bypassing the Barman server;
+  to directly ship WAL files to cloud storage, bypassing the Barman server;
   alternatively, as a hook script for WAL archiving (`pre_archive_retry_script`);
 - `barman-cloud-wal-restore`: script to be used as `restore_command`
-  to fetch WAL files from an S3 object store, bypassing the Barman server, and
+  to fetch WAL files from cloud storage, bypassing the Barman server, and
   store them directly in the PostgreSQL standby;
 - `barman-cloud-backup`: backup script to be used to take a local backup
   directly on the PostgreSQL server and to ship it to a supported cloud provider,
   bypassing the Barman server; alternatively, as a hook script for copying barman
   backups to the cloud (`post_backup_retry_script)`
-- `barman-cloud-list-backup`: script to be used to list the content of
-  Barman backups taken with `barman-cloud-backup` from an S3 object store;
+- `barman-cloud-backup-delete`: script to be used to delete one or more backups
+  Barman backups taken with `barman-cloud-backup` from cloud storage and clean up
+  associated WALs;
+- `barman-cloud-backup-list`: script to be used to list the content of
+  Barman backups taken with `barman-cloud-backup` from cloud storage;
 - `barman-cloud-restore`: script to be used to restore a backup directly
-  taken with `barman-cloud-backup` from an S3 object store;
+  taken with `barman-cloud-backup` from cloud storage;
 
 For information on how to setup credentials for the aws-s3 cloud provider
 please refer to the ["Credentials" section in Boto 3 documentation][boto3creds].

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
             "barman-cloud-wal-archive=barman.clients.cloud_walarchive:main",
             "barman-cloud-restore=barman.clients.cloud_restore:main",
             "barman-cloud-wal-restore=barman.clients.cloud_walrestore:main",
+            "barman-cloud-backup-delete=barman.clients.cloud_backup_delete:main",
             "barman-cloud-backup-list=barman.clients.cloud_backup_list:main",
             "barman-wal-archive=barman.clients.walarchive:main",
             "barman-wal-restore=barman.clients.walrestore:main",

--- a/tests/test_barman_cloud_backup_delete.py
+++ b/tests/test_barman_cloud_backup_delete.py
@@ -1,0 +1,1363 @@
+# -*- coding: utf-8 -*-
+# © Copyright EnterpriseDB UK Limited 2013-2021
+#
+# Client Utilities for Barman, Backup and Recovery Manager for PostgreSQL
+#
+# Barman is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Barman is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Barman.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+import mock
+import pytest
+
+from barman.clients import cloud_backup_delete
+from barman.cloud import CloudBackupCatalog
+
+
+class TestCloudBackupDeleteArguments(object):
+    """Test handling of command line arguments."""
+
+    def test_fails_if_no_backup_id_or_policy_is_provided(self, capsys):
+        """If no backup id is provided then exit"""
+        with pytest.raises(SystemExit):
+            cloud_backup_delete.main(["cloud_storage_url", "test_server"])
+
+        _, err = capsys.readouterr()
+        assert (
+            "one of the arguments -b/--backup-id -r/--retention-policy is required"
+            in err
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_exits_on_connectivity_test(self, get_cloud_interface_mock):
+        """If the -t option is used we check connectivity and exit."""
+        cloud_interface_mock = get_cloud_interface_mock.return_value
+        cloud_interface_mock.test_connectivity.return_value = True
+        with pytest.raises(SystemExit) as exc:
+            cloud_backup_delete.main(
+                ["cloud_storage_url", "test_server", "--backup-id", "backup_id", "-t"]
+            )
+        assert exc.value.code == 0
+        cloud_interface_mock.test_connectivity.assert_called_once()
+
+
+class TestCloudBackupDelete(object):
+    """Test the interaction of barman-cloud-backup-delete with the cloud provider."""
+
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_fails_on_connectivity_test_failure(self, get_cloud_interface_mock):
+        """If connectivity test fails we exit."""
+        cloud_interface_mock = get_cloud_interface_mock.return_value
+        cloud_interface_mock.test_connectivity.return_value = False
+        with pytest.raises(SystemExit) as exc:
+            cloud_backup_delete.main(
+                ["cloud_storage_url", "test_server", "--backup-id", "backup_id"]
+            )
+        assert exc.value.code == 1
+        cloud_interface_mock.test_connectivity.assert_called_once()
+
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_fails_if_bucket_not_found(self, get_cloud_interface_mock, caplog):
+        """If the bucket does not exist we exit with status 1."""
+        cloud_interface_mock = get_cloud_interface_mock.return_value
+        cloud_interface_mock.bucket_name = "no_bucket_here"
+        cloud_interface_mock.bucket_exists = False
+        with pytest.raises(SystemExit) as exc:
+            cloud_backup_delete.main(
+                [
+                    "s3://cloud_storage_url/no_bucket_here",
+                    "test_server",
+                    "--backup-id",
+                    "backup_id",
+                ]
+            )
+        assert exc.value.code == 1
+        assert "Bucket no_bucket_here does not exist" in caplog.text
+
+    def _create_mock_file_info(self, path):
+        file_info = mock.MagicMock()
+        file_info.path = path
+        file_info.additional_files = []
+        return file_info
+
+    def _get_mock_backup_files(self, file_paths):
+        """Return a dict of mock BackupFileInfo objects keyed by file name."""
+        return dict(
+            [name, self._create_mock_file_info(path)]
+            for name, path in file_paths.items()
+        )
+
+    def _create_backup_metadata(self, backup_ids, begin_wals={}):
+        """
+        Helper for tests which creates mock BackupFileInfo and BackupInfo objects
+        which are returned in a dict keyed by backup_id.
+
+        If begin_wals has an entry for a given backup_id then the begin_wal and
+        timeline values will be set according to the wal name in begin_wals.
+
+        This is used by tests for two purposes:
+          1. Creating a mock CloudBackupCatalog.
+          2. Providing the data needed to verify that the expected backups were deleted.
+        """
+        backup_metadata = {}
+        for backup_id in backup_ids:
+            backup_metadata[backup_id] = {}
+            mock_backup_files = self._get_mock_backup_files(
+                {
+                    16388: "%s/16388" % backup_id,
+                    None: "%s/data.tar" % backup_id,
+                }
+            )
+            backup_metadata[backup_id]["files"] = mock_backup_files
+            backup_info = mock.MagicMock(name="backup_info")
+            backup_info.backup_id = backup_id
+            backup_info.status = "DONE"
+            backup_info.end_time = datetime.datetime.strptime(
+                backup_id, "%Y%m%dT%H%M%S"
+            ) + datetime.timedelta(hours=1)
+            try:
+                backup_info.begin_wal = begin_wals[backup_id]
+                backup_info.timeline = int(backup_info.begin_wal[:8])
+            except KeyError:
+                pass
+            backup_metadata[backup_id]["info"] = backup_info
+        return backup_metadata
+
+    def _get_sorted_files_for_backup(self, backup_metadata, backup_id):
+        """
+        Helper function for tests which retrieves the path of each file in the backup
+        sorted by OID, including any additional files which may be present.
+
+        This is used by tests to verify that all files associated with the backup were
+        deleted.
+        """
+        files_for_backup = []
+        for _oid, backup_file in sorted(
+            backup_metadata[backup_id]["files"].items(),
+            key=lambda x: x[0] if x[0] else -1,
+        ):
+            # Only include the main file if it has a path. If path is None then
+            # the tests are not expecting the main file to have been deleted.
+            if backup_file.path:
+                files_for_backup.append(backup_file.path)
+            additional_files = [
+                additional_file.path for additional_file in backup_file.additional_files
+            ]
+            files_for_backup += sorted(additional_files)
+        return files_for_backup
+
+    def _create_catalog(slef, backup_metadata, wals=[]):
+        """
+        Create a mock CloudBackupCatalog from the supplied data so that we can provide
+        a work-alike CloudBackupCatalog to the code-under-test without also including
+        the CloudBackupCatalog logic in the tests.
+        """
+        # Copy so that we don't affect the state the tests are using when the
+        # code under test removes backups from the mock catalog
+        backup_state = backup_metadata.copy()
+
+        def get_backup_info(backup_id):
+            return backup_state[backup_id]["info"]
+
+        def get_backup_list():
+            return dict(
+                [backup_id, metadata["info"]]
+                for backup_id, metadata in backup_state.items()
+            )
+
+        def remove_backup_from_cache(backup_id):
+            del backup_state[backup_id]
+
+        def get_backup_files(backup_info, allow_missing=False):
+            return backup_state[backup_info.backup_id]["files"]
+
+        def get_wal_paths():
+            return dict([wal, "wals/%s.gz" % wal] for wal in wals)
+
+        def remove_wal_from_cache(wal_name):
+            wals.remove(wal_name)
+
+        catalog = mock.Mock(CloudBackupCatalog)
+        catalog.configure_mock(
+            **{
+                "prefix": "",
+                "unreadable_backups": [],
+                "get_backup_info.side_effect": get_backup_info,
+                "get_backup_list.side_effect": get_backup_list,
+                "remove_backup_from_cache.side_effect": remove_backup_from_cache,
+                "get_backup_files.side_effect": get_backup_files,
+                "get_wal_paths.side_effect": get_wal_paths,
+                "remove_wal_from_cache.side_effect": remove_wal_from_cache,
+            }
+        )
+        return catalog
+
+    def _verify_cloud_interface_calls(self, get_cloud_interface_mock, expected_calls):
+        """
+        Verify that cloud_interface.delete_objects was called only with the arguments
+        provided in expected_calls and only in that order.
+        """
+        cloud_interface_mock = get_cloud_interface_mock.return_value
+        assert len(cloud_interface_mock.delete_objects.call_args_list) == len(
+            expected_calls
+        )
+        for i, call_args in enumerate(expected_calls):
+            assert (
+                call_args == cloud_interface_mock.delete_objects.call_args_list[i][0][0]
+            )
+
+    def _verify_only_these_backups_deleted(
+        self, get_cloud_interface_mock, backup_metadata, backup_ids, wals={}
+    ):
+        """
+        Helper function which allows tests to verify that the provided list of
+        backup_ids were fully deleted via cloud_interface.delete_objects. We
+        verify that the backups were deleted and that no other deletions were
+        made.
+
+        For each backup we verify that:
+          1. All files associated with the backup were deleted (including additional
+             files specified in the BackupFileInfo object).
+          2. Then, the backup.info file for the backup was deleted.
+          3. Optionally (if a list of WALs exists in `wals` for the backup being
+             deleted) that the expected WALs were deleted.
+        """
+        call_args = []
+        for backup_id in backup_ids:
+            call_args.append(
+                self._get_sorted_files_for_backup(backup_metadata, backup_id)
+            )
+            call_args.append(["%s/backup.info" % backup_id])
+            try:
+                call_args.append(wals[backup_id])
+            except KeyError:
+                # Not all tests expect WALs to be deleted so silently continue here
+                pass
+        self._verify_cloud_interface_calls(
+            get_cloud_interface_mock,
+            call_args,
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_delete_single_backup(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock
+    ):
+        """
+        Tests that files for the specified backup are deleted via the cloud provider.
+        """
+        # GIVEN a backup catalog with one backup and no WALs
+        backup_id = "20210723T095432"
+        backup_metadata = self._create_backup_metadata([backup_id])
+
+        # AND a CloudBackupCatalog which returns the backup_info for only that backup
+        cloud_backup_catalog_mock.return_value = self._create_catalog(backup_metadata)
+
+        # WHEN barman-cloud-backup-delete runs, specifying the backup ID
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--backup-id", backup_id]
+        )
+
+        # THEN the cloud interface was only used to delete the files associated with
+        # that backup and the backup.info file for that backup
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock, backup_metadata, [backup_id]
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_delete_missing_files(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock
+    ):
+        """
+        Tests that any backup files which are expected but not found are
+        ignored and do not affect the success of the backup deletion.
+        """
+        # GIVEN a backup catalog with one backup and no WALs
+        backup_id = "20210723T095432"
+        backup_metadata = self._create_backup_metadata([backup_id])
+
+        # AND the tablespace archive is missing
+        backup_metadata[backup_id]["files"][16388].path = None
+
+        # AND a CloudBackupCatalog which returns the backup_info for only that backup
+        cloud_backup_catalog_mock.return_value = self._create_catalog(backup_metadata)
+
+        # WHEN barman-cloud-backup-delete runs, specifying the backup ID
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--backup-id", backup_id]
+        )
+
+        # THEN the cloud interface was only used to delete the files associated with
+        # that backup which exist along with the backup.info file for that backup.
+        # There was no delete attempt for the missing tablespace archive.
+        backup_metadata[backup_id]["files"].pop(16388)
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock, backup_metadata, [backup_id]
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_delete_missing_files_with_additional_files(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock
+    ):
+        """
+        Tests that if a file which has additional files is missing, the additional
+        files are still deleted.
+        """
+        # GIVEN a backup catalog with one backup and no WALs
+        backup_id = "20210723T095432"
+        backup_metadata = self._create_backup_metadata([backup_id])
+
+        # AND the PGDATA file has additional files
+        backup_metadata[backup_id]["files"][None].additional_files = [
+            # AND the order of additional_files is not sorted by path
+            self._create_mock_file_info("%s/data_0002.tar" % backup_id),
+            self._create_mock_file_info("%s/data_0001.tar" % backup_id),
+        ]
+
+        # AND the main PGDATA file is missing
+        backup_metadata[backup_id]["files"][None].path = None
+
+        # AND a CloudBackupCatalog which returns the backup_info for only that backup
+        cloud_backup_catalog_mock.return_value = self._create_catalog(backup_metadata)
+
+        # WHEN barman-cloud-backup-delete runs, specifying the backup ID
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--backup-id", backup_id]
+        )
+
+        # THEN the cloud interface was only used to delete the files associated with
+        # that backup which exist along with the backup.info file for that backup.
+        # There was no delete attempt for the missing PGDATA archive but there are
+        # deletes for the additional files. This is implicitly tested because files
+        # with a path of None are excluded from the verification of call args.
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock, backup_metadata, [backup_id]
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_delete_additional_files(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock
+    ):
+        """
+        Tests that additional files (created due to --max-archive-size being
+        exceeded) are also deleted.
+        """
+        # GIVEN a backup catalog with one backup and no WALs
+        backup_id = "20210723T095432"
+        backup_metadata = self._create_backup_metadata([backup_id])
+
+        # AND the tablespace and PGDATA files both have additional files
+        backup_metadata[backup_id]["files"][16388].additional_files = [
+            self._create_mock_file_info("%s/16388_0001.tar" % backup_id),
+            self._create_mock_file_info("%s/16388_0002.tar" % backup_id),
+        ]
+        backup_metadata[backup_id]["files"][None].additional_files = [
+            # AND the order of additional_files is not sorted by path
+            self._create_mock_file_info("%s/data_0002.tar" % backup_id),
+            self._create_mock_file_info("%s/data_0001.tar" % backup_id),
+        ]
+
+        # AND a CloudBackupCatalog which returns the backup_info for only that backup
+        cloud_backup_catalog_mock.return_value = self._create_catalog(backup_metadata)
+
+        # WHEN barman-cloud-backup-delete runs, specifying the backup ID
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--backup-id", backup_id]
+        )
+
+        # THEN the cloud interface was only used to delete the files associated with
+        # that backup and the additional files in the expected sort order
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock, backup_metadata, [backup_id]
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_delete_one_of_multiple_backups(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock
+    ):
+        """
+        Tests that *only* files for the specified backup are deleted via the cloud
+        provider and files for other backups are preserved.
+        """
+        # GIVEN a backup catalog with two backups and no WALs
+        backup_id = "20210723T095432"
+        backup_metadata = self._create_backup_metadata(["20210723T085432", backup_id])
+
+        # AND a CloudBackupCatalog which returns the backup_info for only those backups
+        cloud_backup_catalog_mock.return_value = self._create_catalog(backup_metadata)
+
+        # WHEN barman-cloud-backup-delete runs, specifying the backup ID
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--backup-id", backup_id]
+        )
+
+        # THEN the cloud interface was only used to delete the files associated with
+        # the specified ID
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock, backup_metadata, [backup_id]
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_deletion_of_missing_backup(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock, caplog
+    ):
+        """
+        Tests that a backup ID which cannot be found is handled quietly.
+        """
+        # GIVEN an empty backup catalog
+        catalog = cloud_backup_catalog_mock.return_value
+        catalog.get_backup_info.return_value = None
+
+        # AND a backup_id which is not in the catalog
+        backup_id = "20210723T095432"
+
+        # WHEN barman-cloud-backup-delete runs, specifying the backup ID
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--backup-id", backup_id]
+        )
+
+        # THEN we complete successfully and nothing was deleted
+        cloud_interface_mock = get_cloud_interface_mock.return_value
+        cloud_interface_mock.delete_objects.assert_not_called()
+
+        # AND the logs contain a warning
+        assert "Backup 20210723T095432 does not exist" in caplog.text
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_delete_by_redundancy_policy(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock
+    ):
+        """
+        Test that only files for the backups which are not needed to meet
+        the retention policy are deleted.
+        """
+        # GIVEN a backup catalog with four backups and no WALs
+        out_of_policy_backup_ids = ["20210723T095432", "20210722T095432"]
+        in_policy_backup_ids = ["20210724T095432", "20210725T095432"]
+        backup_metadata = self._create_backup_metadata(
+            in_policy_backup_ids + out_of_policy_backup_ids
+        )
+
+        # AND a CloudBackupCatalog which returns the backup_info for only those backups
+        cloud_backup_catalog_mock.return_value = self._create_catalog(backup_metadata)
+
+        # WHEN barman-cloud-backup-delete runs, specifying a redundancy policy with
+        # two copies
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--retention-policy", "REDUNDANCY 2"]
+        )
+
+        # THEN the cloud interface was only used to delete the files associated with
+        # the backups which are not required to meet the policy
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock, backup_metadata, sorted(out_of_policy_backup_ids)
+        )
+
+    @mock.patch("barman.retention_policies.datetime")
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_delete_by_recovery_window_policy(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock, datetime_mock
+    ):
+        """
+        Test that only files for the backups which are not needed to meet
+        the recovery window retention policy are deleted.
+        """
+        # GIVEN a backup catalog with four daily backups and no WALs
+        out_of_policy_backup_ids = ["20210723T095432", "20210722T095432"]
+        in_policy_backup_ids = ["20210724T095432", "20210725T095432"]
+        backup_metadata = self._create_backup_metadata(
+            in_policy_backup_ids + out_of_policy_backup_ids
+        )
+
+        # AND a CloudBackupCatalog which returns the backup_info for only those backups
+        cloud_backup_catalog_mock.return_value = self._create_catalog(backup_metadata)
+
+        # AND a system time between one and two days after the most recent backup
+        datetime_mock.now.return_value = datetime.datetime(2021, 7, 27)
+
+        # WHEN barman-cloud-backup-delete runs, specifying a recovery window policy of
+        # 2 days
+        cloud_backup_delete.main(
+            [
+                "cloud_storage_url",
+                "test_server",
+                "--retention-policy",
+                "RECOVERY WINDOW OF 2 DAYS",
+            ]
+        )
+
+        # THEN the cloud interface was only used to delete the files associated with
+        # the backups which are not required to meet the policy
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock, backup_metadata, sorted(out_of_policy_backup_ids)
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_delete_by_redundancy_policy_no_obsolete_backups(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock
+    ):
+        """
+        Test that when there are no obsolete backups we exit successfully and nothing
+        is deleted.
+        """
+        # GIVEN a backup catalog with three backups and no WALs
+        in_policy_backup_ids = ["20210723T095432", "20210724T095432", "20210725T095432"]
+        backup_metadata = self._create_backup_metadata(in_policy_backup_ids)
+
+        # AND a CloudBackupCatalog which returns the backup_info for only those backups
+        cloud_backup_catalog_mock.return_value = self._create_catalog(backup_metadata)
+
+        # WHEN barman-cloud-backup-delete runs, specifying a redundancy policy with
+        # three copies
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--retention-policy", "REDUNDANCY 3"]
+        )
+
+        # THEN the cloud interface was not used to delete anything and, implicitly,
+        # no errors were returned
+        cloud_interface_mock = get_cloud_interface_mock.return_value
+        assert len(cloud_interface_mock.delete_objects.call_args_list) == 0
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_delete_by_unsupported_redundancy_policy(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock, caplog
+    ):
+        """
+        Test that when the supplied redundancy policy is unsupported we provide
+        a meaningful error.
+        """
+        # WHEN barman-cloud-backup-delete runs, specifying a redundancy policy
+        # which is unsupported
+        with pytest.raises(SystemExit) as exc:
+            cloud_backup_delete.main(
+                [
+                    "cloud_storage_url",
+                    "test_server",
+                    "--retention-policy",
+                    "THIS IS NOT VALID",
+                ]
+            )
+
+        # THEN we exit with status 1
+        assert exc.value.code == 1
+
+        # AND we logged a useful message
+        assert "Cannot parse option retention_policy: THIS IS NOT VALID" in caplog.text
+
+        # AND the cloud interface was not used to delete anything
+        cloud_interface_mock = get_cloud_interface_mock.return_value
+        assert len(cloud_interface_mock.delete_objects.call_args_list) == 0
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_error_on_delete(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock, caplog
+    ):
+        """
+        Test that when the cloud interface returns an error deleting backup files,
+        we exit with an error and do not delete the backup.info file, clean up any
+        WALs or delete any other backups.
+        """
+        # GIVEN a backup catalog with three backups where the oldest has a
+        # begin_wal value
+        out_of_policy_backup_ids = ["20210723T095432", "20210722T095432"]
+        in_policy_backup_ids = ["20210725T095432"]
+        begin_wals = {out_of_policy_backup_ids[1]: "00000010000000000000076"}
+        backup_metadata = self._create_backup_metadata(
+            in_policy_backup_ids + out_of_policy_backup_ids, begin_wals=begin_wals
+        )
+
+        # AND a CloudBackupCatalog which returns the backup_info for only those backups
+        # and a list of two WALs, one which pre-dates the oldest backup
+        wals = ["000000010000000000000075", "000000010000000000000076"]
+        cloud_backup_catalog_mock.return_value = self._create_catalog(
+            backup_metadata, wals=wals
+        )
+
+        # AND the cloud provider returns an error on delete via CloudInterface the
+        # first time it is called
+        cloud_interface_mock = get_cloud_interface_mock.return_value
+        self._should_error = True
+
+        def mock_delete_objects(objects):
+            if self._should_error:
+                self._should_error = False
+                raise Exception("Something went wrong on delete")
+            else:
+                return True
+
+        cloud_interface_mock.delete_objects.side_effect = mock_delete_objects
+
+        # WHEN barman-cloud-backup-delete runs, specifying a redundancy policy with
+        # one copy
+        with pytest.raises(SystemExit) as exc:
+            cloud_backup_delete.main(
+                [
+                    "cloud_storage_url",
+                    "test_server",
+                    "--retention-policy",
+                    "REDUNDANCY 1",
+                ]
+            )
+
+        # THEN an error was logged when the first backup could not be deleted
+        assert (
+            "Could not delete backup 20210722T095432: Something went wrong on delete"
+            in caplog.text
+        )
+
+        # AND we exit with status 2
+        assert exc.value.code == 2
+
+        # AND the cloud interface was used to delete objects only once - for
+        # the backup that failed. It was not called to delete the backup.info file
+        # of that backup, nor was it called to clean up WALs associated
+        # with that backup. It was also not called to delete subsequent backups.
+        assert len(cloud_interface_mock.delete_objects.call_args_list) == 1
+
+        expected_deleted_objects = self._get_sorted_files_for_backup(
+            backup_metadata, out_of_policy_backup_ids[1]
+        )
+        assert (
+            mock.call(expected_deleted_objects)
+            in cloud_interface_mock.delete_objects.call_args_list
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_error_when_listing_backups(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock, caplog
+    ):
+        """
+        Tests that if any error occurs when reading backup.info files we halt. In such
+        cases it is unsafe to continue (we might end up deleting WALs which are needed
+        by backups which have been moved to another storage class, for example).
+
+        Although barman-cloud-backup-list is optimistic and continues to list the
+        bucket contents, barman-cloud-backup-delete cannot safely proceed after listing
+        the remaining backups.
+        """
+        # GIVEN a backup catalog with two backups and no WALs
+        backup_id = "20210723T095432"
+        broken_backup_id = "20210724T095432"
+        backup_metadata = self._create_backup_metadata([backup_id, broken_backup_id])
+
+        # AND a CloudBackupCatalog which returns the backup_info for only that backup
+        catalog = cloud_backup_catalog_mock.return_value = self._create_catalog(
+            backup_metadata
+        )
+
+        # AND the cloud provider was unable to read one of the backups
+        catalog.unreadable_backups = [broken_backup_id]
+
+        # WHEN barman-cloud-backup-delete runs, specifying the backup ID
+        with pytest.raises(SystemExit) as exc:
+            cloud_backup_delete.main(
+                ["cloud_storage_url", "test_server", "--backup-id", backup_id]
+            )
+
+        # THEN we exit with status 1
+        assert exc.value.code == 1
+
+        # AND we log a useful message
+        assert (
+            "Cannot read the following backups: ['20210724T095432']\n"
+            "Unsafe to proceed with deletion due to failure reading backup catalog"
+        ) in caplog.text
+
+        # AND the cloud interface was not used to delete anything
+        cloud_interface_mock = get_cloud_interface_mock.return_value
+        cloud_interface_mock.delete_objects.assert_not_called()
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_no_wals_cleanup_when_older_backups_left(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock
+    ):
+        """Tests that no WALs are cleaned up when an older backup remains."""
+        # GIVEN a backup catalog with two backups with begin_wal values
+        backup_id = "20210723T095432"
+        older_backup_id = "20210722T095432"
+        begin_wals = {
+            backup_id: "000000010000000000000075",
+            older_backup_id: "000000010000000000000073",
+        }
+        backup_metadata = self._create_backup_metadata(
+            [backup_id, older_backup_id], begin_wals=begin_wals
+        )
+
+        # AND a CloudBackupCatalog which returns the backup_info for only those backups
+        # and a list of three WALs
+        cloud_backup_catalog_mock.return_value = self._create_catalog(
+            backup_metadata,
+            wals=[
+                "000000010000000000000073",
+                "000000010000000000000074",
+                "000000010000000000000075",
+            ],
+        )
+
+        # WHEN barman-cloud-backup-delete runs, specifying the backup ID
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--backup-id", backup_id]
+        )
+
+        # THEN the cloud interface was only used to delete the files associated with
+        # that backup and no WALs were deleted
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock, backup_metadata, [backup_id], wals={}
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_wals_cleaned_up_after_deleting_only_backup(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock
+    ):
+        """
+        Tests that WALs which pre-date the begin_wal of the last remaining
+        backup are deleted. Any WALs including and after the begin_wal of
+        that backup are preserved.
+        """
+        # GIVEN a backup catalog with one backup with a begin_wal value
+        backup_id = "20210723T095432"
+        begin_wals = {
+            backup_id: "000000010000000000000076",
+        }
+        backup_metadata = self._create_backup_metadata(
+            [backup_id], begin_wals=begin_wals
+        )
+
+        # AND a CloudBackupCatalog which returns the backup_info for only that backup
+        # and a list of four WALs
+        cloud_backup_catalog_mock.return_value = self._create_catalog(
+            backup_metadata,
+            wals=[
+                "000000010000000000000074",
+                "000000010000000000000075",
+                "000000010000000000000076",
+                "000000010000000000000077",
+            ],
+        )
+
+        # WHEN barman-cloud-backup-delete runs, specifying the backup ID
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--backup-id", backup_id]
+        )
+
+        # THEN the cloud provider was only asked to delete the backup files and backup.info
+        # for the deleted backup and the WALs which pre-date the deleted backup
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock,
+            backup_metadata,
+            [backup_id],
+            wals={
+                backup_id: [
+                    "wals/000000010000000000000074.gz",
+                    "wals/000000010000000000000075.gz",
+                ]
+            },
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_wals_cleaned_up_after_deleting_oldest_backup(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock
+    ):
+        """
+        Tests that WALs which pre-date the begin_wal of the oldest remaining
+        backup are deleted.
+        """
+        # GIVEN a backup catalog with two backups with begin_wal values
+        backup_id = "20210723T095432"
+        oldest_backup_id = "20210722T095432"
+        begin_wals = {
+            backup_id: "000000010000000000000076",
+            oldest_backup_id: "000000010000000000000075",
+        }
+        backup_metadata = self._create_backup_metadata(
+            [backup_id, oldest_backup_id], begin_wals=begin_wals
+        )
+
+        # AND a CloudBackupCatalog which returns the backup_info for only those backups
+        # and a list of four WALs plus the backup label
+        cloud_backup_catalog_mock.return_value = self._create_catalog(
+            backup_metadata,
+            wals=[
+                "000000010000000000000073",
+                "000000010000000000000074",
+                "000000010000000000000075",
+                "000000010000000000000075.00000028.backup",
+                "000000010000000000000076.00000028.backup",
+                "000000010000000000000076",
+            ],
+        )
+
+        # WHEN barman-cloud-backup-delete runs, specifying the oldest backup ID
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--backup-id", oldest_backup_id]
+        )
+
+        # THEN the cloud provider was only asked to delete the backup files and backup.info
+        # for the deleted backup and the WALs which pre-date the oldest remaining backup
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock,
+            backup_metadata,
+            [oldest_backup_id],
+            wals={
+                oldest_backup_id: [
+                    "wals/000000010000000000000073.gz",
+                    "wals/000000010000000000000074.gz",
+                    "wals/000000010000000000000075.00000028.backup.gz",
+                    "wals/000000010000000000000075.gz",
+                ]
+            },
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_history_files_preserved_when_cleaning_up_wals(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock
+    ):
+        """
+        Tests that history files are not deleted even if they "pre-date" the backup
+        being deleted.
+        """
+        # GIVEN a backup catalog with two backups with begin_wal values
+        backup_id = "20210723T095432"
+        oldest_backup_id = "20210722T095432"
+        begin_wals = {
+            backup_id: "000000010000000000000076",
+            oldest_backup_id: "000000010000000000000075",
+        }
+        backup_metadata = self._create_backup_metadata(
+            [backup_id, oldest_backup_id], begin_wals=begin_wals
+        )
+
+        # AND a CloudBackupCatalog which returns the backup_info for only those backups
+        # and a list of four WALs including a history file
+        cloud_backup_catalog_mock.return_value = self._create_catalog(
+            backup_metadata,
+            wals=[
+                "00000001.history",
+                "000000010000000000000073",
+                "000000010000000000000074",
+                "000000010000000000000075",
+                "000000010000000000000076",
+            ],
+        )
+
+        # WHEN barman-cloud-backup-delete runs, specifying the oldest backup ID
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--backup-id", oldest_backup_id]
+        )
+
+        # THEN the cloud provider was only asked to delete the backup files and backup.info
+        # for the deleted backup and the WALs which pre-date the oldest remaining backup
+        # and *not* the history file.
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock,
+            backup_metadata,
+            [oldest_backup_id],
+            wals={
+                oldest_backup_id: [
+                    "wals/000000010000000000000073.gz",
+                    "wals/000000010000000000000074.gz",
+                    "wals/000000010000000000000075.gz",
+                ]
+            },
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_no_backups_or_wals_deleted_when_dry_run_set(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock, capsys
+    ):
+        """
+        Tests that when there are eligible backups and WALs to delete, nothing
+        is actually deleted when the --dry-run flag is used.
+        """
+        # GIVEN a backup catalog with two backups with begin_wal values
+        backup_id = "20210723T095432"
+        oldest_backup_id = "20210722T095432"
+        begin_wals = {
+            backup_id: "000000010000000000000076",
+            oldest_backup_id: "000000010000000000000075",
+        }
+        backup_metadata = self._create_backup_metadata(
+            [backup_id, oldest_backup_id], begin_wals=begin_wals
+        )
+
+        # AND a CloudBackupCatalog which returns the backup_info for only those backups
+        # and a list of four WALs
+        cloud_backup_catalog_mock.return_value = self._create_catalog(
+            backup_metadata,
+            wals=[
+                "000000010000000000000073",
+                "000000010000000000000074",
+                "000000010000000000000075",
+                "000000010000000000000076",
+            ],
+        )
+
+        # WHEN barman-cloud-backup-delete runs, specifying the oldest backup ID
+        # AND the --dry-run flag is used
+        cloud_backup_delete.main(
+            [
+                "cloud_storage_url",
+                "test_server",
+                "--backup-id",
+                oldest_backup_id,
+                "--dry-run",
+            ]
+        )
+
+        # THEN the cloud provider does not request any deletions
+        cloud_interface_mock = get_cloud_interface_mock.return_value
+        assert len(cloud_interface_mock.delete_objects.call_args_list) == 0
+
+        # AND details of skipped deletions are printed to stdout
+        out, _err = capsys.readouterr()
+        assert (
+            "Skipping deletion of objects ['20210722T095432/data.tar', "
+            "'20210722T095432/16388', '20210722T095432/backup.info'] "
+            "due to --dry-run option"
+        ) in out
+        assert (
+            "Skipping deletion of objects ['wals/000000010000000000000073.gz', "
+            "'wals/000000010000000000000074.gz', 'wals/000000010000000000000075.gz'] "
+            "due to --dry-run option"
+        ) in out
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_wals_cleaned_up_after_deleting_by_retention_policy(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock
+    ):
+        """
+        Tests that WALs which pre-date the begin_wal of the oldest remaining
+        backup are deleted.
+        """
+        # GIVEN a backup catalog with four backups with begin_wal values
+        out_of_policy_backup_ids = ["20210722T095432", "20210723T095432"]
+        in_policy_backup_ids = ["20210724T095432", "20210725T095432"]
+        begin_wals = {
+            out_of_policy_backup_ids[0]: "000000010000000000000076",
+            out_of_policy_backup_ids[1]: "000000010000000000000078",
+            in_policy_backup_ids[0]: "00000001000000000000007A",
+            in_policy_backup_ids[1]: "00000001000000000000007C",
+        }
+        backup_metadata = self._create_backup_metadata(
+            out_of_policy_backup_ids + in_policy_backup_ids, begin_wals=begin_wals
+        )
+
+        # AND a CloudBackupCatalog which returns the backup_info for only those backups
+        # and a list of eight WALs
+        cloud_backup_catalog_mock.return_value = self._create_catalog(
+            backup_metadata,
+            wals=[
+                "000000010000000000000075",
+                "000000010000000000000076",
+                "000000010000000000000077",
+                "000000010000000000000078",
+                "000000010000000000000079",
+                "00000001000000000000007A",
+                "00000001000000000000007B",
+                "00000001000000000000007C",
+            ],
+        )
+
+        # WHEN barman-cloud-backup-delete runs, specifying the oldest backup ID
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--retention-policy", "REDUNDANCY 2"]
+        )
+
+        # THEN the cloud interface was only used to delete the files associated with
+        # the backups which are not required to meet the policy
+        # AND after each backup was deleted, the WALs which pre-date the oldest
+        # remaining backup were deleted too.
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock,
+            backup_metadata,
+            out_of_policy_backup_ids,
+            wals={
+                out_of_policy_backup_ids[0]: [
+                    "wals/000000010000000000000075.gz",
+                    "wals/000000010000000000000076.gz",
+                    "wals/000000010000000000000077.gz",
+                ],
+                out_of_policy_backup_ids[1]: [
+                    "wals/000000010000000000000078.gz",
+                    "wals/000000010000000000000079.gz",
+                ],
+            },
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_wals_on_other_timelines_are_preserved(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock
+    ):
+        """
+        Tests that WALs which pre-date the begin_wal of the oldest remaining
+        backup but are on a different timeline to the deleted backup do not get
+        deleted.
+        """
+        # GIVEN a backup catalog with two backups with begin_wal values
+        # AND an additional backup on another timeline
+        backup_id = "20210723T095432"
+        oldest_backup_id = "20210722T095432"
+        alt_timeline_backup_id = "20210723T105432"
+        begin_wals = {
+            backup_id: "000000020000000000000076",
+            oldest_backup_id: "000000020000000000000075",
+            alt_timeline_backup_id: "000000010000000000000074",
+        }
+        backup_metadata = self._create_backup_metadata(
+            [backup_id, oldest_backup_id, alt_timeline_backup_id], begin_wals=begin_wals
+        )
+
+        # AND a CloudBackupCatalog which returns the backup_info for only those backups
+        # and a list of WALs on both timelines
+        cloud_backup_catalog_mock.return_value = self._create_catalog(
+            backup_metadata,
+            wals=[
+                "000000020000000000000073",
+                "000000020000000000000074",
+                "000000020000000000000075",
+                "000000020000000000000076",
+                "000000010000000000000073",
+                "000000010000000000000074",
+            ],
+        )
+
+        # WHEN barman-cloud-backup-delete runs, specifying the oldest backup ID
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--backup-id", oldest_backup_id]
+        )
+
+        # THEN the cloud provider was only asked to delete the backup files and
+        # backup.info for the deleted backup and only delete the associated WALs
+        # which are on the same timeline as the deleted backup.
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock,
+            backup_metadata,
+            [oldest_backup_id],
+            wals={
+                oldest_backup_id: [
+                    "wals/000000020000000000000073.gz",
+                    "wals/000000020000000000000074.gz",
+                    "wals/000000020000000000000075.gz",
+                ]
+            },
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_wals_are_preserved_if_older_backup_exists_on_alt_timeline(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock
+    ):
+        """
+        Tests that WALs are not deleted if there is an older backup which is on
+        an alternative timeline. Even though those WALs are not required by the
+        backup on that timeline the current logic will not delete them because
+        the logic for finding a previous backup is not timeline-aware.
+
+        This is equivalent behaviour with the existing WAL cleanup implementation
+        in Barman and is intented to prevent the deletion of in-use WALs in
+        complex multi-timeline scenarios.
+        """
+        # GIVEN a backup catalog with two backups with begin_wal values
+        # AND an additional backup on another timeline which is older than
+        # the other backups
+        backup_id = "20210723T095432"
+        oldest_backup_id = "20210722T095432"
+        alt_timeline_backup_id = "20210721T105432"
+        begin_wals = {
+            backup_id: "000000020000000000000076",
+            oldest_backup_id: "000000020000000000000075",
+            alt_timeline_backup_id: "000000010000000000000074",
+        }
+        backup_metadata = self._create_backup_metadata(
+            [backup_id, oldest_backup_id, alt_timeline_backup_id], begin_wals=begin_wals
+        )
+
+        # AND a CloudBackupCatalog which returns the backup_info for only those backups
+        # and a list of WALs on both timelines
+        cloud_backup_catalog_mock.return_value = self._create_catalog(
+            backup_metadata,
+            wals=[
+                "000000020000000000000073",
+                "000000020000000000000074",
+                "000000020000000000000075",
+                "000000020000000000000076",
+                "000000010000000000000073",
+                "000000010000000000000074",
+            ],
+        )
+
+        # WHEN barman-cloud-backup-delete runs, specifying the oldest backup ID
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--backup-id", oldest_backup_id]
+        )
+
+        # THEN the cloud interface was only used to delete the files associated with
+        # that backup and no WALs were deleted
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock, backup_metadata, [oldest_backup_id], wals={}
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_wals_on_timelines_with_no_backups_are_deleted(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock
+    ):
+        """
+        Tests that WALs which are on a timeline for which there are no backups
+        are cleaned up.
+
+        This is equivalent behaviour to Barman and ensures that any WALs which
+        were not cleaned up in a multi-timeline scenario do eventually get
+        cleaned up once all backups which reference them are gone.
+        """
+        # GIVEN a backup catalog with two backups with begin_wal values
+        backup_id = "20210723T095432"
+        oldest_backup_id = "20210722T095432"
+        begin_wals = {
+            backup_id: "000000020000000000000076",
+            oldest_backup_id: "000000020000000000000075",
+        }
+        backup_metadata = self._create_backup_metadata(
+            [backup_id, oldest_backup_id], begin_wals=begin_wals
+        )
+
+        # AND a CloudBackupCatalog which returns the backup_info for only those backups
+        # and a list of WALs across two timelines where timeline 1 has no backups
+        cloud_backup_catalog_mock.return_value = self._create_catalog(
+            backup_metadata,
+            wals=[
+                "000000020000000000000075",
+                "000000020000000000000076",
+                "000000010000000000000076",
+                "000000010000000000000077",
+            ],
+        )
+
+        # WHEN barman-cloud-backup-delete runs, specifying the oldest backup ID
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--backup-id", oldest_backup_id]
+        )
+
+        # THEN the cloud interface was only used to delete the files associated with
+        # that backup
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock,
+            backup_metadata,
+            [oldest_backup_id],
+            # AND we expect the WALs on the other timeline to have been cleaned up
+            # when that backup was deleted, along with elegible WALs on the deleted
+            # backup's timeline
+            wals={
+                oldest_backup_id: [
+                    "wals/000000010000000000000076.gz",
+                    "wals/000000010000000000000077.gz",
+                    "wals/000000020000000000000075.gz",
+                ]
+            },
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_error_on_delete_wal(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock, caplog
+    ):
+        """
+        Test that when the cloud interface returns an error when deleting WALs
+        we log the error but continue deleting backups.
+        """
+        # GIVEN a backup catalog with four backups with begin_wal values
+        out_of_policy_backup_ids = ["20210722T095432", "20210723T095432"]
+        in_policy_backup_ids = ["20210724T095432", "20210725T095432"]
+        begin_wals = {
+            out_of_policy_backup_ids[0]: "000000010000000000000076",
+            out_of_policy_backup_ids[1]: "000000010000000000000078",
+            in_policy_backup_ids[0]: "00000001000000000000007A",
+            in_policy_backup_ids[1]: "00000001000000000000007C",
+        }
+        backup_metadata = self._create_backup_metadata(
+            out_of_policy_backup_ids + in_policy_backup_ids, begin_wals=begin_wals
+        )
+
+        # AND a CloudBackupCatalog which returns the backup_info for only those backups
+        # and a list of eight WALs
+        wals = [
+            "000000010000000000000075",
+            "000000010000000000000076",
+            "000000010000000000000077",
+            "000000010000000000000078",
+            "000000010000000000000079",
+            "00000001000000000000007A",
+            "00000001000000000000007B",
+            "00000001000000000000007C",
+        ]
+        cloud_backup_catalog_mock.return_value = self._create_catalog(
+            backup_metadata, wals=wals
+        )
+
+        # AND the cloud provider returns an error on delete via CloudInterface
+        # the first time it is called with WALs
+        cloud_interface_mock = get_cloud_interface_mock.return_value
+        self._should_error = True
+
+        def mock_delete_objects(objects):
+            if any(o.split("/")[0] == "wals" for o in objects) and self._should_error:
+                self._should_error = False
+                raise Exception("Something went wrong on delete")
+            else:
+                return True
+
+        cloud_interface_mock.delete_objects.side_effect = mock_delete_objects
+
+        # WHEN barman-cloud-backup-delete runs, specifying a redundancy policy with
+        # one copy
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--retention-policy", "REDUNDANCY 2"]
+        )
+
+        # THEN an error was logged when the first backup could not be deleted
+        assert (
+            "Could not delete the following WALs for backup 20210722T095432: "
+            "['wals/000000010000000000000075.gz', 'wals/000000010000000000000076.gz', "
+            "'wals/000000010000000000000077.gz'], Reason: Something went wrong on "
+            "delete" in caplog.text
+        )
+
+        # AND the cloud interface was only used to delete the files associated with
+        # the out-of-policy backups
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock,
+            backup_metadata,
+            out_of_policy_backup_ids,
+            # AND we expect the WALs for each backup to have been cleaned up after each
+            # backup deleteion
+            wals={
+                out_of_policy_backup_ids[0]: [
+                    "wals/000000010000000000000075.gz",
+                    "wals/000000010000000000000076.gz",
+                    "wals/000000010000000000000077.gz",
+                ],
+                # AND the WALs which could not be deleted with the first backup are cleaned
+                # up after deletion of the second backup
+                out_of_policy_backup_ids[1]: [
+                    "wals/000000010000000000000075.gz",
+                    "wals/000000010000000000000076.gz",
+                    "wals/000000010000000000000077.gz",
+                    "wals/000000010000000000000078.gz",
+                    "wals/000000010000000000000079.gz",
+                ],
+            },
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_error_on_list_wal(
+        self, get_cloud_interface_mock, cloud_backup_catalog_mock, caplog
+    ):
+        """
+        Test that when the cloud interface returns an error when listing WALs
+        we log the error but continue deleting backups.
+        """
+        # GIVEN a backup catalog with four backups with begin_wal values
+        out_of_policy_backup_ids = ["20210722T095432", "20210723T095432"]
+        in_policy_backup_ids = ["20210724T095432", "20210725T095432"]
+        begin_wals = {
+            out_of_policy_backup_ids[0]: "000000010000000000000076",
+            out_of_policy_backup_ids[1]: "000000010000000000000078",
+            in_policy_backup_ids[0]: "00000001000000000000007A",
+            in_policy_backup_ids[1]: "00000001000000000000007C",
+        }
+        backup_metadata = self._create_backup_metadata(
+            out_of_policy_backup_ids + in_policy_backup_ids, begin_wals=begin_wals
+        )
+
+        # AND a CloudBackupCatalog which returns the backup_info for only those backups
+        # and a list of eight WALs
+        wals = [
+            "000000010000000000000075",
+            "000000010000000000000076",
+            "000000010000000000000077",
+            "000000010000000000000078",
+            "000000010000000000000079",
+            "00000001000000000000007A",
+            "00000001000000000000007B",
+            "00000001000000000000007C",
+        ]
+
+        catalog = cloud_backup_catalog_mock.return_value = self._create_catalog(
+            backup_metadata, wals=wals
+        )
+        # AND the cloud provider returns an error when listing WALs the first time it is
+        # called
+        self._should_error = True
+
+        original_get_wal_paths_mock = catalog.get_wal_paths.side_effect
+
+        def mock_get_wal_paths():
+            if self._should_error:
+                self._should_error = False
+                raise Exception("Something went wrong")
+            else:
+                return original_get_wal_paths_mock()
+
+        catalog.get_wal_paths.side_effect = mock_get_wal_paths
+
+        # WHEN barman-cloud-backup-delete runs, specifying a redundancy policy with
+        # one copy
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--retention-policy", "REDUNDANCY 2"]
+        )
+
+        # THEN an error was logged when the WALs for the first backup could not be listed
+        assert (
+            "Cannot clean up WALs for backup 20210722T095432 because an error "
+            "occurred listing WALs: Something went wrong" in caplog.text
+        )
+
+        # AND the cloud interface was only used to delete the files associated with
+        # the out-of-policy backups
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock,
+            backup_metadata,
+            out_of_policy_backup_ids,
+            # AND we expect the WALs to have been cleaned up only after the second backup
+            # was deleted (when listing the WAL paths succeeded)
+            wals={
+                # AND the WAL which could not be deleted with the first backup is cleaned
+                # up after deletion of the second backup
+                out_of_policy_backup_ids[1]: [
+                    "wals/000000010000000000000075.gz",
+                    "wals/000000010000000000000076.gz",
+                    "wals/000000010000000000000077.gz",
+                    "wals/000000010000000000000078.gz",
+                    "wals/000000010000000000000079.gz",
+                ]
+            },
+        )

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1344,3 +1344,16 @@ end_time=2014-12-22 09:25:27.410470+01:00
         assert "20210723T133818" in backups
         assert "20210723T154445" not in backups
         assert "20210723T154554" in backups
+
+    def test_unreadable_backup_ids_are_stored(self):
+        """Test we can retrieve IDs of backups which could not be read"""
+        self.remote_open_should_succeed = False
+        mock_cloud_interface = MagicMock()
+        mock_cloud_interface.list_bucket.return_value = [
+            "mt-backups/test-server/base/20210723T133818/",
+        ]
+        mock_cloud_interface.remote_open.side_effect = self.mock_remote_open
+        catalog = CloudBackupCatalog(mock_cloud_interface, "test-server")
+        catalog.get_backup_list()
+        assert len(catalog.unreadable_backups) == 1
+        assert "20210723T133818" in catalog.unreadable_backups

--- a/tests/test_retention_policies.py
+++ b/tests/test_retention_policies.py
@@ -39,22 +39,24 @@ class TestRetentionPolicies(object):
 
         """
         server = build_mocked_server()
-        rp = RetentionPolicyFactory.create(server, "retention_policy", "REDUNDANCY 2")
+        rp = RetentionPolicyFactory.create(
+            "retention_policy", "REDUNDANCY 2", server=server
+        )
         assert isinstance(rp, RedundancyRetentionPolicy)
 
         # Build a BackupInfo object with status to DONE
         backup_info = build_test_backup_info(
-            server=rp.server, backup_id="test1", end_time=datetime.now(tzlocal())
+            server=server, backup_id="test1", end_time=datetime.now(tzlocal())
         )
 
         # instruct the get_available_backups method to return a map with
         # our mock as result and minimum_redundancy = 1
-        rp.server.get_available_backups.return_value = {
+        server.get_available_backups.return_value = {
             "test_backup": backup_info,
             "test_backup2": backup_info,
             "test_backup3": backup_info,
         }
-        rp.server.config.minimum_redundancy = 1
+        server.config.minimum_redundancy = 1
         # execute retention policy report
         report = rp.report()
         # check that our mock is valid for the retention policy because
@@ -70,7 +72,7 @@ class TestRetentionPolicies(object):
             rp.report(context="invalid")
         # Set a new minimum_redundancy parameter, enforcing the usage of the
         # configuration parameter instead of the retention policy default
-        rp.server.config.minimum_redundancy = 3
+        server.config.minimum_redundancy = 3
         # execute retention policy report
         rp.report()
         # Check for the warning inside the log
@@ -94,13 +96,13 @@ class TestRetentionPolicies(object):
         """
         server = build_mocked_server()
         rp = RetentionPolicyFactory.create(
-            server, "retention_policy", "RECOVERY WINDOW OF 4 WEEKS"
+            "retention_policy", "RECOVERY WINDOW OF 4 WEEKS", server=server
         )
         assert isinstance(rp, RecoveryWindowRetentionPolicy)
 
         # Build a BackupInfo object with status to DONE
         backup_info = build_test_backup_info(
-            server=rp.server, backup_id="test1", end_time=datetime.now(tzlocal())
+            server=server, backup_id="test1", end_time=datetime.now(tzlocal())
         )
 
         backup_source = {"test_backup3": backup_info}
@@ -110,11 +112,11 @@ class TestRetentionPolicies(object):
         # Add a second obsolete backup
         backup_info.end_time = datetime.now(tzlocal()) - timedelta(weeks=6)
         backup_source["test_backup"] = backup_info
-        rp.server.get_available_backups.return_value = backup_source
+        server.get_available_backups.return_value = backup_source
         # instruct the get_available_backups method to return a map with
         # our mock as result and minimum_redundancy = 1
-        rp.server.config.minimum_redundancy = 1
-        rp.server.config.name = "test"
+        server.config.minimum_redundancy = 1
+        server.config.name = "test"
         # execute retention policy report
         report = rp.report()
         # check that our mock is valid for the retention policy
@@ -129,7 +131,7 @@ class TestRetentionPolicies(object):
             rp.report(context="invalid")
         # Set a new minimum_redundancy parameter, enforcing the usage of the
         # configuration parameter instead of the retention policy default
-        rp.server.config.minimum_redundancy = 4
+        server.config.minimum_redundancy = 4
         # execute retention policy report
         rp.report()
         # Check for the warning inside the log
@@ -155,18 +157,20 @@ class TestRetentionPolicies(object):
         """
 
         server = build_mocked_server()
-        rp = RetentionPolicyFactory.create(server, "retention_policy", "REDUNDANCY 2")
+        rp = RetentionPolicyFactory.create(
+            "retention_policy", "REDUNDANCY 2", server=server
+        )
         assert isinstance(rp, RedundancyRetentionPolicy)
 
         # Build a BackupInfo object with status to DONE
         backup_info = build_test_backup_info(
-            server=rp.server, backup_id="test1", end_time=datetime.now(tzlocal())
+            server=server, backup_id="test1", end_time=datetime.now(tzlocal())
         )
 
         # instruct the get_available_backups method to return a map with
         # our mock as result and minimum_redundancy = 1
-        rp.server.get_available_backups.return_value = {"test_backup": backup_info}
-        rp.server.config.minimum_redundancy = 1
+        server.get_available_backups.return_value = {"test_backup": backup_info}
+        server.config.minimum_redundancy = 1
         # execute retention policy report
         report = rp.backup_status("test_backup")
 
@@ -179,19 +183,19 @@ class TestRetentionPolicies(object):
         assert empty_report == BackupInfo.NONE
 
         rp = RetentionPolicyFactory.create(
-            server, "retention_policy", "RECOVERY WINDOW OF 4 WEEKS"
+            "retention_policy", "RECOVERY WINDOW OF 4 WEEKS", server=server
         )
         assert isinstance(rp, RecoveryWindowRetentionPolicy)
 
         # Build a BackupInfo object with status to DONE
         backup_info = build_test_backup_info(
-            server=rp.server, backup_id="test1", end_time=datetime.now(tzlocal())
+            server=server, backup_id="test1", end_time=datetime.now(tzlocal())
         )
 
         # instruct the get_available_backups method to return a map with
         # our mock as result and minimum_redundancy = 1
-        rp.server.get_available_backups.return_value = {"test_backup": backup_info}
-        rp.server.config.minimum_redundancy = 1
+        server.get_available_backups.return_value = {"test_backup": backup_info}
+        server.config.minimum_redundancy = 1
         # execute retention policy report
         report = rp.backup_status("test_backup")
 
@@ -207,36 +211,39 @@ class TestRetentionPolicies(object):
     def test_first_backup(self):
         server = build_mocked_server()
         rp = RetentionPolicyFactory.create(
-            server, "retention_policy", "RECOVERY WINDOW OF 4 WEEKS"
+            "retention_policy", "RECOVERY WINDOW OF 4 WEEKS", server
         )
         assert isinstance(rp, RecoveryWindowRetentionPolicy)
 
         # Build a BackupInfo object with status to DONE
         backup_info = build_test_backup_info(
-            server=rp.server, backup_id="test1", end_time=datetime.now(tzlocal())
+            server=server, backup_id="test0", end_time=datetime.now(tzlocal())
         )
 
         # instruct the get_available_backups method to return a map with
         # our mock as result and minimum_redundancy = 1
-        rp.server.get_available_backups.return_value = {"test_backup": backup_info}
-        rp.server.config.minimum_redundancy = 1
+        server.get_available_backups.return_value = {"test_backup": backup_info}
+        server.config.minimum_redundancy = 1
         # execute retention policy report
         report = rp.first_backup()
 
         assert report == "test_backup"
 
-        rp = RetentionPolicyFactory.create(server, "retention_policy", "REDUNDANCY 2")
+        rp = RetentionPolicyFactory.create(
+            "retention_policy", "REDUNDANCY 2", server=server
+        )
         assert isinstance(rp, RedundancyRetentionPolicy)
 
         # Build a BackupInfo object with status to DONE
         backup_info = build_test_backup_info(
-            server=rp.server, backup_id="test1", end_time=datetime.now(tzlocal())
+            server=server, backup_id="test1", end_time=datetime.now(tzlocal())
         )
 
         # instruct the get_available_backups method to return a map with
         # our mock as result and minimum_redundancy = 1
-        rp.server.get_available_backups.return_value = {"test_backup": backup_info}
-        rp.server.config.minimum_redundancy = 1
+        server.get_available_backups.return_value = {"test_backup": backup_info}
+        server.config.minimum_redundancy = 1
+
         # execute retention policy report
         report = rp.first_backup()
 


### PR DESCRIPTION
Adds the command `barman-cloud-backup-delete` which allows backups in cloud storage to be deleted either directly via `--backup-id <BACKUP_ID>` or via a retention policy using `--retention-policy <RETENTION_POLICY>`.

The PR is structured such that the changes required elsewhere in barman and barman-cloud are made in individual commits, followed by the commit which adds the `barman-cloud-backup-delete` command.