### PR TITLE
Fix output message format for barman--wal-archive --test  BARMAN_HOST…

### DIFF
--- a/barman/clients/walarchive.py
+++ b/barman/clients/walarchive.py
@@ -132,7 +132,7 @@ def connectivity_test(config):
     ssh_command = build_ssh_command(config)
     try:
         output = subprocess.Popen(ssh_command, stdout=subprocess.PIPE).communicate()
-        print(output[0])
+        print(output[0].decode("utf-8"))
         sys.exit(0)
     except subprocess.CalledProcessError as e:
         exit_with_error("Impossible to invoke remote put-wal: %s" % e)


### PR DESCRIPTION
… SERVER_NAME WAL_PATH command

Closes #237