### PR TITLE
Fix empty dir optimisation on recovery

### DIFF
--- a/barman/copy_controller.py
+++ b/barman/copy_controller.py
@@ -873,7 +873,9 @@ class RsyncCopyController(object):
             ref_hash = {}
             ref_has_content = False
             for file_item in self._list_files(item, ref):
-                if file_item.path != ".":
+                if file_item.path != "." and not (
+                    item.label == "pgdata" and file_item.path == "pg_tblspc"
+                ):
                     ref_has_content = True
                 if file_item.mode[0] != "d":
                     ref_hash[file_item.path] = file_item

--- a/barman/copy_controller.py
+++ b/barman/copy_controller.py
@@ -902,6 +902,16 @@ class RsyncCopyController(object):
             self.temp_dir, "%s_exclude_and_protect.filter" % item.label
         )
         exclude_and_protect_filter = open(item.exclude_and_protect_file, "w+")
+
+        if not ref_has_content:
+            # If the destination directory is empty then include all
+            # directories and exclude all files. This stops the rsync
+            # command which runs during the _create_dir_and_purge function
+            # from copying the entire contents of the source directory and
+            # ensures it only creates the directories.
+            exclude_and_protect_filter.write("+ */\n")
+            exclude_and_protect_filter.write("- *\n")
+
         # The `safe_list` will contain all items older than
         # safe_horizon, as well as files that we know rsync will
         # check anyway due to a difference in mtime or size

--- a/tests/test_copy_controller.py
+++ b/tests/test_copy_controller.py
@@ -879,10 +879,10 @@ class TestRsyncCopyController(object):
         # the directories
         assert item.dir_file
         assert open(item.dir_file).read() == (".\ntmp\n")
-        # The exclude_and_protect file should be empty because the destination
-        # was empty
+        # The exclude_and_protect file should contain only wildcards to include
+        # all directories and exclude all files
         assert item.exclude_and_protect_file
-        assert open(item.exclude_and_protect_file).read() == ""
+        assert open(item.exclude_and_protect_file).read() == "+ */\n- *\n"
 
     @patch("barman.copy_controller.RsyncCopyController._rsync_factory")
     @patch("barman.copy_controller.RsyncCopyController._rsync_ignore_vanished_files")


### PR DESCRIPTION
Proposed fix for #465 which provides a wildcard `exclude_and_protect` file for empty directories.

Needs unit tests but wanted to get eyes on it while I continue to test it in my dev environment.