### PR TITLE
Limit sonarqube and blackduck jobs to EDB repo: Attempt 2

### DIFF
--- a/.github/workflows/blackduck-scan.yml
+++ b/.github/workflows/blackduck-scan.yml
@@ -13,7 +13,7 @@ jobs:
     name: BlackDuck-scan
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    if: github.repository == 'EnterpriseDB/barman'
+    if: github.event.pull_request.head.repo.full_name == 'EnterpriseDB/barman'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -11,7 +11,7 @@ jobs:
   sonarQube:
     name: SonarQube-Job
     runs-on: ubuntu-latest
-    if: github.repository == 'EnterpriseDB/barman'
+    if: github.event.pull_request.head.repo.full_name == 'EnterpriseDB/barman'
     steps:
       - name: Checkout source repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Use the github event instead of the github context to get the name of
the source repo.