### PR TITLE
Clarify bandwidth_limit units in barman.conf docs

### DIFF
--- a/doc/barman.conf
+++ b/doc/barman.conf
@@ -50,7 +50,7 @@ log_level = INFO
 ;post_wal_delete_retry_script = env | grep ^BARMAN
 ;post_wal_delete_script = env | grep ^BARMAN
 
-; Global bandwidth limit in KBPS - default 0 (meaning no limit)
+; Global bandwidth limit in kilobytes per second - default 0 (meaning no limit)
 ;bandwidth_limit = 4000
 
 ; Number of parallel jobs for backup and recovery via rsync (default 1)


### PR DESCRIPTION
Make it explicit that bandwidth_limit units are kilobytes per second in
barman.conf documentation.

Closes #440