### PR TITLE
Provide commands to check WAL archive destination is usable

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -35,8 +35,13 @@ import barman.diagnose
 from barman import output
 from barman.annotations import KeepManager
 from barman.config import RecoveryOptions
-from barman.exceptions import BadXlogSegmentName, RecoveryException, SyncError
-from barman.infofile import BackupInfo
+from barman.exceptions import (
+    BadXlogSegmentName,
+    RecoveryException,
+    SyncError,
+    WalArchiveContentError,
+)
+from barman.infofile import BackupInfo, WalFileInfo
 from barman.server import Server
 from barman.utils import (
     BarmanEncoder,
@@ -48,6 +53,7 @@ from barman.utils import (
     get_log_levels,
     parse_log_level,
 )
+from barman.xlog import check_archive_usable
 
 _logger = logging.getLogger(__name__)
 
@@ -1247,6 +1253,48 @@ def keep(args):
         backup_manager.keep_backup(backup_info.backup_id, args.target)
 
 
+@named("check-wal-archive")
+@arg(
+    "server_name",
+    completer=server_completer,
+    help="specifies the server name for the command",
+)
+@arg(
+    "--current-wal-segment",
+    help="the most recent WAL segment for the server",
+)
+@arg(
+    "--current-timeline",
+    help="the current timeline for the server",
+    type=check_positive,
+)
+@expects_obj
+def check_wal_archive(args):
+    """
+    Check the WAL archive is usable for the specified server.
+    """
+    server = get_server(args)
+    output.init("check_wal_archive", server.config.name)
+
+    with server.xlogdb() as fxlogdb:
+        wals = [WalFileInfo.from_xlogdb_line(w).name for w in fxlogdb]
+        try:
+            check_archive_usable(
+                wals,
+                current_wal_segment=args.current_wal_segment,
+                current_timeline=args.current_timeline,
+            )
+            output.result("check_wal_archive", server.config.name)
+        except WalArchiveContentError as err:
+            msg = "Barman preflight error for server %s: %s" % (
+                server.config.name,
+                force_str(err),
+            )
+            logging.error(msg)
+            output.error(msg)
+            output.close_and_exit()
+
+
 def pretty_args(args):
     """
     Prettify the given argh namespace to be human readable
@@ -1619,6 +1667,7 @@ def main():
             list_files,
             list_server,
             list_servers,
+            check_wal_archive,
             put_wal,
             rebuild_xlogdb,
             receive_wal,

--- a/barman/clients/cloud_check_wal_archive.py
+++ b/barman/clients/cloud_check_wal_archive.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+# © Copyright EnterpriseDB UK Limited 2018-2021
+#
+# This file is part of Barman.
+#
+# Barman is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Barman is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Barman.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+import barman
+from barman.cloud import configure_logging, CloudBackupCatalog
+from barman.cloud_providers import get_cloud_interface
+from barman.exceptions import WalArchiveContentError
+from barman.utils import force_str, check_positive
+from barman.xlog import check_archive_usable
+
+try:
+    import argparse
+except ImportError:
+    raise SystemExit("Missing required python module: argparse")
+
+
+def main(args=None):
+    """
+    The main script entry point
+
+    :param list[str] args: the raw arguments list. When not provided
+        it defaults to sys.args[1:]
+    """
+    config = parse_arguments(args)
+    configure_logging(config)
+
+    try:
+        cloud_interface = get_cloud_interface(config)
+        catalog = CloudBackupCatalog(cloud_interface, config.server_name)
+        wals = list(catalog.get_wal_paths().keys())
+        check_archive_usable(
+            wals,
+            current_wal_segment=config.current_wal_segment,
+            current_timeline=config.current_timeline,
+        )
+    except WalArchiveContentError as err:
+        logging.error(
+            "Barman cloud preflight error for server %s: %s",
+            config.server_name,
+            force_str(err),
+        )
+        raise SystemExit(1)
+    except Exception as exc:
+        logging.error("Barman cloud preflight check exception: %s", force_str(exc))
+        logging.debug("Exception details:", exc_info=exc)
+        raise SystemExit(2)
+
+
+def parse_arguments(args=None):
+    """
+    Parse command line arguments
+
+    :return: The options parsed
+    """
+
+    parser = argparse.ArgumentParser(
+        description="Carries out preflight checks on the specified cloud storage "
+        "for the specified PostgreSQL server.",
+        add_help=False,
+    )
+    parser.add_argument(
+        "destination_url",
+        help="URL of the cloud destination, such as a bucket in AWS S3."
+        " For example: `s3://bucket/path/to/folder`.",
+    )
+    parser.add_argument(
+        "server_name", help="the name of the server as configured in Barman."
+    )
+    parser.add_argument(
+        "-V", "--version", action="version", version="%%(prog)s %s" % barman.__version__
+    )
+    parser.add_argument("--help", action="help", help="show this help message and exit")
+    verbosity = parser.add_mutually_exclusive_group()
+    verbosity.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="increase output verbosity (e.g., -vv is more than -v)",
+    )
+    verbosity.add_argument(
+        "-q",
+        "--quiet",
+        action="count",
+        default=0,
+        help="decrease output verbosity (e.g., -qq is less than -q)",
+    )
+    parser.add_argument(
+        "-t",
+        "--test",
+        help="Test cloud connectivity and exit",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--current-wal-segment",
+        help="The most recent WAL segment for the server",
+    )
+    parser.add_argument(
+        "--current-timeline",
+        help="The current timeline for the server",
+        type=check_positive,
+    )
+    parser.add_argument(
+        "--cloud-provider",
+        help="The cloud provider to use as a storage backend",
+        choices=["aws-s3", "azure-blob-storage"],
+        default="aws-s3",
+    )
+    s3_arguments = parser.add_argument_group(
+        "Extra options for the aws-s3 cloud provider"
+    )
+    s3_arguments.add_argument(
+        "--endpoint-url",
+        help="Override default S3 endpoint URL with the given one",
+    )
+    s3_arguments.add_argument(
+        "-P",
+        "--profile",
+        help="profile name (e.g. INI section in AWS credentials file)",
+    )
+    return parser.parse_args(args=args)
+
+
+if __name__ == "__main__":
+    main()

--- a/barman/exceptions.py
+++ b/barman/exceptions.py
@@ -373,3 +373,9 @@ class ArchivalBackupException(BarmanException):
     """
     Exception for errors concerning archival backups.
     """
+
+
+class WalArchiveContentError(BarmanException):
+    """
+    Exception raised when unexpected content is detected in the WAL archive.
+    """

--- a/barman/output.py
+++ b/barman/output.py
@@ -1055,6 +1055,22 @@ class ConsoleOutputWriter(object):
         for status, message in sorted(server_info.items()):
             self.info("\t%s: %s", status, message)
 
+    def init_check_wal_archive(self, server_name):
+        """
+        Init the preflight-check command output method
+
+        :param str server_name: the server we are displaying
+        """
+        self.info("Server %s:" % server_name)
+
+    def result_check_wal_archive(self, server_name):
+        """
+        Output the results of the show-servers command
+
+        :param str server_name: the server we are displaying
+        """
+        self.info(" - Barman preflight checks for server %s passed" % server_name)
+
 
 class JsonOutputWriter(ConsoleOutputWriter):
     def __init__(self, *args, **kwargs):
@@ -1672,6 +1688,24 @@ class JsonOutputWriter(ConsoleOutputWriter):
                 message = str(message)
 
             self.json_output[server_name][status] = message
+
+    def init_check_wal_archive(self, server_name):
+        """
+        Init the preflight-check command output method
+
+        :param str server_name: the server we are displaying
+        """
+        self.json_output[server_name] = {}
+
+    def result_check_wal_archive(self, server_name):
+        """
+        Output the results of the preflight-check command
+
+        :param str server_name: the server we are displaying
+        """
+        self.json_output[server_name] = (
+            "Barman preflight checks for server %s passed" % server_name
+        )
 
 
 class NagiosOutputWriter(ConsoleOutputWriter):

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
             "barman-cloud-backup-delete=barman.clients.cloud_backup_delete:main",
             "barman-cloud-backup-keep=barman.clients.cloud_backup_keep:main",
             "barman-cloud-backup-list=barman.clients.cloud_backup_list:main",
+            "barman-cloud-check-wal-archive=barman.clients.cloud_check_wal_archive:main",
             "barman-wal-archive=barman.clients.walarchive:main",
             "barman-wal-restore=barman.clients.walrestore:main",
         ],

--- a/tests/test_barman_cloud_check_wal_archive.py
+++ b/tests/test_barman_cloud_check_wal_archive.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# © Copyright EnterpriseDB UK Limited 2013-2021
+#
+# Client Utilities for Barman, Backup and Recovery Manager for PostgreSQL
+#
+# Barman is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Barman is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Barman.  If not, see <http://www.gnu.org/licenses/>.
+
+import mock
+import pytest
+
+from barman.clients import cloud_check_wal_archive
+
+
+class TestCloudCheckWalArchive(object):
+    @pytest.fixture
+    def cloud_backup_catalog(self):
+        """Create a mock CloudBackupCatalog with a WAL"""
+        cloud_backup_catalog = mock.Mock()
+        cloud_backup_catalog.get_wal_paths.return_value = {
+            "000000010000000000000001": "path/to/wals/000000010000000000000001.gz",
+        }
+        return cloud_backup_catalog
+
+    @mock.patch("barman.clients.cloud_check_wal_archive.check_archive_usable")
+    @mock.patch("barman.clients.cloud_check_wal_archive.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_check_wal_archive.get_cloud_interface")
+    def test_check_wal_archive_no_args(
+        self,
+        _mock_cloud_interface,
+        mock_cloud_backup_catalog,
+        mock_check_archive_usable,
+        cloud_backup_catalog,
+    ):
+        """Verify xlog.check_archive_usable is called with no additional args."""
+        mock_cloud_backup_catalog.return_value = cloud_backup_catalog
+        cloud_check_wal_archive.main(["cloud_storage_url", "test_server"])
+        mock_check_archive_usable.assert_called_once_with(
+            ["000000010000000000000001"],
+            current_wal_segment=None,
+            current_timeline=None,
+        )
+
+    @mock.patch("barman.clients.cloud_check_wal_archive.check_archive_usable")
+    @mock.patch("barman.clients.cloud_check_wal_archive.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_check_wal_archive.get_cloud_interface")
+    def test_check_wal_archive_args(
+        self,
+        _mock_cloud_interface,
+        mock_cloud_backup_catalog,
+        mock_check_archive_usable,
+        cloud_backup_catalog,
+    ):
+        """Verify xlog.check_archive_usable is called with no additional args."""
+        mock_cloud_backup_catalog.return_value = cloud_backup_catalog
+        cloud_check_wal_archive.main(
+            [
+                "cloud_storage_url",
+                "test_server",
+                "--current-wal-segment",
+                "0000000100000001",
+                "--current-timeline",
+                "2",
+            ]
+        )
+        mock_check_archive_usable.assert_called_once_with(
+            ["000000010000000000000001"],
+            current_wal_segment="0000000100000001",
+            current_timeline=2,
+        )

--- a/tests/test_wal_archiver.py
+++ b/tests/test_wal_archiver.py
@@ -31,7 +31,11 @@ from barman.exceptions import (
 from barman.infofile import WalFileInfo
 from barman.process import ProcessInfo
 from barman.server import CheckOutputStrategy
-from barman.wal_archiver import FileWalArchiver, StreamingWalArchiver, WalArchiverQueue
+from barman.wal_archiver import (
+    FileWalArchiver,
+    StreamingWalArchiver,
+    WalArchiverQueue,
+)
 from testing_helpers import build_backup_manager, build_test_backup_info, caplog_reset
 
 

--- a/tests/test_xlog.py
+++ b/tests/test_xlog.py
@@ -24,6 +24,7 @@ from mock import mock
 import barman.exceptions
 from barman import xlog
 from barman.compression import CompressionManager
+from barman.exceptions import CommandException, WalArchiveContentError
 from barman.infofile import WalFileInfo
 
 
@@ -492,3 +493,293 @@ class Test(object):
     )
     def test_xlog_segment_mask(self, mask, size):
         assert mask == xlog.xlog_segment_mask(size)
+
+
+class TestCheckArchiveUsable(object):
+    EXPECTED_EMPTY_MESSAGE = "Expected empty archive"
+    EXPECTED_ARCHIVE_CONTENT_ERROR = "Found %s file%s in WAL archive equal to or newer than WAL segment %s on timeline %s"
+
+    def test_passes_if_no_wals(self):
+        xlog.check_archive_usable([])
+
+    def test_fails_if_wal_exists(self):
+        with pytest.raises(WalArchiveContentError) as exc:
+            xlog.check_archive_usable(["000000010000000000000001"])
+        assert self.EXPECTED_EMPTY_MESSAGE == str(exc.value)
+
+    def test_fails_if_history_exists(self):
+        with pytest.raises(WalArchiveContentError) as exc:
+            xlog.check_archive_usable(["00000002.history"])
+        assert self.EXPECTED_EMPTY_MESSAGE == str(exc.value)
+
+    def test_fails_if_backup_wal_exists(self):
+        with pytest.raises(WalArchiveContentError) as exc:
+            xlog.check_archive_usable(["000000010000000000000001.00000028.backup"])
+        assert self.EXPECTED_EMPTY_MESSAGE == str(exc.value)
+
+    def test_error_if_current_wal_segment_and_no_current_timeline(self):
+        with pytest.raises(CommandException) as exc:
+            xlog.check_archive_usable([], current_wal_segment="00000001")
+        assert (
+            "Invalid parameter combination: current_wal_segment=00000001, current_timeline=None"
+            == str(exc.value)
+        )
+
+    def test_error_if_current_timeline_and_no_current_wal_segment(self):
+        with pytest.raises(CommandException) as exc:
+            xlog.check_archive_usable([], current_timeline=1)
+        assert (
+            "Invalid parameter combination: current_wal_segment=None, current_timeline=1"
+            == str(exc.value)
+        )
+
+    @pytest.mark.parametrize(
+        "bad_wal_segment",
+        [
+            "",
+            "00000001",
+            "000000010000000G",
+            "00000000100000001",
+            "-0000000100000001",
+            "0000000100000001.gz",
+            1,
+            ["0000000100000001"],
+        ],
+    )
+    def test_error_if_current_wal_segment_is_malformed(self, bad_wal_segment):
+        with pytest.raises(CommandException) as exc:
+            xlog.check_archive_usable(
+                [],
+                current_wal_segment=bad_wal_segment,
+                current_timeline=2,
+            )
+        assert (
+            "Cannot check WAL archive with malformed current_wal_segment %s"
+            % bad_wal_segment
+            == str(exc.value)
+        )
+
+    @pytest.mark.parametrize("bad_timeline", [-1, 0, "a string"])
+    def test_error_if_current_timeline_is_malformed(self, bad_timeline):
+        with pytest.raises(CommandException) as exc:
+            xlog.check_archive_usable(
+                [],
+                current_wal_segment="0000000100000001",
+                current_timeline=bad_timeline,
+            )
+        assert (
+            "Cannot check WAL archive with malformed current_timeline %s" % bad_timeline
+            == str(exc.value)
+        )
+
+    def test_passes_if_current_timeline_and_current_wal_segment_with_no_wals(self):
+        xlog.check_archive_usable(
+            [], current_wal_segment="0000000000000001", current_timeline=1
+        )
+
+    @pytest.mark.parametrize(
+        "wals,current_timeline",
+        [
+            (["00000002.history"], 2),
+            (["00000002.history"], 3),
+            (["00000002.history", "00000003.history"], 3),
+            (["00000002.history", "00000003.history"], 4),
+            (["00000003.history", "00000002.history"], 3),
+            (["00000003.history", "00000002.history"], 4),
+        ],
+    )
+    def test_passes_if_current_timeline_gte_history_file(self, wals, current_timeline):
+        xlog.check_archive_usable(
+            wals,
+            current_wal_segment="0000000000000001",
+            current_timeline=current_timeline,
+        )
+
+    @pytest.mark.parametrize(
+        "wals,current_timeline,num_expected_newer_files",
+        [
+            (["00000002.history"], 1, 1),
+            (["00000002.history", "00000003.history"], 1, 2),
+            (["00000002.history", "00000003.history"], 2, 1),
+            (["00000003.history", "00000002.history"], 1, 2),
+            (["00000003.history", "00000002.history"], 2, 1),
+        ],
+    )
+    def test_fails_if_current_timeline_lt_history_file(
+        self, wals, current_timeline, num_expected_newer_files
+    ):
+        current_wal_segment = "0000000000000001"
+        with pytest.raises(WalArchiveContentError) as exc:
+            xlog.check_archive_usable(
+                wals,
+                current_wal_segment=current_wal_segment,
+                current_timeline=current_timeline,
+            )
+        assert (
+            self.EXPECTED_ARCHIVE_CONTENT_ERROR
+            % (
+                num_expected_newer_files,
+                num_expected_newer_files > 1 and "s" or "",
+                current_wal_segment,
+                current_timeline,
+            )
+            == str(exc.value)
+        )
+
+    @pytest.mark.parametrize(
+        "wals,current_timeline",
+        [
+            (["000000010000000000000001"], 2),
+            (["000000020000000000000001"], 3),
+            (
+                [
+                    "000000010000000000000001",
+                    "000000010000000000000002",
+                    "000000010000000000000003",
+                ],
+                2,
+            ),
+            (
+                [
+                    "000000010000000000000001",
+                    "000000010000000000000002",
+                    "000000020000000000000001",
+                ],
+                3,
+            ),
+        ],
+    )
+    def test_passes_if_current_timeline_gte_wal_file_timeline(
+        self, wals, current_timeline
+    ):
+        xlog.check_archive_usable(
+            wals,
+            current_wal_segment="0000000000000002",
+            current_timeline=current_timeline,
+        )
+
+    @pytest.mark.parametrize(
+        "wals,current_timeline,num_expected_illegal_files",
+        [
+            (["000000020000000000000001"], 1, 1),
+            (["000000030000000000000001"], 2, 1),
+            (
+                [
+                    "000000020000000000000001",
+                    "000000020000000000000002",
+                    "000000020000000000000003",
+                ],
+                1,
+                3,
+            ),
+            (
+                [
+                    "000000020000000000000001",
+                    "000000020000000000000002",
+                    "000000030000000000000001",
+                ],
+                2,
+                1,
+            ),
+        ],
+    )
+    def test_fails_if_current_timeline_lt_wal_file_timeline(
+        self, wals, current_timeline, num_expected_illegal_files
+    ):
+        current_wal_segment = "0000000000000004"
+        with pytest.raises(WalArchiveContentError) as exc:
+            xlog.check_archive_usable(
+                wals,
+                current_wal_segment=current_wal_segment,
+                current_timeline=current_timeline,
+            )
+        assert (
+            self.EXPECTED_ARCHIVE_CONTENT_ERROR
+            % (
+                num_expected_illegal_files,
+                num_expected_illegal_files > 1 and "s" or "",
+                current_wal_segment,
+                current_timeline,
+            )
+            == str(exc.value)
+        )
+
+    @pytest.mark.parametrize(
+        "wals,current_wal_segment",
+        [
+            (["000000020000000000000001"], "0000000000000002"),
+            (["000000020000000010000001"], "0000000100000002"),
+            (
+                ["000000020000000010000001", "000000020000000010000002"],
+                "0000000100000003",
+            ),
+            (
+                ["000000020000000010000001", "000000020000000010000002"],
+                "0000000200000000",
+            ),
+        ],
+    )
+    def test_passes_if_current_timeline_eq_wal_file_timeline_and_wal_segment_gt_wal_file_segment(
+        self, wals, current_wal_segment
+    ):
+        xlog.check_archive_usable(
+            wals, current_wal_segment=current_wal_segment, current_timeline=2
+        )
+
+    @pytest.mark.parametrize(
+        "wals,current_wal_segment,num_expected_illegal_files",
+        [
+            (["000000020000000000000001"], "0000000000000001", 1),
+            (["000000020000000000000001"], "0000000000000000", 1),
+            (
+                ["000000020000000100000001", "000000020000000100000002"],
+                "0000000100000002",
+                1,
+            ),
+            (
+                ["000000020000000010000001", "000000020000000010000002"],
+                "0000000000000003",
+                2,
+            ),
+        ],
+    )
+    def test_fails_if_current_timeline_eq_wal_file_timeline_and_wal_segment_lte_wal_file_segment(
+        self, wals, current_wal_segment, num_expected_illegal_files
+    ):
+        current_timeline = 2
+        with pytest.raises(WalArchiveContentError) as exc:
+            xlog.check_archive_usable(
+                wals,
+                current_wal_segment=current_wal_segment,
+                current_timeline=current_timeline,
+            )
+        assert (
+            self.EXPECTED_ARCHIVE_CONTENT_ERROR
+            % (
+                num_expected_illegal_files,
+                num_expected_illegal_files > 1 and "s" or "",
+                current_wal_segment,
+                current_timeline,
+            )
+            == str(exc.value)
+        )
+
+    @pytest.mark.parametrize(
+        "wals",
+        [
+            ["00000002.history", "0"],
+            ["000000010000000100000001", 0],
+            ["000000010000000100000001", "00000001000000010000000G"],
+            ["000000010000000100000001", "000000010000000100000001.gz"],
+        ],
+    )
+    def test_fails_if_existing_wals_malformed(self, wals):
+        current_wal_segment = "0000000000000001"
+        current_timeline = 2
+        with pytest.raises(WalArchiveContentError) as exc:
+            xlog.check_archive_usable(
+                wals,
+                current_wal_segment=current_wal_segment,
+                current_timeline=current_timeline,
+            )
+        assert "Unexpected file %s found in WAL archive" % wals[1] == str(exc.value)


### PR DESCRIPTION
Adds commands to barman and barman cloud which check that a barman server
or cloud location is safe to use as an archive destination for a new
PostgreSQL server.

A location is considered safe if either:

1. There are no WAL files at all in the archive.
2. Any existing WAL files meet one of the following criteria:
  a. They belong to an older timeline than that specified by the
     current_timeline argument.
  b. They are on the same timeline as the current_timeline argument but
     the segment is less than that specified in the current_wal_segment
     argument.

A file is considered a WAL file if it passes the `is_any_xlog_file` check
in `barman/xlog.py` so this applies to WAL files, history files, partial
WAL files and backup labels.

The commands added are:

* barman check-wal-archive
* barman-cloud-check-wal-archive

The motivation for this patch is to provide a way that external
orchestration tools can validate the WAL archive destination is safe for
a newly provisioned PostgreSQL cluster, given such a cluster may use the
exact same name as an old cluster.

In such scenarios, any WAL files which have a higher timeline or segment
than the WALs being written by the new cluster will cause any attempt to
restore from a backup to fail.

Reasons why external orchestration tooling may re-use the same cluster
name and archive destination include (but are not limited to):

* A new cluster is created via initdb with the same name as the old one.
  The sysid will be different but this does not affect the archive
  destination so any archived WALs relating to the older cluster will be
  present in the same location.
* A cluster is restored from a base backup and uses the same name as the
  old cluster. The cluster has the same sysid and starts with a segment
  ID > 1 and timeline > 1. The same archive destination used by the old
  cluster will be used for the restored cluster.
* A new cluster is started which happens to re-use the same name and
  archive destination.

All of these cases lead to the situation where WAL archiving and backup
is functioning normally *but* any attempts to restore from those backups
will fail. This is dangerous for anyone relying on the databases managed
by external orchestration/automation.

The commands provided by this patch do not solve the problem alone
because neither Barman nor PostgreSQL have the necessary context. The
commands can, however, be added to external automation in order to
catch archive safety issues at the provisioning stage.

Closes #432