### PR TITLE
Update installation docs #489

### DIFF
--- a/doc/manual/16-installation.en.md
+++ b/doc/manual/16-installation.en.md
@@ -90,6 +90,29 @@ The `barman` application will be installed in your user directory ([make sure th
 
 [Barman is also available on the Python Package Index (PyPI)][pypi] and can be installed through `pip`.
 
+## PostgreSQL client binaries
+
+The following Barman features depend on PostgreSQL client binaries:
+
+* [Streaming backup](#streaming-backup) with `backup_method = postgres` (requires `pg_basebackup`)
+* [Streaming WAL archiving](#wal-streaming) with `streaming_archiver = on` (requires
+  `pg_receivewal` or `pg_receivexlog`)
+* [Verifying backups](#verify) with `barman verfy-backup` (requires `pg_verifybackup`)
+
+These binaries are installed with the PostgreSQL client packages and can be
+found in the following locations:
+
+* On RedHat/CentOS: `/usr/pgsql-${PG_MAJOR_VERSION}/bin`
+* On Debian/Ubuntu: `/usr/lib/postgresql/${PG_MAJOR_VERSION}/bin`
+
+You must ensure that either:
+
+1. The Barman user has the `bin` directory for the appropriate `PG_MAJOR_VERSION`
+   on its path, or:
+2. The [path_prefix](#binary-paths) option is set in the Barman configuration for each
+   server and points to the `bin` directory for the appropriate
+   `PG_MAJOR_VERSION`.
+
 # Upgrading Barman
 
 Barman follows the trunk-based development paradigm, and as such

--- a/doc/manual/99-references.en.md
+++ b/doc/manual/99-references.en.md
@@ -14,7 +14,7 @@
   [aptpgdg]: http://apt.postgresql.org/
   [aptpgdgwiki]: https://wiki.postgresql.org/wiki/Apt
   [epel]: http://fedoraproject.org/wiki/EPEL
-  [man5]: http://docs.pgbarman.org/barman.5.html
+  [man5]: https://docs.pgbarman.org/barman.5.html
   [setup_user]: https://docs.python.org/3/install/index.html#alternate-installation-the-user-scheme
   [pypi]: https://pypi.python.org/pypi/barman/
   [pgpass]: https://www.postgresql.org/docs/current/static/libpq-pgpass.html


### PR DESCRIPTION
Will need rebasing once #475 is merged.

Not 100% happy with this as it is - maybe it's not the right place and it should be in configuration? Or perhaps we shouldn't have this information here and just add another warning in the `verify` command section (similar to what we already have with [WAL Streaming](https://docs.pgbarman.org/release/2.17/#wal-streaming) and [Streaming backup](https://docs.pgbarman.org/release/2.17/#streaming-backup).