### PR TITLE
Upgrade py dependency

### DIFF
--- a/tests/requirements_minimal.txt
+++ b/tests/requirements_minimal.txt
@@ -5,6 +5,6 @@ pytest==4.6.11
 boto3<1.11
 mock
 pytest-timeout
-py<1.6.0
+py==1.10.0
 argh==0.21.2
 python-dateutil==1.5


### PR DESCRIPTION
Pins the py dependency to 1.10.0 to resolve a dependabot alert.
This was previously set to <1.6.0 because 1.6.0 dropped compatibility
for python 2.6, however we no longer support python 2.6 so are free to
upgrade.