### PR TITLE
Exclude build dir from sonarqube scan

### DIFF
--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -42,4 +42,4 @@ jobs:
             PULL_REQUEST_BRANCH: '${{github.head_ref}}'
             PULL_REQUEST_BASE_BRANCH: '${{github.base_ref}}'
             REPO_DEFAULT_BRANCH: '${{github.event.repository.default_branch}}'
-            REPO_EXCLUDE_FILES: '*properties*,**/src/test/**/*,**/*.sql,**/docs/**/*,**/*/*.java'
+            REPO_EXCLUDE_FILES: '*properties*,**/src/test/**/*,**/*.sql,**/docs/**/*,**/*/*.java,**/build/**'


### PR DESCRIPTION
Excludes the `./build` directory from the sonarqube scan in order to stop
files within being considered as duplication of code in `./barman`.

This fixes our github actions workflow which currently fails due to
sonarqube flagging false duplicates.