### PR TITLE
Dev/463 - VANISHED_RE now covers rsync sender process

### DIFF
--- a/barman/copy_controller.py
+++ b/barman/copy_controller.py
@@ -274,7 +274,7 @@ class RsyncCopyController(object):
         |
         # final summary
         rsync\ error:\ .* \(code\ 23\)\ at\ main\.c\(\d+\)
-            \ \[(generator|receiver)=[^\]]+\]
+            \ \[(generator|receiver|sender)=[^\]]+\]
         )
         $ # end of the line
     """,

--- a/tests/test_copy_controller.py
+++ b/tests/test_copy_controller.py
@@ -1131,6 +1131,26 @@ class TestRsyncCopyController(object):
         )
         rcc._rsync_ignore_vanished_files(rsync_mock, 1, 2, a=3, b=4)
 
+        # Check with return code != 0
+        # 23 - Partial transfer due to error
+        # Version with 'sender' as error source
+        # This should not raise
+        rsync_mock.reset_mock()
+        rsync_mock.ret = 23
+        rsync_mock.err = (
+            # a file has vanished before rsync start
+            'rsync: link_stat "a/file" failed: No such file or directory (2)\n'
+            # files which vanished after rsync start
+            'file has vanished: "some/other/file"\n'
+            # files which have been truncated during transfer
+            'rsync: read errors mapping "/truncated": No data available (61)\n'
+            # final summary
+            "rsync error: some files/attrs were not transferred "
+            "(see previous errors) (code 23) at main.c(1249) "
+            "[Sender=3.1.2]\n"
+        )
+        rcc._rsync_ignore_vanished_files(rsync_mock, 1, 2, a=3, b=4)
+
     # This test runs for 1, 4 and 16 workers
     @pytest.mark.parametrize("workers", [1, 4, 16])
     @patch("barman.copy_controller.Pool", new=multiprocessing.dummy.Pool)


### PR DESCRIPTION
We have a regex defined in the barman code which is in charge of
filtering out rsync error messages when rsync return code is 23.

Previous to this commit it was only covering `receiver` and `generator`
rsync processes while checking the rsync error output.

If the error was issued by the `sender` process, barman would mark
the backup as failed while checking messages like this:

```
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1178) [sender=3.1.2]
```

This very simple commit only introduces the `sender` process to the
regex pattern of `VANISHED_RE`.

More details can be also found [in the GitHub issue](#463).