### PR TITLE
Avoid parsing backup label when backup_method = postgres

### DIFF
--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -1568,9 +1568,6 @@ class PostgresBackupStrategy(BackupStrategy):
 
         :param barman.infofile.LocalBackupInfo backup_info: backup information
         """
-        self._read_backup_label(backup_info)
-        self._backup_info_from_backup_label(backup_info)
-
         # Set data in backup_info from current_xlog_info
         self.current_action = "stopping postgres backup_method"
         output.info("Finalising the backup.")


### PR DESCRIPTION
Removes the call to `_backup_info_from_backup_label` in
`PostgresBackupStrategy` because all the fields read from the backup
label have already been set in `backup_info` during an earlier call to
`_backup_info_from_start_location` which retrieves them directly from
PostgreSQL.

The practical effect of this change is that it resolves a discrepancy
between the `begin_time` and `end_time` timezones in the backup info
because both `begin_time` and `end_time` are now read directly from
PostgreSQL and therefore have the same timezone info as the PostgreSQL
server.

The justification for the change is as follows:

1. When `PostgressBackupStrategy` was added in 1dd8ea8 the standard way
   to populate backup_info in Barman was to read from the backup label.
2. In b9233e4 the behaviour was changed such that backup_info fields
   were read directly from PostgreSQL but the subsequent call to read
   the values from the backup label was not removed.
3. In 8be0c15 the call to read the values from the backup label was
   removed for `ConcurrentBackupStrategy` but not for
   `PostgresBackupStrategy`.

By removing the call to `_backup_info_from_backup_label` we make it
consistent with the other backup strategies. The only remaining user of
`_backup_info_from_backup_label` is `ConcurrentBackupStrategy` when
running against PostgreSQL < 9.6 (i.e. it is using pgespresso). In these
cases the API to provide the backup_info fields from PostgreSQL is not
available and we must continue to read them from the backup label.

Closes #206