### PR TITLE
Do not overwrite begin_time when reading backup_label

### DIFF
--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -1509,9 +1509,13 @@ class BackupStrategy(with_metaclass(ABCMeta, object)):
             "begin_offset",
             xlog.parse_lsn(wal_info.group(1)) % backup_info.xlog_segment_size,
         )
-        backup_info.set_attribute(
-            "begin_time", dateutil.parser.parse(start_time.group(1))
-        )
+
+        # If we have already obtained a begin_time then it takes precedence over the
+        # begin time in the backup label
+        if not backup_info.begin_time:
+            backup_info.set_attribute(
+                "begin_time", dateutil.parser.parse(start_time.group(1))
+            )
 
     def _read_backup_label(self, backup_info):
         """

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -852,12 +852,12 @@ class TestPostgresBackupExecutor(object):
             begin_offset=28,
             copy_stats=dict(copy_time=100, total_time=105),
         )
-        timestamp = datetime.datetime(2015, 10, 26, 14, 38)
+        current_xlog_timestamp = datetime.datetime(2015, 10, 26, 14, 38)
         backup_manager.server.postgres.current_xlog_info = dict(
             location="0/12000090",
             file_name="000000010000000000000012",
             file_offset=144,
-            timestamp=timestamp,
+            timestamp=current_xlog_timestamp,
         )
         backup_manager.server.postgres.get_setting.return_value = "/pg/data"
         tmp_backup_label = (
@@ -886,7 +886,7 @@ class TestPostgresBackupExecutor(object):
         assert "Finalising the backup." in out
         assert backup_info.end_xlog == "0/12000090"
         assert backup_info.end_offset == 144
-        assert backup_info.begin_time == start_time
+        assert backup_info.begin_time == current_xlog_timestamp
         assert backup_info.begin_wal == "000000010000000000000040"
 
         # Check the CommandFailedException re raising


### PR DESCRIPTION
Check whether a `backup_info` already has `begin_time` before setting it
from a backup label in `_backup_info_from_backup_label`.

This resolves a discrepancy between the `begin_time` and `end_time`
timezones in the backup info because both `begin_time` and `end_time`
are now timestamps obtained directly from PostgreSQL and therefore have
the same timezone as the PostgreSQL server.

This only affects the `PostgresBackupStrategy` which still needs to read
the backup label when backing up a server in recovery mode as it cannot
get the WAL name and offsets directly from PostgreSQL in such cases.

The only other backup strategy which calls
`_backup_info_from_backup_label` is `ConcurrentBackupStrategy` when
backing up a <9.6 server. In these cases it uses pgespresso and
`begin_time` is not set by the time `_backup_info_from_backup_label`
runs called.

Closes #206