### PR TITLE
Add support for Azure SAS token at blob container level

### DIFF
--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -19,7 +19,7 @@
 import datetime
 import os
 from io import BytesIO
-from azure.core.exceptions import ServiceRequestError
+from azure.core.exceptions import ResourceNotFoundError, ServiceRequestError
 from azure.storage.blob import PartialBatchErrorException
 
 import mock
@@ -733,8 +733,8 @@ class TestAzureCloudInterface(object):
             "AZURE_STORAGE_KEY": "storage_key",
         },
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_uploader_minimal(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_uploader_minimal(self, ContainerClientMock):
         """Connection string auth takes precedence over SAS token or shared token"""
         container_name = "container"
         account_url = "https://storageaccount.blob.core.windows.net"
@@ -744,24 +744,17 @@ class TestAzureCloudInterface(object):
 
         assert cloud_interface.bucket_name == "container"
         assert cloud_interface.path == "path/to/dir"
-        blob_service_mock.from_connection_string.assert_called_once_with(
+        ContainerClientMock.from_connection_string.assert_called_once_with(
             conn_str=os.environ["AZURE_STORAGE_CONNECTION_STRING"],
             container_name=container_name,
-        )
-        get_container_client_mock = (
-            blob_service_mock.from_connection_string.return_value.get_container_client
-        )
-        get_container_client_mock.assert_called_once_with(container_name)
-        assert (
-            cloud_interface.container_client == get_container_client_mock.return_value
         )
 
     @mock.patch.dict(
         os.environ,
         {"AZURE_STORAGE_SAS_TOKEN": "sas_token", "AZURE_STORAGE_KEY": "storage_key"},
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_uploader_sas_token_auth(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_uploader_sas_token_auth(self, ContainerClientMock):
         """SAS token takes precedence over shared token"""
         container_name = "container"
         account_url = "storageaccount.blob.core.windows.net"
@@ -771,7 +764,7 @@ class TestAzureCloudInterface(object):
 
         assert cloud_interface.bucket_name == "container"
         assert cloud_interface.path == "path/to/dir"
-        blob_service_mock.assert_called_once_with(
+        ContainerClientMock.assert_called_once_with(
             account_url=account_url,
             credential=os.environ["AZURE_STORAGE_SAS_TOKEN"],
             container_name=container_name,
@@ -781,8 +774,8 @@ class TestAzureCloudInterface(object):
         os.environ,
         {"AZURE_STORAGE_KEY": "storage_key"},
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_uploader_shared_token_auth(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_uploader_shared_token_auth(self, ContainerClientMock):
         """Shared token is used if SAS token and connection string aren't set"""
         container_name = "container"
         account_url = "storageaccount.blob.core.windows.net"
@@ -792,16 +785,16 @@ class TestAzureCloudInterface(object):
 
         assert cloud_interface.bucket_name == "container"
         assert cloud_interface.path == "path/to/dir"
-        blob_service_mock.assert_called_once_with(
+        ContainerClientMock.assert_called_once_with(
             account_url=account_url,
             credential=os.environ["AZURE_STORAGE_KEY"],
             container_name=container_name,
         )
 
     @mock.patch("azure.identity.DefaultAzureCredential")
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
     def test_uploader_default_credential_auth(
-        self, blob_service_mock, default_azure_credential
+        self, ContainerClientMock, default_azure_credential
     ):
         """Uses DefaultAzureCredential if no other auth provided"""
         container_name = "container"
@@ -812,7 +805,7 @@ class TestAzureCloudInterface(object):
 
         assert cloud_interface.bucket_name == "container"
         assert cloud_interface.path == "path/to/dir"
-        blob_service_mock.assert_called_once_with(
+        ContainerClientMock.assert_called_once_with(
             account_url=account_url,
             credential=default_azure_credential.return_value,
             container_name=container_name,
@@ -824,8 +817,8 @@ class TestAzureCloudInterface(object):
             "AZURE_STORAGE_CONNECTION_STRING": "connection_string",
         },
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_emulated_storage(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_emulated_storage(self, ContainerClientMock):
         """Connection string auth and emulated storage URL are valid"""
         container_name = "container"
         account_url = "https://127.0.0.1/devstoreaccount1"
@@ -835,7 +828,7 @@ class TestAzureCloudInterface(object):
 
         assert cloud_interface.bucket_name == "container"
         assert cloud_interface.path == "path/to/dir"
-        blob_service_mock.from_connection_string.assert_called_once_with(
+        ContainerClientMock.from_connection_string.assert_called_once_with(
             conn_str=os.environ["AZURE_STORAGE_CONNECTION_STRING"],
             container_name=container_name,
         )
@@ -845,8 +838,7 @@ class TestAzureCloudInterface(object):
         os.environ,
         {"AZURE_STORAGE_SAS_TOKEN": "sas_token", "AZURE_STORAGE_KEY": "storage_key"},
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_emulated_storage_no_connection_string(self, blob_service_mock):
+    def test_emulated_storage_no_connection_string(self):
         """Emulated storage URL with no connection string fails"""
         container_name = "container"
         account_url = "https://127.0.0.1/devstoreaccount1"
@@ -860,8 +852,7 @@ class TestAzureCloudInterface(object):
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_uploader_malformed_urls(self, blob_service_mock):
+    def test_uploader_malformed_urls(self):
         url = "https://not.the.azure.domain/container"
         with pytest.raises(ValueError) as exc:
             AzureCloudInterface(url=url)
@@ -875,8 +866,8 @@ class TestAzureCloudInterface(object):
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_connectivity(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_connectivity(self, ContainerClientMock):
         """
         Test the test_connectivity method
         """
@@ -884,35 +875,37 @@ class TestAzureCloudInterface(object):
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
         assert cloud_interface.test_connectivity() is True
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
-        container_client_mock.exists.assert_called_once_with()
+        # Bucket existence checking is carried out by checking we can successfully
+        # iterate the bucket contents
+        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client.list_blobs.assert_called_once_with()
+        blobs_iterator = container_client.list_blobs.return_value
+        blobs_iterator.next.assert_called_once_with()
+        # Also test that an empty bucket passes connectivity test
+        blobs_iterator.next.side_effect = StopIteration()
+        assert cloud_interface.test_connectivity() is True
 
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_connectivity_failure(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_connectivity_failure(self, ContainerClientMock):
         """
         Test the test_connectivity method in case of failure
         """
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
-        container_client_mock.exists.side_effect = ServiceRequestError("error")
+        container_client = ContainerClientMock.from_connection_string.return_value
+        blobs_iterator = container_client.list_blobs.return_value
+        blobs_iterator.next.side_effect = ServiceRequestError("error")
         assert cloud_interface.test_connectivity() is False
 
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_setup_bucket(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_setup_bucket(self, ContainerClientMock):
         """
         Test if a bucket already exists
         """
@@ -920,74 +913,66 @@ class TestAzureCloudInterface(object):
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
         cloud_interface.setup_bucket()
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
-        container_client_mock.exists.assert_called_once_with()
+        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client.list_blobs.assert_called_once_with()
+        blobs_iterator = container_client.list_blobs.return_value
+        blobs_iterator.next.assert_called_once_with()
 
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_setup_bucket_create(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_setup_bucket_create(self, ContainerClientMock):
         """
-        Test auto-creation of a bucket if it not exists
+        Test auto-creation of a bucket if it does not exist
         """
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
-        container_client_mock.exists.return_value = False
+        container_client = ContainerClientMock.from_connection_string.return_value
+        blobs_iterator = container_client.list_blobs.return_value
+        blobs_iterator.next.side_effect = ResourceNotFoundError()
         cloud_interface.setup_bucket()
-        container_client_mock.exists.assert_called_once_with()
-        container_client_mock.create_container.assert_called_once_with()
+        container_client.list_blobs.assert_called_once_with()
+        blobs_iterator.next.assert_called_once_with()
+        container_client.create_container.assert_called_once_with()
 
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_upload_fileobj(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_upload_fileobj(self, ContainerClientMock):
         """Test container client upload_blob is called with expected args"""
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
+        container_client = ContainerClientMock.from_connection_string.return_value
         mock_fileobj = mock.MagicMock()
         mock_key = "path/to/blob"
         cloud_interface.upload_fileobj(mock_fileobj, mock_key)
         # The key and fileobj are passed on to the upload_blob call
-        container_client_mock.upload_blob.assert_called_once_with(
+        container_client.upload_blob.assert_called_once_with(
             name=mock_key, data=mock_fileobj, overwrite=True
         )
 
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_upload_fileobj_with_encryption_scope(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_upload_fileobj_with_encryption_scope(self, ContainerClientMock):
         """Test encrption scope is passed to upload_blob"""
         encryption_scope = "test_encryption_scope"
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob",
             encryption_scope=encryption_scope,
         )
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
+        container_client = ContainerClientMock.from_connection_string.return_value
         mock_fileobj = mock.MagicMock()
         mock_key = "path/to/blob"
         cloud_interface.upload_fileobj(mock_fileobj, mock_key)
         # The key and fileobj are passed on to the upload_blob call along
         # with the encryption_scope
-        container_client_mock.upload_blob.assert_called_once_with(
+        container_client.upload_blob.assert_called_once_with(
             name=mock_key,
             data=mock_fileobj,
             overwrite=True,
@@ -997,19 +982,16 @@ class TestAzureCloudInterface(object):
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_upload_part(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_upload_part(self, ContainerClientMock):
         """
         Tests the upload of a single block in Azure
         """
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
-        blob_client_mock = container_client_mock.get_blob_client.return_value
+        container_client = ContainerClientMock.from_connection_string.return_value
+        blob_client_mock = container_client.get_blob_client.return_value
 
         mock_body = mock.MagicMock()
         mock_key = "path/to/blob"
@@ -1017,14 +999,14 @@ class TestAzureCloudInterface(object):
 
         # A blob client is created for the key and stage_block is called with
         # the mock_body and a block_id generated from the part number
-        container_client_mock.get_blob_client.assert_called_once_with(mock_key)
+        container_client.get_blob_client.assert_called_once_with(mock_key)
         blob_client_mock.stage_block.assert_called_once_with("00001", mock_body)
 
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_upload_part_with_encryption_scope(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_upload_part_with_encryption_scope(self, ContainerClientMock):
         """
         Tests that the encryption scope is passed to the blob client when
         uploading a single block
@@ -1034,11 +1016,8 @@ class TestAzureCloudInterface(object):
             "https://storageaccount.blob.core.windows.net/container/path/to/blob",
             encryption_scope=encryption_scope,
         )
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
-        blob_client_mock = container_client_mock.get_blob_client.return_value
+        container_client = ContainerClientMock.from_connection_string.return_value
+        blob_client_mock = container_client.get_blob_client.return_value
 
         mock_body = mock.MagicMock()
         mock_key = "path/to/blob"
@@ -1047,7 +1026,7 @@ class TestAzureCloudInterface(object):
         # A blob client is created for the key and stage_block is called with
         # the mock_body and a block_id generated from the part number and the
         # encryption scope
-        container_client_mock.get_blob_client.assert_called_once_with(mock_key)
+        container_client.get_blob_client.assert_called_once_with(mock_key)
         blob_client_mock.stage_block.assert_called_once_with(
             "00001", mock_body, encryption_scope=encryption_scope
         )
@@ -1055,17 +1034,14 @@ class TestAzureCloudInterface(object):
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_complete_multipart_upload(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_complete_multipart_upload(self, ContainerClientMock):
         """Tests completion of a block blob upload in Azure Blob Storage"""
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
-        blob_client_mock = container_client_mock.get_blob_client.return_value
+        container_client = ContainerClientMock.from_connection_string.return_value
+        blob_client_mock = container_client.get_blob_client.return_value
 
         mock_parts = [{"PartNumber": "00001"}]
         mock_key = "path/to/blob"
@@ -1073,14 +1049,14 @@ class TestAzureCloudInterface(object):
 
         # A blob client is created for the key and commit_block_list is called
         # with the supplied list of part numbers
-        container_client_mock.get_blob_client.assert_called_once_with(mock_key)
+        container_client.get_blob_client.assert_called_once_with(mock_key)
         blob_client_mock.commit_block_list.assert_called_once_with(["00001"])
 
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_complete_multipart_upload_with_encryption_scope(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_complete_multipart_upload_with_encryption_scope(self, ContainerClientMock):
         """
         Tests the completion of a block blob upload in Azure Blob Storage and that
         the encryption scope is passed to the blob client
@@ -1090,11 +1066,8 @@ class TestAzureCloudInterface(object):
             "https://storageaccount.blob.core.windows.net/container/path/to/blob",
             encryption_scope=encryption_scope,
         )
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
-        blob_client_mock = container_client_mock.get_blob_client.return_value
+        container_client = ContainerClientMock.from_connection_string.return_value
+        blob_client_mock = container_client.get_blob_client.return_value
 
         mock_parts = [{"PartNumber": "00001"}]
         mock_key = "path/to/blob"
@@ -1102,7 +1075,7 @@ class TestAzureCloudInterface(object):
 
         # A blob client is created for the key and commit_block_list is called
         # with the supplied list of part numbers and the encryption scope
-        container_client_mock.get_blob_client.assert_called_once_with(mock_key)
+        container_client.get_blob_client.assert_called_once_with(mock_key)
         blob_client_mock.commit_block_list.assert_called_once_with(
             ["00001"], encryption_scope=encryption_scope
         )
@@ -1110,32 +1083,29 @@ class TestAzureCloudInterface(object):
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_abort_multipart_upload(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_abort_multipart_upload(self, ContainerClientMock):
         """Test aborting a block blob upload in Azure Blob Storage"""
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
-        blob_client_mock = container_client_mock.get_blob_client.return_value
+        container_client = ContainerClientMock.from_connection_string.return_value
+        blob_client_mock = container_client.get_blob_client.return_value
 
         mock_key = "path/to/blob"
         cloud_interface._abort_multipart_upload({}, mock_key)
 
         # A blob client is created for the key and commit_block_list is called
         # with an empty list, followed by delete_blob with no args
-        container_client_mock.get_blob_client.assert_called_once_with(mock_key)
+        container_client.get_blob_client.assert_called_once_with(mock_key)
         blob_client_mock.commit_block_list.assert_called_once_with([])
         blob_client_mock.delete_blob.assert_called_once_with()
 
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_abort_multipart_upload_with_encryption_scope(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_abort_multipart_upload_with_encryption_scope(self, ContainerClientMock):
         """
         Test aborting a block blob upload in Azure Blob Storage and verify that the
         encryption scope is passed to the blob client
@@ -1145,11 +1115,8 @@ class TestAzureCloudInterface(object):
             "https://storageaccount.blob.core.windows.net/container/path/to/blob",
             encryption_scope=encryption_scope,
         )
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
-        blob_client_mock = container_client_mock.get_blob_client.return_value
+        container_client = ContainerClientMock.from_connection_string.return_value
+        blob_client_mock = container_client.get_blob_client.return_value
 
         mock_key = "path/to/blob"
         cloud_interface._abort_multipart_upload({}, mock_key)
@@ -1157,7 +1124,7 @@ class TestAzureCloudInterface(object):
         # A blob client is created for the key and commit_block_list is called
         # with an empty list and the encryption scope, followed by delete_blob
         # with no args
-        container_client_mock.get_blob_client.assert_called_once_with(mock_key)
+        container_client.get_blob_client.assert_called_once_with(mock_key)
         blob_client_mock.commit_block_list.assert_called_once_with(
             [], encryption_scope=encryption_scope
         )
@@ -1166,40 +1133,34 @@ class TestAzureCloudInterface(object):
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_delete_objects(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_delete_objects(self, ContainerClientMock):
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
+        container_client = ContainerClientMock.from_connection_string.return_value
 
         mock_keys = ["path/to/object/1", "path/to/object/2"]
         cloud_interface.delete_objects(mock_keys)
 
-        container_client_mock.delete_blobs.assert_called_once_with(*mock_keys)
+        container_client.delete_blobs.assert_called_once_with(*mock_keys)
 
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_delete_objects_with_empty_list(self, blob_service_mock):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_delete_objects_with_empty_list(self, ContainerClientMock):
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
+        container_client = ContainerClientMock.from_connection_string.return_value
 
         mock_keys = []
         cloud_interface.delete_objects(mock_keys)
 
         # The Azure SDK is happy to accept an empty list here so verify that we
         # simply passed it on
-        container_client_mock.delete_blobs.assert_called_once_with()
+        container_client.delete_blobs.assert_called_once_with()
 
     def _create_mock_HttpResponse(self, status_code, url):
         """Helper function for partial failure tests."""
@@ -1211,19 +1172,16 @@ class TestAzureCloudInterface(object):
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_delete_objects_partial_failure(self, blob_service_mock, caplog):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_delete_objects_partial_failure(self, ContainerClientMock, caplog):
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
+        container_client = ContainerClientMock.from_connection_string.return_value
 
         mock_keys = ["path/to/object/1", "path/to/object/2"]
 
-        container_client_mock.delete_blobs.return_value = iter(
+        container_client.delete_blobs.return_value = iter(
             [
                 self._create_mock_HttpResponse(403, "path/to/object/1"),
                 self._create_mock_HttpResponse(202, "path/to/object/2"),
@@ -1245,8 +1203,10 @@ class TestAzureCloudInterface(object):
     @mock.patch.dict(
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
-    @mock.patch("barman.cloud_providers.azure_blob_storage.BlobServiceClient")
-    def test_delete_objects_partial_failure_exception(self, blob_service_mock, caplog):
+    @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
+    def test_delete_objects_partial_failure_exception(
+        self, ContainerClientMock, caplog
+    ):
         """
         Test that partial failures raised via PartialBatchErrorException are handled.
         This isn't explicitly described in the Azure documentation but is something
@@ -1255,10 +1215,7 @@ class TestAzureCloudInterface(object):
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        blob_service_client_mock = blob_service_mock.from_connection_string.return_value
-        container_client_mock = (
-            blob_service_client_mock.get_container_client.return_value
-        )
+        container_client = ContainerClientMock.from_connection_string.return_value
 
         mock_keys = ["path/to/object/1", "path/to/object/2"]
 
@@ -1271,7 +1228,7 @@ class TestAzureCloudInterface(object):
         partial_batch_error_exception = PartialBatchErrorException(
             "something went wrong", None, parts
         )
-        container_client_mock.delete_blobs.side_effect = partial_batch_error_exception
+        container_client.delete_blobs.side_effect = partial_batch_error_exception
 
         with pytest.raises(CloudProviderError) as exc:
             cloud_interface.delete_objects(mock_keys)


### PR DESCRIPTION
Replaces the implementation of AzureCloudInterface._check_bucket_existence
so that it does not use ContainerClient.exists. Instead we use
ContainerClient.list_blobs as a proxy for existence - if we can call
next() on the return value of list_blobs and trigger either no exception
or a StopIteration then we know the bucket exists.

This fixes the only issue which prevented the azure blob storage cloud
provider from working with SAS tokens created at the blob container
level, specifically that calling ContainerClient.exists requires storage
account permissions, not container permissions.

We also change the logic around creating the ContainerClient so that we
instantiate it directly rather than first creating a BlobServiceClient.
This isn't strictly required to fix the SAS token issue but since it
results in a simpler connection initialisation it is worth doing anyway.

Closes #388