### PR TITLE
Pass WAL archive check if bucket is missing

### DIFF
--- a/barman/clients/cloud_check_wal_archive.py
+++ b/barman/clients/cloud_check_wal_archive.py
@@ -22,6 +22,7 @@ from barman.clients.cloud_cli import (
     create_argument_parser,
     GeneralErrorExit,
     OperationErrorExit,
+    NetworkErrorExit,
     UrlArgumentType,
 )
 from barman.cloud import configure_logging, CloudBackupCatalog
@@ -43,6 +44,12 @@ def main(args=None):
 
     try:
         cloud_interface = get_cloud_interface(config)
+        if not cloud_interface.test_connectivity():
+            # Deliberately raise an error if we cannot connect
+            raise NetworkErrorExit()
+        if not cloud_interface.bucket_exists:
+            # If the bucket does not exist then the check should pass
+            return
         catalog = CloudBackupCatalog(cloud_interface, config.server_name)
         wals = list(catalog.get_wal_paths().keys())
         check_archive_usable(

--- a/doc/barman-cloud-check-wal-archive.1
+++ b/doc/barman-cloud-check-wal-archive.1
@@ -15,7 +15,8 @@ barman\-cloud\-check\-wal\-archive [\f[I]OPTIONS\f[]]
 Check that the WAL archive destination for \f[I]SERVER_NAME\f[] is safe
 to use for a new PostgreSQL cluster.
 With no optional args (the default) this check will pass if the WAL
-archive is empty and fail otherwise.
+archive is empty or if the target bucket cannot be found.
+All other conditions will result in failure.
 .PP
 This script and Barman are administration tools for disaster recovery of
 PostgreSQL servers written in Python and maintained by EnterpriseDB.

--- a/doc/barman-cloud-check-wal-archive.1.md
+++ b/doc/barman-cloud-check-wal-archive.1.md
@@ -16,7 +16,8 @@ barman-cloud-check-wal-archive [*OPTIONS*] *SOURCE_URL* *SERVER_NAME*
 
 Check that the WAL archive destination for *SERVER_NAME* is safe to use
 for a new PostgreSQL cluster. With no optional args (the default) this
-check will pass if the WAL archive is empty and fail otherwise.
+check will pass if the WAL archive is empty or if the target bucket cannot
+be found. All other conditions will result in failure.
 
 This script and Barman are administration tools for disaster recovery
 of PostgreSQL servers written in Python and maintained by EnterpriseDB.


### PR DESCRIPTION
Updates barman-cloud-check-wal-archive such that the check passes if the
target bucket does not exist *and* we were able to successfully connect
to the cloud provider.

If we cannot successfully connect to the cloud provider then the check
errors and exits with status 2.

Closes #477.