### PR TITLE
Dev/476 add tags to uploaded files

### DIFF
--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -24,6 +24,7 @@ from contextlib import closing
 from shutil import rmtree
 
 from barman.clients.cloud_cli import (
+    add_tag_argument,
     create_argument_parser,
     GeneralErrorExit,
     NetworkErrorExit,
@@ -264,6 +265,11 @@ def parse_arguments(args=None):
         "--dbname",
         help="Database name or conninfo string for Postgres connection (default: postgres)",
         default="postgres",
+    )
+    add_tag_argument(
+        parser,
+        name="tags",
+        help="Tags to be added to all uploaded files in cloud storage",
     )
     s3_arguments.add_argument(
         "-e",

--- a/barman/clients/cloud_cli.py
+++ b/barman/clients/cloud_cli.py
@@ -18,9 +18,12 @@
 
 import argparse
 
+import csv
+import logging
 from enum import Enum
 
 import barman
+from barman.utils import force_str
 
 
 class OperationErrorExit(SystemExit):
@@ -57,6 +60,36 @@ class GeneralErrorExit(SystemExit):
 class UrlArgumentType(Enum):
     source = "source"
     destination = "destination"
+
+
+def __parse_tag(tag):
+    """Parse key,value tag with csv reader"""
+    try:
+        rows = list(csv.reader([tag], delimiter=","))
+    except csv.Error as exc:
+        logging.error(
+            "Error parsing tag %s: %s",
+            tag,
+            force_str(exc),
+        )
+        raise CLIErrorExit()
+    if len(rows) != 1 or len(rows[0]) != 2:
+        logging.error(
+            "Invalid tag format: %s",
+            tag,
+        )
+        raise CLIErrorExit()
+
+    return tuple(rows[0])
+
+
+def add_tag_argument(parser, name, help):
+    parser.add_argument(
+        "--%s" % name,
+        type=__parse_tag,
+        nargs="*",
+        help=help,
+    )
 
 
 class CloudArgumentParser(argparse.ArgumentParser):

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -525,15 +525,18 @@ class CloudInterface(with_metaclass(ABCMeta)):
         """
         pass
 
-    def __init__(self, url, jobs=2):
+    def __init__(self, url, jobs=2, tags=None):
         """
         Base constructor
 
         :param str url: url for the cloud storage resource
         :param int jobs: How many sub-processes to use for asynchronous
           uploading, defaults to 2.
+        :param List[tuple] tags: List of tags as k,v tuples to be added to all
+          uploaded objects
         """
         self.url = url
+        self.tags = tags
 
         # The worker process and the shared queue are created only when
         # needed
@@ -944,12 +947,14 @@ class CloudInterface(with_metaclass(ABCMeta)):
         """
 
     @abstractmethod
-    def upload_fileobj(self, fileobj, key):
+    def upload_fileobj(self, fileobj, key, override_tags=None):
         """
         Synchronously upload the content of a file-like object to a cloud key
 
         :param fileobj IOBase: File-like object to upload
         :param str key: The key to identify the uploaded object
+        :param List[tuple] override_tags: List of k,v tuples which should override any
+          tags already defined in the cloud interface
         """
 
     @abstractmethod
@@ -1046,7 +1051,11 @@ class CloudBackupUploader(with_metaclass(ABCMeta)):
     """
 
     def __init__(
-        self, server_name, cloud_interface, max_archive_size, compression=None
+        self,
+        server_name,
+        cloud_interface,
+        max_archive_size,
+        compression=None,
     ):
         """
         Base constructor.
@@ -1297,7 +1306,12 @@ class CloudBackupUploaderPostgres(CloudBackupUploader):
     """
 
     def __init__(
-        self, server_name, cloud_interface, max_archive_size, postgres, compression=None
+        self,
+        server_name,
+        cloud_interface,
+        max_archive_size,
+        postgres,
+        compression=None,
     ):
         super(CloudBackupUploaderPostgres, self).__init__(
             server_name,

--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -84,8 +84,9 @@ def get_cloud_interface(config):
     cloud_interface_kwargs = {
         "url": config.source_url if "source_url" in config else config.destination_url
     }
-    if "jobs" in config:
-        cloud_interface_kwargs["jobs"] = config.jobs
+    for arg in ("jobs", "tags"):
+        if arg in config:
+            cloud_interface_kwargs[arg] = getattr(config, arg)
 
     if config.cloud_provider == "aws-s3":
         return _make_s3_cloud_interface(config, cloud_interface_kwargs)

--- a/doc/barman-cloud-backup.1
+++ b/doc/barman-cloud-backup.1
@@ -123,6 +123,12 @@ the cloud provider to which the backup should be uploaded
 .RS
 .RE
 .TP
+.B \[en]tags KEY1,VALUE1 KEY2,VALUE2 \&...
+a space\-separated list of comma\-separated key\-value pairs
+representing tags to be added to each object created in cloud storage
+.RS
+.RE
+.TP
 .B \-P, \[en]profile
 profile name (e.g.\ INI section in AWS credentials file)
 .RS

--- a/doc/barman-cloud-backup.1.md
+++ b/doc/barman-cloud-backup.1.md
@@ -90,6 +90,10 @@ SERVER_NAME
 --cloud-provider {aws-s3,azure-blob-storage}
 :    the cloud provider to which the backup should be uploaded
 
+--tags KEY1,VALUE1 KEY2,VALUE2 ...
+:    a space-separated list of comma-separated key-value pairs representing tags
+     to be added to each object created in cloud storage
+
 -P, --profile
 :    profile name (e.g. INI section in AWS credentials file)
 

--- a/doc/barman-cloud-wal-archive.1
+++ b/doc/barman-cloud-wal-archive.1
@@ -86,6 +86,25 @@ the cloud provider to which the backup should be uploaded
 .RS
 .RE
 .TP
+.B \[en]tags KEY1,VALUE1 KEY2,VALUE2 \&...
+A space\-separated list of comma\-separated key\-value pairs
+representing tags to be added to each WAL file archived to cloud
+storage.
+.RS
+.RE
+.TP
+.B \[en]history\-tags KEY1,VALUE1 KEY2,VALUE2 \&...
+A space\-separated list of comma\-separated key\-value pairs
+representing tags to be added to each history file archived to cloud
+storage.
+If this is provided alongside the \f[C]\-\-tags\f[] option then the
+value of \f[C]\-\-history\-tags\f[] will be used in place of
+\f[C]\-\-tags\f[] for history files.
+All other WAL files will continue to be tagged with the value of
+\f[C]\-\-tags\f[].
+.RS
+.RE
+.TP
 .B \-P, \[en]profile
 profile name (e.g.\ INI section in AWS credentials file)
 .RS

--- a/doc/barman-cloud-wal-archive.1.md
+++ b/doc/barman-cloud-wal-archive.1.md
@@ -69,6 +69,17 @@ WAL_PATH
 --cloud-provider {aws-s3,azure-blob-storage}
 :    the cloud provider to which the backup should be uploaded
 
+--tags KEY1,VALUE1 KEY2,VALUE2 ...
+:    A space-separated list of comma-separated key-value pairs representing tags
+     to be added to each WAL file archived to cloud storage.
+
+--history-tags KEY1,VALUE1 KEY2,VALUE2 ...
+:    A space-separated list of comma-separated key-value pairs representing tags
+     to be added to each history file archived to cloud storage.
+     If this is provided alongside the `--tags` option then the value of
+     `--history-tags` will be used in place of `--tags` for history files.
+     All other WAL files will continue to be tagged with the value of `--tags`.
+
 -P, --profile
 :    profile name (e.g. INI section in AWS credentials file)
 


### PR DESCRIPTION
Allows tags to be added to backup files and archived WALs. These tags are key value pairs and are included in the necessary cloud provider API calls to ensure the tags are added to uploaded objects.

For backups, the supplied `--tags` will be added to all files uploaded during the backup, including the `backup.info` file.

For WALs:

* If `--tags` and `--history-tags` are provided then the tags provided under `--tags` will be added to every WAL archived *except* history files and `--history-tags` will be added to every history file archived.
* If only `--history-tags` is provided then WALs will not have any tags and `--history-tags` will be added to every history file archived.
* If only `--tags` is provided then the supplied tags will be added to *all* WALs archived (including the history files).

This is currently broken into five commits as it might simplify review but the intention is to squash it into a single commit before merging.

Closes #476 