### PR TITLE
Move pg_receieve{wal,xlog} after the connection check

### DIFF
--- a/barman/wal_archiver.py
+++ b/barman/wal_archiver.py
@@ -732,10 +732,6 @@ class StreamingWalArchiver(WalArchiver):
         # Ensure the presence of the destination directory
         mkpath(self.config.streaming_wals_directory)
 
-        command = "pg_receivewal"
-        if self.server.streaming.server_version < 100000:
-            command = "pg_receivexlog"
-
         # Execute basic sanity checks on PostgreSQL connection
         streaming_status = self.server.streaming.get_remote_status()
         if streaming_status["streaming_supported"] is None:
@@ -749,6 +745,9 @@ class StreamingWalArchiver(WalArchiver):
                 % self.server.streaming.server_txt_version
             )
         # Execute basic sanity checks on pg_receivexlog
+        command = "pg_receivewal"
+        if self.server.streaming.server_version < 100000:
+            command = "pg_receivexlog"
         remote_status = self.get_remote_status()
         if not remote_status["pg_receivexlog_installed"]:
             raise ArchiverFailure("%s not present in $PATH" % command)


### PR DESCRIPTION
Moves the server version check for determining whether we log
pg_receivewal or pg_receivexlog so that it occurs after the initial
connection check.

This fixes the "Barman using replication slots server unreachable fails
running receive-wal" integration test which was breaking because the
call to self.server.streaming.server_version was raising an exception
directly and the expected log messages were not being logged.