### PR TITLE
Add Barman Cloud option for specifying Azure credential

### DIFF
--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
-import argparse
 import logging
 import os
 import re
@@ -24,7 +23,7 @@ import tempfile
 from contextlib import closing
 from shutil import rmtree
 
-import barman
+from barman.clients.cloud_cli import create_argument_parser, UrlArgumentType
 from barman.cloud import (
     CloudBackupUploaderBarman,
     CloudBackupUploaderPostgres,
@@ -194,39 +193,12 @@ def parse_arguments(args=None):
     :return: The options parsed
     """
 
-    parser = argparse.ArgumentParser(
+    parser, s3_arguments, azure_arguments = create_argument_parser(
         description="This script can be used to perform a backup "
         "of a local PostgreSQL instance and ship "
         "the resulting tarball(s) to the Cloud. "
         "Currently AWS S3 and Azure Blob Storage are supported.",
-        add_help=False,
-    )
-    parser.add_argument(
-        "destination_url",
-        help="URL of the cloud destination, such as a bucket in AWS S3."
-        " For example: `s3://bucket/path/to/folder`.",
-    )
-    parser.add_argument(
-        "server_name", help="the name of the server as configured in Barman."
-    )
-    parser.add_argument(
-        "-V", "--version", action="version", version="%%(prog)s %s" % barman.__version__
-    )
-    parser.add_argument("--help", action="help", help="show this help message and exit")
-    verbosity = parser.add_mutually_exclusive_group()
-    verbosity.add_argument(
-        "-v",
-        "--verbose",
-        action="count",
-        default=0,
-        help="increase output verbosity (e.g., -vv is more than -v)",
-    )
-    verbosity.add_argument(
-        "-q",
-        "--quiet",
-        action="count",
-        default=0,
-        help="decrease output verbosity (e.g., -qq is less than -q)",
+        source_or_destination=UrlArgumentType.destination,
     )
     compression = parser.add_mutually_exclusive_group()
     compression.add_argument(
@@ -244,13 +216,6 @@ def parse_arguments(args=None):
         action="store_const",
         const="bz2",
         dest="compression",
-    )
-    parser.add_argument(
-        "-t",
-        "--test",
-        help="Test cloud connectivity and exit",
-        action="store_true",
-        default=False,
     )
     parser.add_argument(
         "-h",
@@ -289,22 +254,10 @@ def parse_arguments(args=None):
         default="100GB",
     )
     parser.add_argument(
-        "--cloud-provider",
-        help="The cloud provider to use as a storage backend",
-        choices=["aws-s3", "azure-blob-storage"],
-        default="aws-s3",
-    )
-    s3_arguments = parser.add_argument_group(
-        "Extra options for the aws-s3 cloud provider"
-    )
-    s3_arguments.add_argument(
-        "--endpoint-url",
-        help="Override default S3 endpoint URL with the given one",
-    )
-    s3_arguments.add_argument(
-        "-P",
-        "--profile",
-        help="profile name (e.g. INI section in AWS credentials file)",
+        "-d",
+        "--dbname",
+        help="Database name or conninfo string for Postgres connection (default: postgres)",
+        default="postgres",
     )
     s3_arguments.add_argument(
         "-e",
@@ -312,24 +265,6 @@ def parse_arguments(args=None):
         help="The encryption algorithm used when storing the uploaded data in S3. "
         "Allowed values: 'AES256'|'aws:kms'.",
         choices=["AES256", "aws:kms"],
-    )
-    parser.add_argument(
-        "-d",
-        "--dbname",
-        help="Database name or conninfo string for Postgres connection (default: postgres)",
-        default="postgres",
-    )
-    azure_arguments = parser.add_argument_group(
-        "Extra options for the azure-blob-storage cloud provider"
-    )
-    azure_arguments.add_argument(
-        "--credential",
-        choices=["azure-cli", "managed-identity"],
-        help="Optionally specify the type of credential to use when "
-        "authenticating with Azure Blob Storage. If omitted then "
-        "the credential will be obtained from the environment. If no "
-        "credentials can be found in the environment then the default "
-        "Azure authentication flow will be used",
     )
     azure_arguments.add_argument(
         "--encryption-scope",

--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -323,6 +323,15 @@ def parse_arguments(args=None):
         "Extra options for the azure-blob-storage cloud provider"
     )
     azure_arguments.add_argument(
+        "--credential",
+        choices=["azure-cli", "managed-identity"],
+        help="Optionally specify the type of credential to use when "
+        "authenticating with Azure Blob Storage. If omitted then "
+        "the credential will be obtained from the environment. If no "
+        "credentials can be found in the environment then the default "
+        "Azure authentication flow will be used",
+    )
+    azure_arguments.add_argument(
         "--encryption-scope",
         help="The name of an encryption scope defined in the Azure Blob Storage "
         "service which is to be used to encrypt the data in Azure",

--- a/barman/clients/cloud_backup_delete.py
+++ b/barman/clients/cloud_backup_delete.py
@@ -16,14 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
-import argparse
 import logging
 import os
 from contextlib import closing
 from operator import attrgetter
 
-import barman
 from barman.backup import BackupManager
+from barman.clients.cloud_cli import create_argument_parser
 from barman.cloud import CloudBackupCatalog, configure_logging
 from barman.cloud_providers import get_cloud_interface
 from barman.retention_policies import RetentionPolicyFactory
@@ -286,19 +285,10 @@ def parse_arguments(args=None):
 
     :return: The options parsed
     """
-    parser = argparse.ArgumentParser(
+    parser, _, _ = create_argument_parser(
         description="This script can be used to delete backups "
         "made with barman-cloud-backup command. "
         "Currently AWS S3 and Azure Blob Storage are supported.",
-        add_help=False,
-    )
-    parser.add_argument(
-        "source_url",
-        help="URL of the cloud source, such as a bucket in AWS S3."
-        " For example: `s3://bucket/path/to/folder`.",
-    )
-    parser.add_argument(
-        "server_name", help="the name of the server as configured in Barman."
     )
     delete_arguments = parser.add_mutually_exclusive_group(required=True)
     delete_arguments.add_argument(
@@ -317,62 +307,6 @@ def parse_arguments(args=None):
         "--dry-run",
         action="store_true",
         help="Find the objects which need to be deleted but do not delete them",
-    )
-    parser.add_argument(
-        "-V", "--version", action="version", version="%%(prog)s %s" % barman.__version__
-    )
-    parser.add_argument("--help", action="help", help="show this help message and exit")
-    verbosity = parser.add_mutually_exclusive_group()
-    verbosity.add_argument(
-        "-v",
-        "--verbose",
-        action="count",
-        default=0,
-        help="increase output verbosity (e.g., -vv is more than -v)",
-    )
-    verbosity.add_argument(
-        "-q",
-        "--quiet",
-        action="count",
-        default=0,
-        help="decrease output verbosity (e.g., -qq is less than -q)",
-    )
-    parser.add_argument(
-        "-t",
-        "--test",
-        help="Test cloud connectivity and exit",
-        action="store_true",
-        default=False,
-    )
-    parser.add_argument(
-        "--cloud-provider",
-        help="The cloud provider to use as a storage backend",
-        choices=["aws-s3", "azure-blob-storage"],
-        default="aws-s3",
-    )
-    s3_arguments = parser.add_argument_group(
-        "Extra options for the aws-s3 cloud provider"
-    )
-    s3_arguments.add_argument(
-        "--endpoint-url",
-        help="Override default S3 endpoint URL with the given one",
-    )
-    s3_arguments.add_argument(
-        "-P",
-        "--profile",
-        help="profile name (e.g. INI section in AWS credentials file)",
-    )
-    azure_arguments = parser.add_argument_group(
-        "Extra options for the azure-blob-storage cloud provider"
-    )
-    azure_arguments.add_argument(
-        "--credential",
-        choices=["azure-cli", "managed-identity"],
-        help="Optionally specify the type of credential to use when "
-        "authenticating with Azure Blob Storage. If omitted then "
-        "the credential will be obtained from the environment. If no "
-        "credentials can be found in the environment then the default "
-        "Azure authentication flow will be used",
     )
     return parser.parse_args(args=args)
 

--- a/barman/clients/cloud_backup_delete.py
+++ b/barman/clients/cloud_backup_delete.py
@@ -362,6 +362,18 @@ def parse_arguments(args=None):
         "--profile",
         help="profile name (e.g. INI section in AWS credentials file)",
     )
+    azure_arguments = parser.add_argument_group(
+        "Extra options for the azure-blob-storage cloud provider"
+    )
+    azure_arguments.add_argument(
+        "--credential",
+        choices=["azure-cli", "managed-identity"],
+        help="Optionally specify the type of credential to use when "
+        "authenticating with Azure Blob Storage. If omitted then "
+        "the credential will be obtained from the environment. If no "
+        "credentials can be found in the environment then the default "
+        "Azure authentication flow will be used",
+    )
     return parser.parse_args(args=args)
 
 

--- a/barman/clients/cloud_backup_keep.py
+++ b/barman/clients/cloud_backup_keep.py
@@ -165,6 +165,18 @@ def parse_arguments(args=None):
         "--profile",
         help="profile name (e.g. INI section in AWS credentials file)",
     )
+    azure_arguments = parser.add_argument_group(
+        "Extra options for the azure-blob-storage cloud provider"
+    )
+    azure_arguments.add_argument(
+        "--credential",
+        choices=["azure-cli", "managed-identity"],
+        help="Optionally specify the type of credential to use when "
+        "authenticating with Azure Blob Storage. If omitted then "
+        "the credential will be obtained from the environment. If no "
+        "credentials can be found in the environment then the default "
+        "Azure authentication flow will be used",
+    )
     return parser.parse_args(args=args)
 
 

--- a/barman/clients/cloud_backup_keep.py
+++ b/barman/clients/cloud_backup_keep.py
@@ -16,12 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
-import argparse
 import logging
 from contextlib import closing
 
-import barman
 from barman.annotations import KeepManager
+from barman.clients.cloud_cli import create_argument_parser
 from barman.cloud import CloudBackupCatalog, configure_logging
 from barman.cloud_providers import get_cloud_interface
 from barman.infofile import BackupInfo
@@ -84,19 +83,10 @@ def parse_arguments(args=None):
     Parse command line arguments
     :return: The options parsed
     """
-    parser = argparse.ArgumentParser(
-        description="This script can be used to delete backups "
-        "made with barman-cloud-backup command. "
+    parser, _, _ = create_argument_parser(
+        description="This script can be used to tag backups in cloud storage as "
+        "archival backups such that they will not be deleted. "
         "Currently AWS S3 and Azure Blob Storage are supported.",
-        add_help=False,
-    )
-    parser.add_argument(
-        "source_url",
-        help="URL of the cloud source, such as a bucket in AWS S3."
-        " For example: `s3://bucket/path/to/folder`.",
-    )
-    parser.add_argument(
-        "server_name", help="the name of the server as configured in Barman."
     )
     parser.add_argument(
         "backup_id",
@@ -120,62 +110,6 @@ def parse_arguments(args=None):
         "--target",
         help="Specify the recovery target for this backup",
         choices=[KeepManager.TARGET_FULL, KeepManager.TARGET_STANDALONE],
-    )
-    parser.add_argument(
-        "-V", "--version", action="version", version="%%(prog)s %s" % barman.__version__
-    )
-    parser.add_argument("--help", action="help", help="show this help message and exit")
-    verbosity = parser.add_mutually_exclusive_group()
-    verbosity.add_argument(
-        "-v",
-        "--verbose",
-        action="count",
-        default=0,
-        help="increase output verbosity (e.g., -vv is more than -v)",
-    )
-    verbosity.add_argument(
-        "-q",
-        "--quiet",
-        action="count",
-        default=0,
-        help="decrease output verbosity (e.g., -qq is less than -q)",
-    )
-    parser.add_argument(
-        "-t",
-        "--test",
-        help="Test cloud connectivity and exit",
-        action="store_true",
-        default=False,
-    )
-    parser.add_argument(
-        "--cloud-provider",
-        help="The cloud provider to use as a storage backend",
-        choices=["aws-s3", "azure-blob-storage"],
-        default="aws-s3",
-    )
-    s3_arguments = parser.add_argument_group(
-        "Extra options for the aws-s3 cloud provider"
-    )
-    s3_arguments.add_argument(
-        "--endpoint-url",
-        help="Override default S3 endpoint URL with the given one",
-    )
-    s3_arguments.add_argument(
-        "-P",
-        "--profile",
-        help="profile name (e.g. INI section in AWS credentials file)",
-    )
-    azure_arguments = parser.add_argument_group(
-        "Extra options for the azure-blob-storage cloud provider"
-    )
-    azure_arguments.add_argument(
-        "--credential",
-        choices=["azure-cli", "managed-identity"],
-        help="Optionally specify the type of credential to use when "
-        "authenticating with Azure Blob Storage. If omitted then "
-        "the credential will be obtained from the environment. If no "
-        "credentials can be found in the environment then the default "
-        "Azure authentication flow will be used",
     )
     return parser.parse_args(args=args)
 

--- a/barman/clients/cloud_backup_list.py
+++ b/barman/clients/cloud_backup_list.py
@@ -170,6 +170,18 @@ def parse_arguments(args=None):
         "--profile",
         help="profile name (e.g. INI section in AWS credentials file)",
     )
+    azure_arguments = parser.add_argument_group(
+        "Extra options for the azure-blob-storage cloud provider"
+    )
+    azure_arguments.add_argument(
+        "--credential",
+        choices=["azure-cli", "managed-identity"],
+        help="Optionally specify the type of credential to use when "
+        "authenticating with Azure Blob Storage. If omitted then "
+        "the credential will be obtained from the environment. If no "
+        "credentials can be found in the environment then the default "
+        "Azure authentication flow will be used",
+    )
     return parser.parse_args(args=args)
 
 

--- a/barman/clients/cloud_backup_list.py
+++ b/barman/clients/cloud_backup_list.py
@@ -16,12 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
-import argparse
 import json
 import logging
 from contextlib import closing
 
-import barman
+from barman.clients.cloud_cli import create_argument_parser
 from barman.cloud import CloudBackupCatalog, configure_logging
 from barman.cloud_providers import get_cloud_interface
 from barman.infofile import BackupInfo
@@ -106,81 +105,16 @@ def parse_arguments(args=None):
     :return: The options parsed
     """
 
-    parser = argparse.ArgumentParser(
+    parser, _, _ = create_argument_parser(
         description="This script can be used to list backups "
         "made with barman-cloud-backup command. "
         "Currently AWS S3 and Azure Blob Storage are supported.",
-        add_help=False,
     )
 
-    parser.add_argument(
-        "source_url",
-        help="URL of the cloud source, such as a bucket in AWS S3."
-        " For example: `s3://bucket/path/to/folder`.",
-    )
-    parser.add_argument(
-        "server_name", help="the name of the server as configured in Barman."
-    )
-    parser.add_argument(
-        "-V", "--version", action="version", version="%%(prog)s %s" % barman.__version__
-    )
-    parser.add_argument("--help", action="help", help="show this help message and exit")
-    verbosity = parser.add_mutually_exclusive_group()
-    verbosity.add_argument(
-        "-v",
-        "--verbose",
-        action="count",
-        default=0,
-        help="increase output verbosity (e.g., -vv is more than -v)",
-    )
-    verbosity.add_argument(
-        "-q",
-        "--quiet",
-        action="count",
-        default=0,
-        help="decrease output verbosity (e.g., -qq is less than -q)",
-    )
-    parser.add_argument(
-        "-t",
-        "--test",
-        help="Test cloud connectivity and exit",
-        action="store_true",
-        default=False,
-    )
     parser.add_argument(
         "--format",
         default="console",
         help="Output format (console or json). Default console.",
-    )
-    parser.add_argument(
-        "--cloud-provider",
-        help="The cloud provider to use as a storage backend",
-        choices=["aws-s3", "azure-blob-storage"],
-        default="aws-s3",
-    )
-    s3_arguments = parser.add_argument_group(
-        "Extra options for the aws-s3 cloud provider"
-    )
-    s3_arguments.add_argument(
-        "--endpoint-url",
-        help="Override default S3 endpoint URL with the given one",
-    )
-    s3_arguments.add_argument(
-        "-P",
-        "--profile",
-        help="profile name (e.g. INI section in AWS credentials file)",
-    )
-    azure_arguments = parser.add_argument_group(
-        "Extra options for the azure-blob-storage cloud provider"
-    )
-    azure_arguments.add_argument(
-        "--credential",
-        choices=["azure-cli", "managed-identity"],
-        help="Optionally specify the type of credential to use when "
-        "authenticating with Azure Blob Storage. If omitted then "
-        "the credential will be obtained from the environment. If no "
-        "credentials can be found in the environment then the default "
-        "Azure authentication flow will be used",
     )
     return parser.parse_args(args=args)
 

--- a/barman/clients/cloud_check_wal_archive.py
+++ b/barman/clients/cloud_check_wal_archive.py
@@ -127,6 +127,18 @@ def parse_arguments(args=None):
         "--profile",
         help="profile name (e.g. INI section in AWS credentials file)",
     )
+    azure_arguments = parser.add_argument_group(
+        "Extra options for the azure-blob-storage cloud provider"
+    )
+    azure_arguments.add_argument(
+        "--credential",
+        choices=["azure-cli", "managed-identity"],
+        help="Optionally specify the type of credential to use when "
+        "authenticating with Azure Blob Storage. If omitted then "
+        "the credential will be obtained from the environment. If no "
+        "credentials can be found in the environment then the default "
+        "Azure authentication flow will be used",
+    )
     return parser.parse_args(args=args)
 
 

--- a/barman/clients/cloud_check_wal_archive.py
+++ b/barman/clients/cloud_check_wal_archive.py
@@ -16,10 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
-import argparse
 import logging
 
-import barman
+from barman.clients.cloud_cli import create_argument_parser, UrlArgumentType
 from barman.cloud import configure_logging, CloudBackupCatalog
 from barman.cloud_providers import get_cloud_interface
 from barman.exceptions import WalArchiveContentError
@@ -65,79 +64,15 @@ def parse_arguments(args=None):
     :return: The options parsed
     """
 
-    parser = argparse.ArgumentParser(
+    parser, _, _ = create_argument_parser(
         description="Checks that the WAL archive on the specified cloud storage "
         "can be safely used for a new PostgreSQL server.",
-        add_help=False,
-    )
-    parser.add_argument(
-        "destination_url",
-        help="URL of the cloud destination, such as a bucket in AWS S3."
-        " For example: `s3://bucket/path/to/folder`.",
-    )
-    parser.add_argument(
-        "server_name", help="the name of the server as configured in Barman."
-    )
-    parser.add_argument(
-        "-V", "--version", action="version", version="%%(prog)s %s" % barman.__version__
-    )
-    parser.add_argument("--help", action="help", help="show this help message and exit")
-    verbosity = parser.add_mutually_exclusive_group()
-    verbosity.add_argument(
-        "-v",
-        "--verbose",
-        action="count",
-        default=0,
-        help="increase output verbosity (e.g., -vv is more than -v)",
-    )
-    verbosity.add_argument(
-        "-q",
-        "--quiet",
-        action="count",
-        default=0,
-        help="decrease output verbosity (e.g., -qq is less than -q)",
-    )
-    parser.add_argument(
-        "-t",
-        "--test",
-        help="Test cloud connectivity and exit",
-        action="store_true",
-        default=False,
+        source_or_destination=UrlArgumentType.destination,
     )
     parser.add_argument(
         "--timeline",
         help="The earliest timeline whose WALs should cause the check to fail",
         type=check_positive,
-    )
-    parser.add_argument(
-        "--cloud-provider",
-        help="The cloud provider to use as a storage backend",
-        choices=["aws-s3", "azure-blob-storage"],
-        default="aws-s3",
-    )
-    s3_arguments = parser.add_argument_group(
-        "Extra options for the aws-s3 cloud provider"
-    )
-    s3_arguments.add_argument(
-        "--endpoint-url",
-        help="Override default S3 endpoint URL with the given one",
-    )
-    s3_arguments.add_argument(
-        "-P",
-        "--profile",
-        help="profile name (e.g. INI section in AWS credentials file)",
-    )
-    azure_arguments = parser.add_argument_group(
-        "Extra options for the azure-blob-storage cloud provider"
-    )
-    azure_arguments.add_argument(
-        "--credential",
-        choices=["azure-cli", "managed-identity"],
-        help="Optionally specify the type of credential to use when "
-        "authenticating with Azure Blob Storage. If omitted then "
-        "the credential will be obtained from the environment. If no "
-        "credentials can be found in the environment then the default "
-        "Azure authentication flow will be used",
     )
     return parser.parse_args(args=args)
 

--- a/barman/clients/cloud_cli.py
+++ b/barman/clients/cloud_cli.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+# © Copyright EnterpriseDB UK Limited 2018-2021
+#
+# This file is part of Barman.
+#
+# Barman is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Barman is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Barman.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+
+from enum import Enum
+
+import barman
+
+
+class UrlArgumentType(Enum):
+    source = "source"
+    destination = "destination"
+
+
+def create_argument_parser(description, source_or_destination=UrlArgumentType.source):
+    """
+    Create a barman-cloud argument parser with the given description.
+
+    Returns an `argparse.ArgumentParser` object which parses the core arguments
+    and options for barman-cloud commands.
+    """
+    parser = argparse.ArgumentParser(
+        description=description,
+        add_help=False,
+    )
+    parser.add_argument(
+        "%s_url" % source_or_destination.value,
+        help=(
+            "URL of the cloud %s, such as a bucket in AWS S3."
+            " For example: `s3://bucket/path/to/folder`."
+        )
+        % source_or_destination.value,
+    )
+    parser.add_argument(
+        "server_name", help="the name of the server as configured in Barman."
+    )
+    parser.add_argument(
+        "-V", "--version", action="version", version="%%(prog)s %s" % barman.__version__
+    )
+    parser.add_argument("--help", action="help", help="show this help message and exit")
+    verbosity = parser.add_mutually_exclusive_group()
+    verbosity.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="increase output verbosity (e.g., -vv is more than -v)",
+    )
+    verbosity.add_argument(
+        "-q",
+        "--quiet",
+        action="count",
+        default=0,
+        help="decrease output verbosity (e.g., -qq is less than -q)",
+    )
+    parser.add_argument(
+        "-t",
+        "--test",
+        help="Test cloud connectivity and exit",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--cloud-provider",
+        help="The cloud provider to use as a storage backend",
+        choices=["aws-s3", "azure-blob-storage"],
+        default="aws-s3",
+    )
+    s3_arguments = parser.add_argument_group(
+        "Extra options for the aws-s3 cloud provider"
+    )
+    s3_arguments.add_argument(
+        "--endpoint-url",
+        help="Override default S3 endpoint URL with the given one",
+    )
+    s3_arguments.add_argument(
+        "-P",
+        "--profile",
+        help="profile name (e.g. INI section in AWS credentials file)",
+    )
+    azure_arguments = parser.add_argument_group(
+        "Extra options for the azure-blob-storage cloud provider"
+    )
+    azure_arguments.add_argument(
+        "--credential",
+        choices=["azure-cli", "managed-identity"],
+        help="Optionally specify the type of credential to use when "
+        "authenticating with Azure Blob Storage. If omitted then "
+        "the credential will be obtained from the environment. If no "
+        "credentials can be found in the environment then the default "
+        "Azure authentication flow will be used",
+    )
+    return parser, s3_arguments, azure_arguments
+
+
+azure = [
+    (
+        "--credential",
+        {
+            "choices": ["azure-cli", "managed-identity"],
+            "help": (
+                "Optionally specify the type of credential to use when "
+                "authenticating with Azure Blob Storage. If omitted then "
+                "the credential will be obtained from the environment. If no "
+                "credentials can be found in the environment then the default "
+                "Azure authentication flow will be used"
+            ),
+        },
+    ),
+]

--- a/barman/clients/cloud_restore.py
+++ b/barman/clients/cloud_restore.py
@@ -152,6 +152,18 @@ def parse_arguments(args=None):
         "--profile",
         help="profile name (e.g. INI section in AWS credentials file)",
     )
+    azure_arguments = parser.add_argument_group(
+        "Extra options for the azure-blob-storage cloud provider"
+    )
+    azure_arguments.add_argument(
+        "--credential",
+        choices=["azure-cli", "managed-identity"],
+        help="Optionally specify the type of credential to use when "
+        "authenticating with Azure Blob Storage. If omitted then "
+        "the credential will be obtained from the environment. If no "
+        "credentials can be found in the environment then the default "
+        "Azure authentication flow will be used",
+    )
     return parser.parse_args(args=args)
 
 

--- a/barman/clients/cloud_restore.py
+++ b/barman/clients/cloud_restore.py
@@ -15,12 +15,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
-import argparse
 import logging
 import os
 from contextlib import closing
 
-import barman
+from barman.clients.cloud_cli import create_argument_parser
 from barman.cloud import CloudBackupCatalog, configure_logging
 from barman.cloud_providers import get_cloud_interface
 from barman.utils import force_str
@@ -84,85 +83,19 @@ def parse_arguments(args=None):
     :return: The options parsed
     """
 
-    parser = argparse.ArgumentParser(
+    parser, _, _ = create_argument_parser(
         description="This script can be used to download a backup "
         "previously made with barman-cloud-backup command."
         "Currently AWS S3 and Azure Blob Storage are supported.",
-        add_help=False,
-    )
-
-    parser.add_argument(
-        "source_url",
-        help="URL of the cloud source, such as a bucket in AWS S3."
-        " For example: `s3://bucket/path/to/folder`.",
-    )
-    parser.add_argument(
-        "server_name", help="the name of the server as configured in Barman."
     )
     parser.add_argument("backup_id", help="the backup ID")
     parser.add_argument("recovery_dir", help="the path to a directory for recovery.")
-    parser.add_argument(
-        "-V", "--version", action="version", version="%%(prog)s %s" % barman.__version__
-    )
-    parser.add_argument("--help", action="help", help="show this help message and exit")
-    verbosity = parser.add_mutually_exclusive_group()
-    verbosity.add_argument(
-        "-v",
-        "--verbose",
-        action="count",
-        default=0,
-        help="increase output verbosity (e.g., -vv is more than -v)",
-    )
-    verbosity.add_argument(
-        "-q",
-        "--quiet",
-        action="count",
-        default=0,
-        help="decrease output verbosity (e.g., -qq is less than -q)",
-    )
-    parser.add_argument(
-        "-t",
-        "--test",
-        help="Test cloud connectivity and exit",
-        action="store_true",
-        default=False,
-    )
     parser.add_argument(
         "--tablespace",
         help="tablespace relocation rule",
         metavar="NAME:LOCATION",
         action="append",
         default=[],
-    )
-    parser.add_argument(
-        "--cloud-provider",
-        help="The cloud provider to use as a storage backend",
-        choices=["aws-s3", "azure-blob-storage"],
-        default="aws-s3",
-    )
-    s3_arguments = parser.add_argument_group(
-        "Extra options for the aws-s3 cloud provider"
-    )
-    s3_arguments.add_argument(
-        "--endpoint-url",
-        help="Override default S3 endpoint URL with the given one",
-    )
-    s3_arguments.add_argument(
-        "-P",
-        "--profile",
-        help="profile name (e.g. INI section in AWS credentials file)",
-    )
-    azure_arguments = parser.add_argument_group(
-        "Extra options for the azure-blob-storage cloud provider"
-    )
-    azure_arguments.add_argument(
-        "--credential",
-        choices=["azure-cli", "managed-identity"],
-        help="Optionally specify the type of credential to use when "
-        "authenticating with Azure Blob Storage. If omitted then "
-        "the credential will be obtained from the environment. If no "
-        "credentials can be found in the environment then the default "
-        "Azure authentication flow will be used",
     )
     return parser.parse_args(args=args)
 

--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
-import argparse
 import bz2
 import gzip
 import logging
@@ -26,7 +25,7 @@ import shutil
 from contextlib import closing
 from io import BytesIO
 
-import barman
+from barman.clients.cloud_cli import create_argument_parser, UrlArgumentType
 from barman.cloud import configure_logging
 from barman.cloud_providers import get_cloud_interface
 from barman.exceptions import BarmanException
@@ -108,44 +107,17 @@ def parse_arguments(args=None):
     :return: The options parsed
     """
 
-    parser = argparse.ArgumentParser(
+    parser, s3_arguments, azure_arguments = create_argument_parser(
         description="This script can be used in the `archive_command` "
         "of a PostgreSQL server to ship WAL files to the Cloud. "
         "Currently AWS S3 and Azure Blob Storage are supported.",
-        add_help=False,
-    )
-    parser.add_argument(
-        "destination_url",
-        help="URL of the cloud destination, such as a bucket in AWS S3."
-        " For example: `s3://bucket/path/to/folder`.",
-    )
-    parser.add_argument(
-        "server_name", help="the name of the server as configured in Barman."
+        source_or_destination=UrlArgumentType.destination,
     )
     parser.add_argument(
         "wal_path",
         nargs="?",
         help="the value of the '%%p' keyword (according to 'archive_command').",
         default=None,
-    )
-    parser.add_argument(
-        "-V", "--version", action="version", version="%%(prog)s %s" % barman.__version__
-    )
-    parser.add_argument("--help", action="help", help="show this help message and exit")
-    verbosity = parser.add_mutually_exclusive_group()
-    verbosity.add_argument(
-        "-v",
-        "--verbose",
-        action="count",
-        default=0,
-        help="increase output verbosity (e.g., -vv is more than -v)",
-    )
-    verbosity.add_argument(
-        "-q",
-        "--quiet",
-        action="count",
-        default=0,
-        help="decrease output verbosity (e.g., -qq is less than -q)",
     )
     compression = parser.add_mutually_exclusive_group()
     compression.add_argument(
@@ -166,31 +138,6 @@ def parse_arguments(args=None):
         const="bzip2",
         dest="compression",
     )
-    parser.add_argument(
-        "-t",
-        "--test",
-        help="Test cloud connectivity and exit",
-        action="store_true",
-        default=False,
-    )
-    parser.add_argument(
-        "--cloud-provider",
-        help="The cloud provider to use as a storage backend",
-        choices=["aws-s3", "azure-blob-storage"],
-        default="aws-s3",
-    )
-    s3_arguments = parser.add_argument_group(
-        "Extra options for the aws-s3 cloud provider"
-    )
-    s3_arguments.add_argument(
-        "--endpoint-url",
-        help="Override default S3 endpoint URL with the given one",
-    )
-    s3_arguments.add_argument(
-        "-P",
-        "--profile",
-        help="profile name (e.g. INI section in AWS credentials file)",
-    )
     s3_arguments.add_argument(
         "-e",
         "--encryption",
@@ -198,18 +145,6 @@ def parse_arguments(args=None):
         "Allowed values: 'AES256'|'aws:kms'.",
         choices=["AES256", "aws:kms"],
         metavar="ENCRYPTION",
-    )
-    azure_arguments = parser.add_argument_group(
-        "Extra options for the azure-blob-storage cloud provider"
-    )
-    azure_arguments.add_argument(
-        "--credential",
-        choices=["azure-cli", "managed-identity"],
-        help="Optionally specify the type of credential to use when "
-        "authenticating with Azure Blob Storage. If omitted then "
-        "the credential will be obtained from the environment. If no "
-        "credentials can be found in the environment then the default "
-        "Azure authentication flow will be used",
     )
     azure_arguments.add_argument(
         "--encryption-scope",

--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -203,6 +203,15 @@ def parse_arguments(args=None):
         "Extra options for the azure-blob-storage cloud provider"
     )
     azure_arguments.add_argument(
+        "--credential",
+        choices=["azure-cli", "managed-identity"],
+        help="Optionally specify the type of credential to use when "
+        "authenticating with Azure Blob Storage. If omitted then "
+        "the credential will be obtained from the environment. If no "
+        "credentials can be found in the environment then the default "
+        "Azure authentication flow will be used",
+    )
+    azure_arguments.add_argument(
         "--encryption-scope",
         help="The name of an encryption scope defined in the Azure Blob Storage "
         "service which is to be used to encrypt the data in Azure",

--- a/barman/clients/cloud_walrestore.py
+++ b/barman/clients/cloud_walrestore.py
@@ -146,6 +146,18 @@ def parse_arguments(args=None):
         "--profile",
         help="profile name (e.g. INI section in AWS credentials file)",
     )
+    azure_arguments = parser.add_argument_group(
+        "Extra options for the azure-blob-storage cloud provider"
+    )
+    azure_arguments.add_argument(
+        "--credential",
+        choices=["azure-cli", "managed-identity"],
+        help="Optionally specify the type of credential to use when "
+        "authenticating with Azure Blob Storage. If omitted then "
+        "the credential will be obtained from the environment. If no "
+        "credentials can be found in the environment then the default "
+        "Azure authentication flow will be used",
+    )
     return parser.parse_args(args=args)
 
 

--- a/barman/clients/cloud_walrestore.py
+++ b/barman/clients/cloud_walrestore.py
@@ -16,13 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
-import argparse
 import logging
 import os
 import sys
 from contextlib import closing
 
-import barman
+from barman.clients.cloud_cli import create_argument_parser
 from barman.cloud import configure_logging, ALLOWED_COMPRESSIONS
 from barman.cloud_providers import get_cloud_interface
 from barman.exceptions import BarmanException
@@ -78,22 +77,13 @@ def parse_arguments(args=None):
     :return: The options parsed
     """
 
-    parser = argparse.ArgumentParser(
+    parser, _, _ = create_argument_parser(
         description="This script can be used as a `restore_command` "
         "to download WAL files previously archived with "
         "barman-cloud-wal-archive command. "
         "Currently AWS S3 and Azure Blob Storage are supported.",
-        add_help=False,
     )
 
-    parser.add_argument(
-        "source_url",
-        help="URL of the cloud source, such as a bucket in AWS S3."
-        " For example: `s3://bucket/path/to/folder`.",
-    )
-    parser.add_argument(
-        "server_name", help="the name of the server as configured in Barman."
-    )
     parser.add_argument(
         "wal_name",
         help="The value of the '%%f' keyword (according to 'restore_command').",
@@ -101,62 +91,6 @@ def parse_arguments(args=None):
     parser.add_argument(
         "wal_dest",
         help="The value of the '%%p' keyword (according to 'restore_command').",
-    )
-    parser.add_argument(
-        "-V", "--version", action="version", version="%%(prog)s %s" % barman.__version__
-    )
-    parser.add_argument("--help", action="help", help="show this help message and exit")
-    verbosity = parser.add_mutually_exclusive_group()
-    verbosity.add_argument(
-        "-v",
-        "--verbose",
-        action="count",
-        default=0,
-        help="increase output verbosity (e.g., -vv is more than -v)",
-    )
-    verbosity.add_argument(
-        "-q",
-        "--quiet",
-        action="count",
-        default=0,
-        help="decrease output verbosity (e.g., -qq is less than -q)",
-    )
-    parser.add_argument(
-        "-t",
-        "--test",
-        help="Test cloud connectivity and exit",
-        action="store_true",
-        default=False,
-    )
-    parser.add_argument(
-        "--cloud-provider",
-        help="The cloud provider to use as a storage backend",
-        choices=["aws-s3", "azure-blob-storage"],
-        default="aws-s3",
-    )
-    s3_arguments = parser.add_argument_group(
-        "Extra options for the aws-s3 cloud provider"
-    )
-    s3_arguments.add_argument(
-        "--endpoint-url",
-        help="Override default S3 endpoint URL with the given one",
-    )
-    s3_arguments.add_argument(
-        "-P",
-        "--profile",
-        help="profile name (e.g. INI section in AWS credentials file)",
-    )
-    azure_arguments = parser.add_argument_group(
-        "Extra options for the azure-blob-storage cloud provider"
-    )
-    azure_arguments.add_argument(
-        "--credential",
-        choices=["azure-cli", "managed-identity"],
-        help="Optionally specify the type of credential to use when "
-        "authenticating with Azure Blob Storage. If omitted then "
-        "the credential will be obtained from the environment. If no "
-        "credentials can be found in the environment then the default "
-        "Azure authentication flow will be used",
     )
     return parser.parse_args(args=args)
 

--- a/doc/barman-cloud-backup-delete.1
+++ b/doc/barman-cloud-backup-delete.1
@@ -115,6 +115,15 @@ override the default S3 URL construction mechanism by specifying an
 endpoint.
 .RS
 .RE
+.TP
+.B \[en]credential {azure\-cli,managed\-identity}
+optionally specify the type of credential to use when authenticating
+with Azure Blob Storage.
+If omitted then the credential will be obtained from the environment.
+If no credentials can be found in the environment then the default Azure
+authentication flow will be used.
+.RS
+.RE
 .SH REFERENCES
 .PP
 For Boto:

--- a/doc/barman-cloud-backup-delete.1.md
+++ b/doc/barman-cloud-backup-delete.1.md
@@ -89,6 +89,12 @@ SERVER_NAME
 --endpoint-url
 :    override the default S3 URL construction mechanism by specifying an endpoint.
 
+--credential {azure-cli,managed-identity}
+:    optionally specify the type of credential to use when authenticating with
+     Azure Blob Storage. If omitted then the credential will be obtained from the
+     environment. If no credentials can be found in the environment then the default
+     Azure authentication flow will be used.
+
 # REFERENCES
 
 For Boto:

--- a/doc/barman-cloud-backup-keep.1
+++ b/doc/barman-cloud-backup-keep.1
@@ -109,6 +109,15 @@ override the default S3 URL construction mechanism by specifying an
 endpoint.
 .RS
 .RE
+.TP
+.B \[en]credential {azure\-cli,managed\-identity}
+optionally specify the type of credential to use when authenticating
+with Azure Blob Storage.
+If omitted then the credential will be obtained from the environment.
+If no credentials can be found in the environment then the default Azure
+authentication flow will be used.
+.RS
+.RE
 .SH REFERENCES
 .PP
 For Boto:

--- a/doc/barman-cloud-backup-keep.1.md
+++ b/doc/barman-cloud-backup-keep.1.md
@@ -82,6 +82,11 @@ BACKUP_ID
 --endpoint-url
 :    override the default S3 URL construction mechanism by specifying an endpoint.
 
+--credential {azure-cli,managed-identity}
+:    optionally specify the type of credential to use when authenticating with
+     Azure Blob Storage. If omitted then the credential will be obtained from the
+     environment. If no credentials can be found in the environment then the default
+     Azure authentication flow will be used.
 
 # REFERENCES
 

--- a/doc/barman-cloud-backup-list.1
+++ b/doc/barman-cloud-backup-list.1
@@ -77,6 +77,15 @@ override the default S3 URL construction mechanism by specifying an
 endpoint.
 .RS
 .RE
+.TP
+.B \[en]credential {azure\-cli,managed\-identity}
+optionally specify the type of credential to use when authenticating
+with Azure Blob Storage.
+If omitted then the credential will be obtained from the environment.
+If no credentials can be found in the environment then the default Azure
+authentication flow will be used.
+.RS
+.RE
 .SH REFERENCES
 .PP
 For Boto:

--- a/doc/barman-cloud-backup-list.1.md
+++ b/doc/barman-cloud-backup-list.1.md
@@ -61,6 +61,12 @@ SERVER_NAME
 --endpoint-url
 :    override the default S3 URL construction mechanism by specifying an endpoint.
 
+--credential {azure-cli,managed-identity}
+:    optionally specify the type of credential to use when authenticating with
+     Azure Blob Storage. If omitted then the credential will be obtained from the
+     environment. If no credentials can be found in the environment then the default
+     Azure authentication flow will be used.
+
 # REFERENCES
 
 For Boto:

--- a/doc/barman-cloud-backup.1
+++ b/doc/barman-cloud-backup.1
@@ -145,6 +145,15 @@ the name of an encryption scope defined in the Azure Blob Storage
 service which is to be used to encrypt the data in Azure
 .RS
 .RE
+.TP
+.B \[en]credential {azure\-cli,managed\-identity}
+optionally specify the type of credential to use when authenticating
+with Azure Blob Storage.
+If omitted then the credential will be obtained from the environment.
+If no credentials can be found in the environment then the default Azure
+authentication flow will be used.
+.RS
+.RE
 .SH REFERENCES
 .PP
 For Boto:

--- a/doc/barman-cloud-backup.1.md
+++ b/doc/barman-cloud-backup.1.md
@@ -104,6 +104,12 @@ SERVER_NAME
 :    the name of an encryption scope defined in the Azure Blob Storage
      service which is to be used to encrypt the data in Azure
 
+--credential {azure-cli,managed-identity}
+:    optionally specify the type of credential to use when authenticating with
+     Azure Blob Storage. If omitted then the credential will be obtained from the
+     environment. If no credentials can be found in the environment then the default
+     Azure authentication flow will be used.
+
 # REFERENCES
 
 For Boto:

--- a/doc/barman-cloud-check-wal-archive.1
+++ b/doc/barman-cloud-check-wal-archive.1
@@ -84,6 +84,15 @@ override the default S3 URL construction mechanism by specifying an
 endpoint.
 .RS
 .RE
+.TP
+.B \[en]credential {azure\-cli,managed\-identity}
+optionally specify the type of credential to use when authenticating
+with Azure Blob Storage.
+If omitted then the credential will be obtained from the environment.
+If no credentials can be found in the environment then the default Azure
+authentication flow will be used.
+.RS
+.RE
 .SH REFERENCES
 .PP
 For Boto:

--- a/doc/barman-cloud-check-wal-archive.1.md
+++ b/doc/barman-cloud-check-wal-archive.1.md
@@ -65,6 +65,11 @@ SERVER_NAME
 --endpoint-url
 :    override the default S3 URL construction mechanism by specifying an endpoint.
 
+--credential {azure-cli,managed-identity}
+:    optionally specify the type of credential to use when authenticating with
+     Azure Blob Storage. If omitted then the credential will be obtained from the
+     environment. If no credentials can be found in the environment then the default
+     Azure authentication flow will be used.
 
 # REFERENCES
 

--- a/doc/barman-cloud-restore.1
+++ b/doc/barman-cloud-restore.1
@@ -88,6 +88,15 @@ override the default S3 URL construction mechanism by specifying an
 endpoint.
 .RS
 .RE
+.TP
+.B \[en]credential {azure\-cli,managed\-identity}
+optionally specify the type of credential to use when authenticating
+with Azure Blob Storage.
+If omitted then the credential will be obtained from the environment.
+If no credentials can be found in the environment then the default Azure
+authentication flow will be used.
+.RS
+.RE
 .SH REFERENCES
 .PP
 For Boto:

--- a/doc/barman-cloud-restore.1.md
+++ b/doc/barman-cloud-restore.1.md
@@ -68,6 +68,12 @@ original location (you may repeat the option for multiple tablespaces)
 --endpoint-url
 :    override the default S3 URL construction mechanism by specifying an endpoint.
 
+--credential {azure-cli,managed-identity}
+:    optionally specify the type of credential to use when authenticating with
+     Azure Blob Storage. If omitted then the credential will be obtained from the
+     environment. If no credentials can be found in the environment then the default
+     Azure authentication flow will be used.
+
 # REFERENCES
 
 For Boto:

--- a/doc/barman-cloud-wal-archive.1
+++ b/doc/barman-cloud-wal-archive.1
@@ -108,6 +108,15 @@ the name of an encryption scope defined in the Azure Blob Storage
 service which is to be used to encrypt the data in Azure
 .RS
 .RE
+.TP
+.B \[en]credential {azure\-cli,managed\-identity}
+optionally specify the type of credential to use when authenticating
+with Azure Blob Storage.
+If omitted then the credential will be obtained from the environment.
+If no credentials can be found in the environment then the default Azure
+authentication flow will be used.
+.RS
+.RE
 .SH REFERENCES
 .PP
 For Boto:

--- a/doc/barman-cloud-wal-archive.1.md
+++ b/doc/barman-cloud-wal-archive.1.md
@@ -83,6 +83,11 @@ WAL_PATH
 :    the name of an encryption scope defined in the Azure Blob Storage
      service which is to be used to encrypt the data in Azure
 
+--credential {azure-cli,managed-identity}
+:    optionally specify the type of credential to use when authenticating with
+     Azure Blob Storage. If omitted then the credential will be obtained from the
+     environment. If no credentials can be found in the environment then the default
+     Azure authentication flow will be used.
 
 # REFERENCES
 

--- a/doc/barman-cloud-wal-restore.1
+++ b/doc/barman-cloud-wal-restore.1
@@ -85,6 +85,15 @@ override the default S3 URL construction mechanism by specifying an
 endpoint.
 .RS
 .RE
+.TP
+.B \[en]credential {azure\-cli,managed\-identity}
+optionally specify the type of credential to use when authenticating
+with Azure Blob Storage.
+If omitted then the credential will be obtained from the environment.
+If no credentials can be found in the environment then the default Azure
+authentication flow will be used.
+.RS
+.RE
 .SH REFERENCES
 .PP
 For Boto:

--- a/doc/barman-cloud-wal-restore.1.md
+++ b/doc/barman-cloud-wal-restore.1.md
@@ -64,6 +64,12 @@ WAL_PATH
 --endpoint-url
 :    override the default S3 URL construction mechanism by specifying an endpoint.
 
+--credential {azure-cli,managed-identity}
+:    optionally specify the type of credential to use when authenticating with
+     Azure Blob Storage. If omitted then the credential will be obtained from the
+     environment. If no credentials can be found in the environment then the default
+     Azure authentication flow will be used.
+
 # REFERENCES
 
 For Boto:

--- a/doc/manual/55-barman-cli.en.md
+++ b/doc/manual/55-barman-cli.en.md
@@ -78,7 +78,9 @@ please refer to the ["Credentials" section in Boto 3 documentation][boto3creds].
 For credentials for the azure-blob-storage cloud provider see the
 ["Environment variables for authorization parameters" section in the Azure documentation][azure-storage-auth].
 The following environment variables are supported: `AZURE_STORAGE_CONNECTION_STRING`,
-`AZURE_STORAGE_KEY` and `AZURE_STORAGE_SAS_TOKEN`.
+`AZURE_STORAGE_KEY` and `AZURE_STORAGE_SAS_TOKEN`. You can also use the
+`--credential` option to specify either `azure-cli` or `managed-identity` credentials
+in order to authenticate via Azure Active Directory.
 
 > **WARNING:** Cloud utilities require the appropriate library for the cloud
 > provider you wish to use - either: [boto3][boto3] or

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1377,7 +1377,7 @@ class TestGetCloudInterface(object):
         get_cloud_interface(mock_config_azure)
         mock_azure_cloud_interface.assert_called_once()
         assert isinstance(
-            type(mock_azure_cloud_interface.call_args_list[0][1]["credential"]),
+            mock_azure_cloud_interface.call_args_list[0][1]["credential"],
             expected_credential,
         )
 

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -737,6 +737,18 @@ class TestAzureCloudInterface(object):
     Tests which verify backend-specific behaviour of AzureCloudInterface.
     """
 
+    @pytest.fixture
+    def mock_account_url(self):
+        return "storageaccount.blob.core.windows.net"
+
+    @pytest.fixture
+    def mock_object_path(self):
+        return "path/to/object"
+
+    @pytest.fixture
+    def mock_storage_url(self, mock_account_url, mock_object_path):
+        return "https://%s/%s/%s" % (mock_account_url, "container", mock_object_path)
+
     @mock.patch.dict(
         os.environ,
         {
@@ -746,17 +758,16 @@ class TestAzureCloudInterface(object):
         },
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_uploader_minimal(self, ContainerClientMock):
+    def test_uploader_minimal(
+        self, container_client_mock, mock_storage_url, mock_object_path
+    ):
         """Connection string auth takes precedence over SAS token or shared token"""
         container_name = "container"
-        account_url = "https://storageaccount.blob.core.windows.net"
-        cloud_interface = AzureCloudInterface(
-            url="%s/%s/path/to/dir" % (account_url, container_name)
-        )
+        cloud_interface = AzureCloudInterface(url=mock_storage_url)
 
         assert cloud_interface.bucket_name == "container"
-        assert cloud_interface.path == "path/to/dir"
-        ContainerClientMock.from_connection_string.assert_called_once_with(
+        assert cloud_interface.path == mock_object_path
+        container_client_mock.from_connection_string.assert_called_once_with(
             conn_str=os.environ["AZURE_STORAGE_CONNECTION_STRING"],
             container_name=container_name,
         )
@@ -770,20 +781,25 @@ class TestAzureCloudInterface(object):
         },
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_uploader_with_specified_credential(self, ContainerClientMock):
+    def test_uploader_with_specified_credential(
+        self,
+        container_client_mock,
+        mock_account_url,
+        mock_object_path,
+        mock_storage_url,
+    ):
         """Specified credential option takes precedences over environment"""
         container_name = "container"
-        account_url = "storageaccount.blob.core.windows.net"
         credential = AzureCliCredential()
         cloud_interface = AzureCloudInterface(
-            url="https://%s/%s/path/to/dir" % (account_url, container_name),
+            url=mock_storage_url,
             credential=credential,
         )
 
         assert cloud_interface.bucket_name == "container"
-        assert cloud_interface.path == "path/to/dir"
-        ContainerClientMock.assert_called_once_with(
-            account_url=account_url,
+        assert cloud_interface.path == mock_object_path
+        container_client_mock.assert_called_once_with(
+            account_url=mock_account_url,
             credential=credential,
             container_name=container_name,
         )
@@ -793,18 +809,23 @@ class TestAzureCloudInterface(object):
         {"AZURE_STORAGE_SAS_TOKEN": "sas_token", "AZURE_STORAGE_KEY": "storage_key"},
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_uploader_sas_token_auth(self, ContainerClientMock):
+    def test_uploader_sas_token_auth(
+        self,
+        container_client_mock,
+        mock_account_url,
+        mock_storage_url,
+        mock_object_path,
+    ):
         """SAS token takes precedence over shared token"""
         container_name = "container"
-        account_url = "storageaccount.blob.core.windows.net"
         cloud_interface = AzureCloudInterface(
-            url="https://%s/%s/path/to/dir" % (account_url, container_name)
+            mock_storage_url,
         )
 
         assert cloud_interface.bucket_name == "container"
-        assert cloud_interface.path == "path/to/dir"
-        ContainerClientMock.assert_called_once_with(
-            account_url=account_url,
+        assert cloud_interface.path == mock_object_path
+        container_client_mock.assert_called_once_with(
+            account_url=mock_account_url,
             credential=os.environ["AZURE_STORAGE_SAS_TOKEN"],
             container_name=container_name,
         )
@@ -814,18 +835,21 @@ class TestAzureCloudInterface(object):
         {"AZURE_STORAGE_KEY": "storage_key"},
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_uploader_shared_token_auth(self, ContainerClientMock):
+    def test_uploader_shared_token_auth(
+        self,
+        container_client_mock,
+        mock_account_url,
+        mock_storage_url,
+        mock_object_path,
+    ):
         """Shared token is used if SAS token and connection string aren't set"""
         container_name = "container"
-        account_url = "storageaccount.blob.core.windows.net"
-        cloud_interface = AzureCloudInterface(
-            url="https://%s/%s/path/to/dir" % (account_url, container_name)
-        )
+        cloud_interface = AzureCloudInterface(url=mock_storage_url)
 
         assert cloud_interface.bucket_name == "container"
-        assert cloud_interface.path == "path/to/dir"
-        ContainerClientMock.assert_called_once_with(
-            account_url=account_url,
+        assert cloud_interface.path == mock_object_path
+        container_client_mock.assert_called_once_with(
+            account_url=mock_account_url,
             credential=os.environ["AZURE_STORAGE_KEY"],
             container_name=container_name,
         )
@@ -833,19 +857,23 @@ class TestAzureCloudInterface(object):
     @mock.patch("azure.identity.DefaultAzureCredential")
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
     def test_uploader_default_credential_auth(
-        self, ContainerClientMock, default_azure_credential
+        self,
+        container_client_mock,
+        default_azure_credential,
+        mock_account_url,
+        mock_storage_url,
+        mock_object_path,
     ):
         """Uses DefaultAzureCredential if no other auth provided"""
         container_name = "container"
-        account_url = "storageaccount.blob.core.windows.net"
         cloud_interface = AzureCloudInterface(
-            url="https://%s/%s/path/to/dir" % (account_url, container_name)
+            url=mock_storage_url,
         )
 
         assert cloud_interface.bucket_name == "container"
-        assert cloud_interface.path == "path/to/dir"
-        ContainerClientMock.assert_called_once_with(
-            account_url=account_url,
+        assert cloud_interface.path == mock_object_path
+        container_client_mock.assert_called_once_with(
+            account_url=mock_account_url,
             credential=default_azure_credential.return_value,
             container_name=container_name,
         )
@@ -857,17 +885,17 @@ class TestAzureCloudInterface(object):
         },
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_emulated_storage(self, ContainerClientMock):
+    def test_emulated_storage(self, container_client_mock, mock_object_path):
         """Connection string auth and emulated storage URL are valid"""
         container_name = "container"
         account_url = "https://127.0.0.1/devstoreaccount1"
         cloud_interface = AzureCloudInterface(
-            url="%s/%s/path/to/dir" % (account_url, container_name)
+            url="%s/%s/%s" % (account_url, container_name, mock_object_path)
         )
 
         assert cloud_interface.bucket_name == "container"
-        assert cloud_interface.path == "path/to/dir"
-        ContainerClientMock.from_connection_string.assert_called_once_with(
+        assert cloud_interface.path == mock_object_path
+        container_client_mock.from_connection_string.assert_called_once_with(
             conn_str=os.environ["AZURE_STORAGE_CONNECTION_STRING"],
             container_name=container_name,
         )
@@ -877,12 +905,14 @@ class TestAzureCloudInterface(object):
         os.environ,
         {"AZURE_STORAGE_SAS_TOKEN": "sas_token", "AZURE_STORAGE_KEY": "storage_key"},
     )
-    def test_emulated_storage_no_connection_string(self):
+    def test_emulated_storage_no_connection_string(self, mock_object_path):
         """Emulated storage URL with no connection string fails"""
         container_name = "container"
         account_url = "https://127.0.0.1/devstoreaccount1"
         with pytest.raises(ValueError) as exc:
-            AzureCloudInterface(url="%s/%s/path/to/dir" % (account_url, container_name))
+            AzureCloudInterface(
+                url="%s/%s/%s" % (account_url, container_name, mock_object_path)
+            )
         assert (
             str(exc.value)
             == "A connection string must be provided when using emulated storage"
@@ -906,7 +936,7 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_connectivity(self, ContainerClientMock):
+    def test_connectivity(self, container_client_mock):
         """
         Test the test_connectivity method
         """
@@ -916,7 +946,7 @@ class TestAzureCloudInterface(object):
         assert cloud_interface.test_connectivity() is True
         # Bucket existence checking is carried out by checking we can successfully
         # iterate the bucket contents
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
         container_client.list_blobs.assert_called_once_with()
         blobs_iterator = container_client.list_blobs.return_value
         blobs_iterator.next.assert_called_once_with()
@@ -928,14 +958,14 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_connectivity_failure(self, ContainerClientMock):
+    def test_connectivity_failure(self, container_client_mock):
         """
         Test the test_connectivity method in case of failure
         """
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
         blobs_iterator = container_client.list_blobs.return_value
         blobs_iterator.next.side_effect = ServiceRequestError("error")
         assert cloud_interface.test_connectivity() is False
@@ -944,7 +974,7 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_setup_bucket(self, ContainerClientMock):
+    def test_setup_bucket(self, container_client_mock):
         """
         Test if a bucket already exists
         """
@@ -952,7 +982,7 @@ class TestAzureCloudInterface(object):
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
         cloud_interface.setup_bucket()
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
         container_client.list_blobs.assert_called_once_with()
         blobs_iterator = container_client.list_blobs.return_value
         blobs_iterator.next.assert_called_once_with()
@@ -961,14 +991,14 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_setup_bucket_create(self, ContainerClientMock):
+    def test_setup_bucket_create(self, container_client_mock):
         """
         Test auto-creation of a bucket if it does not exist
         """
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
         blobs_iterator = container_client.list_blobs.return_value
         blobs_iterator.next.side_effect = ResourceNotFoundError()
         cloud_interface.setup_bucket()
@@ -980,12 +1010,12 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_upload_fileobj(self, ContainerClientMock):
+    def test_upload_fileobj(self, container_client_mock):
         """Test container client upload_blob is called with expected args"""
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
         mock_fileobj = mock.MagicMock()
         mock_key = "path/to/blob"
         cloud_interface.upload_fileobj(mock_fileobj, mock_key)
@@ -998,14 +1028,14 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_upload_fileobj_with_encryption_scope(self, ContainerClientMock):
+    def test_upload_fileobj_with_encryption_scope(self, container_client_mock):
         """Test encrption scope is passed to upload_blob"""
         encryption_scope = "test_encryption_scope"
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob",
             encryption_scope=encryption_scope,
         )
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
         mock_fileobj = mock.MagicMock()
         mock_key = "path/to/blob"
         cloud_interface.upload_fileobj(mock_fileobj, mock_key)
@@ -1022,14 +1052,14 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_upload_part(self, ContainerClientMock):
+    def test_upload_part(self, container_client_mock):
         """
         Tests the upload of a single block in Azure
         """
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
         blob_client_mock = container_client.get_blob_client.return_value
 
         mock_body = mock.MagicMock()
@@ -1045,7 +1075,7 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_upload_part_with_encryption_scope(self, ContainerClientMock):
+    def test_upload_part_with_encryption_scope(self, container_client_mock):
         """
         Tests that the encryption scope is passed to the blob client when
         uploading a single block
@@ -1055,7 +1085,7 @@ class TestAzureCloudInterface(object):
             "https://storageaccount.blob.core.windows.net/container/path/to/blob",
             encryption_scope=encryption_scope,
         )
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
         blob_client_mock = container_client.get_blob_client.return_value
 
         mock_body = mock.MagicMock()
@@ -1074,12 +1104,12 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_complete_multipart_upload(self, ContainerClientMock):
+    def test_complete_multipart_upload(self, container_client_mock):
         """Tests completion of a block blob upload in Azure Blob Storage"""
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
         blob_client_mock = container_client.get_blob_client.return_value
 
         mock_parts = [{"PartNumber": "00001"}]
@@ -1095,7 +1125,9 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_complete_multipart_upload_with_encryption_scope(self, ContainerClientMock):
+    def test_complete_multipart_upload_with_encryption_scope(
+        self, container_client_mock
+    ):
         """
         Tests the completion of a block blob upload in Azure Blob Storage and that
         the encryption scope is passed to the blob client
@@ -1105,7 +1137,7 @@ class TestAzureCloudInterface(object):
             "https://storageaccount.blob.core.windows.net/container/path/to/blob",
             encryption_scope=encryption_scope,
         )
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
         blob_client_mock = container_client.get_blob_client.return_value
 
         mock_parts = [{"PartNumber": "00001"}]
@@ -1123,12 +1155,12 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_abort_multipart_upload(self, ContainerClientMock):
+    def test_abort_multipart_upload(self, container_client_mock):
         """Test aborting a block blob upload in Azure Blob Storage"""
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
         blob_client_mock = container_client.get_blob_client.return_value
 
         mock_key = "path/to/blob"
@@ -1144,7 +1176,7 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_abort_multipart_upload_with_encryption_scope(self, ContainerClientMock):
+    def test_abort_multipart_upload_with_encryption_scope(self, container_client_mock):
         """
         Test aborting a block blob upload in Azure Blob Storage and verify that the
         encryption scope is passed to the blob client
@@ -1154,7 +1186,7 @@ class TestAzureCloudInterface(object):
             "https://storageaccount.blob.core.windows.net/container/path/to/blob",
             encryption_scope=encryption_scope,
         )
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
         blob_client_mock = container_client.get_blob_client.return_value
 
         mock_key = "path/to/blob"
@@ -1173,11 +1205,11 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_delete_objects(self, ContainerClientMock):
+    def test_delete_objects(self, container_client_mock):
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
 
         mock_keys = ["path/to/object/1", "path/to/object/2"]
         cloud_interface.delete_objects(mock_keys)
@@ -1188,11 +1220,11 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_delete_objects_with_empty_list(self, ContainerClientMock):
+    def test_delete_objects_with_empty_list(self, container_client_mock):
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
 
         mock_keys = []
         cloud_interface.delete_objects(mock_keys)
@@ -1212,11 +1244,11 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_delete_objects_partial_failure(self, ContainerClientMock, caplog):
+    def test_delete_objects_partial_failure(self, container_client_mock, caplog):
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
 
         mock_keys = ["path/to/object/1", "path/to/object/2"]
 
@@ -1244,7 +1276,7 @@ class TestAzureCloudInterface(object):
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
     def test_delete_objects_partial_failure_exception(
-        self, ContainerClientMock, caplog
+        self, container_client_mock, caplog
     ):
         """
         Test that partial failures raised via PartialBatchErrorException are handled.
@@ -1254,7 +1286,7 @@ class TestAzureCloudInterface(object):
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
 
         mock_keys = ["path/to/object/1", "path/to/object/2"]
 
@@ -1285,14 +1317,14 @@ class TestAzureCloudInterface(object):
         os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
     )
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
-    def test_delete_objects_404_not_failure(self, ContainerClientMock, caplog):
+    def test_delete_objects_404_not_failure(self, container_client_mock, caplog):
         """
         Test that 404 responses in partial failures do not create an error.
         """
         cloud_interface = AzureCloudInterface(
             "https://storageaccount.blob.core.windows.net/container/path/to/blob"
         )
-        container_client = ContainerClientMock.from_connection_string.return_value
+        container_client = container_client_mock.from_connection_string.return_value
 
         mock_keys = ["path/to/object/1", "path/to/object/2"]
 

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -448,7 +448,6 @@ if sys.version_info[0] >= 3:
         """
         return s
 
-
 else:
 
     def b(s):


### PR DESCRIPTION
This PR improves the Barman Cloud user experience when authenticating via Azure Active Directory.
The first commit adds the functionality, the subsequent commits refactor the code in response to sonarqube warnings - I think these should be kept separate in the history so that it is clear which changes related to adding the functionality and which were due to refactoring.

Closes #396 

---

Adds the `--credential` option to the Barman Cloud scripts. The option
can be set to the following values:

* `azure-cli`: AzureCliCredential, which uses the token obtained by
  logging into azure via the CLI using `az login`.
* `managed-identity`: ManagedIdentityCredential, which uses the Azure
  Managed Identity endpoint to fetch a token (Barman Cloud must be
  running on an Azure resource which supports managed identities for this
  to work).

This improves the user experience when authenticating using either
Azure CLI tokens or managed identities, both of which result in
excessive log noise and latency when handled by `DefaultAzureCredential`.

If the `--credential` option is not set then the existing behaviour is
applied - the environment is checked for the connection string, access
key and SAS token values and if none are found it attempts to use
`DefaultAzureCredential`.