### PR TITLE
Limit sonarqube and blackduck jobs to EDB repo only

### DIFF
--- a/.github/workflows/blackduck-scan.yml
+++ b/.github/workflows/blackduck-scan.yml
@@ -13,7 +13,7 @@ jobs:
     name: BlackDuck-scan
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    if: github.repository == "EnterpriseDB/barman"
+    if: github.repository == 'EnterpriseDB/barman'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/blackduck-scan.yml
+++ b/.github/workflows/blackduck-scan.yml
@@ -13,6 +13,7 @@ jobs:
     name: BlackDuck-scan
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    if: github.repository == "EnterpriseDB/barman"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -11,7 +11,7 @@ jobs:
   sonarQube:
     name: SonarQube-Job
     runs-on: ubuntu-latest
-    if: github.repository == "EnterpriseDB/barman"
+    if: github.repository == 'EnterpriseDB/barman'
     steps:
       - name: Checkout source repo
         uses: actions/checkout@v2

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -11,6 +11,7 @@ jobs:
   sonarQube:
     name: SonarQube-Job
     runs-on: ubuntu-latest
+    if: github.repository == "EnterpriseDB/barman"
     steps:
       - name: Checkout source repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Adds a conditional to both the sonarqube-scan and blackduck-scan jobs so
that they only run if the repository is `EnterpriseDB/barman`. The jobs
will fail when running on PRs from other repositories because they do
not have access to the necessary credentials.

This prevents us from automatically failing these two checks on all PRs
from forks.