### PR TITLE
Allow set-version.sh to run on macOS

### DIFF
--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -22,7 +22,7 @@ set -eu
 BASE="$(dirname $(cd $(dirname "$0"); pwd))"
 cd "$BASE"
 
-if [[ $(uname -s) == "Darwin" ]]
+if [ "$(uname -s)" = "Darwin" ]
 then
     date_cmd="gdate"
 else


### PR DESCRIPTION
Uses gdate as the date command if we are running on macOS.