### PR TITLE
Handle EnterpriseDB version strings

### DIFF
--- a/barman/postgres.py
+++ b/barman/postgres.py
@@ -477,7 +477,11 @@ class PostgreSQLConnection(PostgreSQL):
         try:
             cur = self._cursor()
             cur.execute("SELECT version()")
-            return cur.fetchone()[0].split()[1]
+            platform, version = cur.fetchone()[0].split()[:2]
+            if platform == "EnterpriseDB":
+                return ".".join(version.split(".")[:-1])
+            else:
+                return version
         except (PostgresConnectionError, psycopg2.Error) as e:
             _logger.debug(
                 "Error retrieving PostgreSQL version: %s", force_str(e).strip()


### PR DESCRIPTION
Adds a special case in `PostgreSQLConnection.server_txt_version` to
handle the result of `SELECT version();` when it returns the
EnterpriseDB version instead of the PostgreSQL version - this is the
case in EPAS 9.6 (more recent versions return the PostgreSQL version
followed by the EnterpriseDB version so are already handled correctly).

This means that we determine the same major version when running against
EPAS 9.6 that we do when running against PostgreSQL 9.6 which means that
the `--include` patterns passed to RSync will include the tablespace
directories.

This fixes a bug where tablespaces were not included in backups when
running against EPAS 9.6.

Closes #424