### PR TITLE
Expose azure upload parameters #472

### DIFF
--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -36,7 +36,7 @@ from barman.clients.cloud_cli import (
 from barman.cloud import configure_logging
 from barman.cloud_providers import get_cloud_interface
 from barman.exceptions import BarmanException
-from barman.utils import force_str
+from barman.utils import check_positive, check_size, force_str
 from barman.xlog import hash_dir, is_any_xlog_file, is_history_file
 
 
@@ -172,6 +172,28 @@ def parse_arguments(args=None):
         "--encryption-scope",
         help="The name of an encryption scope defined in the Azure Blob Storage "
         "service which is to be used to encrypt the data in Azure",
+    )
+    azure_arguments.add_argument(
+        "--max-block-size",
+        help="The chunk size to be used when uploading an object via the "
+        "concurrent chunk method (default: 4MB).",
+        type=check_size,
+        default="4MB",
+    )
+    azure_arguments.add_argument(
+        "--max-concurrency",
+        help="The maximum number of chunks to be uploaded concurrently (default: 1).",
+        type=check_positive,
+        default=1,
+    )
+    azure_arguments.add_argument(
+        "--max-single-put-size",
+        help="Maximum size for which the Azure client will upload an object in a "
+        "single request (default: 64MB). If this is set lower than the PostgreSQL "
+        "WAL segment size after any applied compression then the concurrent chunk "
+        "upload method for WAL archiving will be used.",
+        default="64MB",
+        type=check_size,
     )
     return parser.parse_args(args=args)
 

--- a/doc/barman-cloud-wal-archive.1
+++ b/doc/barman-cloud-wal-archive.1
@@ -136,6 +136,32 @@ If no credentials can be found in the environment then the default Azure
 authentication flow will be used.
 .RS
 .RE
+.TP
+.B \[en]max\-block\-size SIZE
+the chunk size to be used when uploading an object to Azure Blob Storage
+via the concurrent chunk method (default: 4MB).
+.RS
+.RE
+.TP
+.B \[en]max\-concurrency CONCURRENCY
+the maximum number of chunks to be uploaded concurrently to Azure Blob
+Storage (default: 1).
+Whether the maximum concurrency is achieved depends on the values of
+\[en]max\-block\-size (should be less than or equal to
+\f[C]WAL\ segment\ size\ after\ compression\ /\ max_concurrency\f[]) and
+\[en]max\-single\-put\-size (must be less than WAL segment size after
+compression).
+.RS
+.RE
+.TP
+.B \[en]max\-single\-put\-size SIZE
+maximum size for which the Azure client will upload an object to Azure
+Blob Storage in a single request (default: 64MB).
+If this is set lower than the WAL segment size after any applied
+compression then the concurrent chunk upload method for WAL archiving
+will be used.
+.RS
+.RE
 .SH REFERENCES
 .PP
 For Boto:

--- a/doc/barman-cloud-wal-archive.1.md
+++ b/doc/barman-cloud-wal-archive.1.md
@@ -100,6 +100,23 @@ WAL_PATH
      environment. If no credentials can be found in the environment then the default
      Azure authentication flow will be used.
 
+--max-block-size SIZE
+:    the chunk size to be used when uploading an object to Azure Blob Storage via the
+     concurrent chunk method (default: 4MB).
+
+--max-concurrency CONCURRENCY
+:    the maximum number of chunks to be uploaded concurrently to Azure Blob Storage
+     (default: 1). Whether the maximum concurrency is achieved depends on the values
+     of --max-block-size (should be less than or equal to
+     `WAL segment size after compression / max_concurrency`) and --max-single-put-size
+     (must be less than WAL segment size after compression).
+
+--max-single-put-size SIZE
+:    maximum size for which the Azure client will upload an object to Azure Blob
+     Storage in a single request (default: 64MB). If this is set lower than the
+     WAL segment size after any applied compression then the concurrent chunk upload
+     method for WAL archiving will be used.
+
 # REFERENCES
 
 For Boto:

--- a/tests/test_barman_cloud_wal_archive.py
+++ b/tests/test_barman_cloud_wal_archive.py
@@ -276,6 +276,72 @@ class TestMain(object):
             )
         assert excinfo.value.code == 3
 
+    @pytest.mark.parametrize(
+        (
+            "azure_client_args",
+            "expected_cloud_interface_kwargs",
+        ),
+        [
+            # Defaults should result in CLI defaults which match the Azure
+            # defaults
+            (
+                [],
+                {
+                    "max_block_size": 4 << 20,
+                    "max_concurrency": 1,
+                    "max_single_put_size": 64 << 20,
+                },
+            ),
+            # CLI args should override defaults in CLI and AzureCloudInterface
+            (
+                [
+                    "--max-block-size",
+                    "1MB",
+                    "--max-concurrency",
+                    "16",
+                    "--max-single-put-size",
+                    "8MB",
+                ],
+                {
+                    "max_block_size": 1 << 20,
+                    "max_concurrency": 16,
+                    "max_single_put_size": 8 << 20,
+                },
+            ),
+        ],
+    )
+    @mock.patch.dict(
+        os.environ, {"AZURE_STORAGE_CONNECTION_STRING": "connection_string"}
+    )
+    @mock.patch("barman.clients.cloud_walarchive.CloudWalUploader")
+    @mock.patch("barman.cloud_providers.azure_blob_storage.AzureCloudInterface")
+    def test_wal_archive_azure_upload_block_args(
+        self,
+        cloud_interface_mock,
+        _uploader_mock,
+        azure_client_args,
+        expected_cloud_interface_kwargs,
+    ):
+        """Test that azure block upload arguments are passed to the cloud interface."""
+        cloud_walarchive.main(
+            [
+                "https://account.blob.core.windows.net/container/path/to/dir",
+                "test-server",
+                "000000080000ABFF000000C2",
+                "--cloud-provider",
+                "azure-blob-storage",
+            ]
+            + azure_client_args
+        )
+
+        # Verify expected kwargs are passed to cloud interface
+        cloud_interface_mock.assert_called_once_with(
+            url="https://account.blob.core.windows.net/container/path/to/dir",
+            encryption_scope=None,
+            tags=None,
+            **expected_cloud_interface_kwargs
+        )
+
 
 # noinspection PyProtectedMember
 class TestWalUploader(object):
@@ -450,7 +516,7 @@ class TestWalUploaderAzure(object):
         """
         Test the upload of a WAL
         """
-        # Create a simple S3WalUploader obj
+        # Create a simple CloudWalUploader obj
         container_name = "container"
         cloud_interface = AzureCloudInterface(
             url="https://account.blob.core.windows.net/container/path/to/dir"
@@ -481,6 +547,7 @@ class TestWalUploaderAzure(object):
             ),
             overwrite=True,
             length=mock_fileobj_length,
+            max_concurrency=8,
         )
 
 

--- a/tests/test_barman_cloud_wal_archive.py
+++ b/tests/test_barman_cloud_wal_archive.py
@@ -459,6 +459,8 @@ class TestWalUploaderAzure(object):
         source = "/wal_dir/000000080000ABFF000000C1"
         # Simulate the file object returned by the retrieve_file_obj method
         rfo_mock.return_value.name = source
+        mock_fileobj_length = 42
+        rfo_mock.return_value.tell.return_value = mock_fileobj_length
         uploader.upload_wal(source)
 
         ContainerClientMock.from_connection_string.assert_called_once_with(
@@ -478,6 +480,7 @@ class TestWalUploaderAzure(object):
                 os.path.basename(source),
             ),
             overwrite=True,
+            length=mock_fileobj_length,
         )
 
 

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -863,10 +863,12 @@ class TestAzureCloudInterface(object):
             "AZURE_STORAGE_KEY": "storage_key",
         },
     )
+    @mock.patch("barman.cloud_providers.azure_blob_storage.requests.Session")
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
     def test_uploader_with_specified_credential(
         self,
         container_client_mock,
+        mock_session,
         mock_account_url,
         mock_object_path,
         mock_storage_url,
@@ -886,6 +888,7 @@ class TestAzureCloudInterface(object):
             account_url=mock_account_url,
             credential=credential,
             container_name=container_name,
+            session=mock_session.return_value,
             **default_azure_client_args
         )
 
@@ -893,10 +896,12 @@ class TestAzureCloudInterface(object):
         os.environ,
         {"AZURE_STORAGE_SAS_TOKEN": "sas_token", "AZURE_STORAGE_KEY": "storage_key"},
     )
+    @mock.patch("barman.cloud_providers.azure_blob_storage.requests.Session")
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
     def test_uploader_sas_token_auth(
         self,
         container_client_mock,
+        mock_session,
         mock_account_url,
         mock_storage_url,
         mock_object_path,
@@ -914,6 +919,7 @@ class TestAzureCloudInterface(object):
             account_url=mock_account_url,
             credential=os.environ["AZURE_STORAGE_SAS_TOKEN"],
             container_name=container_name,
+            session=mock_session.return_value,
             **default_azure_client_args
         )
 
@@ -921,10 +927,12 @@ class TestAzureCloudInterface(object):
         os.environ,
         {"AZURE_STORAGE_KEY": "storage_key"},
     )
+    @mock.patch("barman.cloud_providers.azure_blob_storage.requests.Session")
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
     def test_uploader_shared_token_auth(
         self,
         container_client_mock,
+        mock_session,
         mock_account_url,
         mock_storage_url,
         mock_object_path,
@@ -940,14 +948,17 @@ class TestAzureCloudInterface(object):
             account_url=mock_account_url,
             credential=os.environ["AZURE_STORAGE_KEY"],
             container_name=container_name,
+            session=mock_session.return_value,
             **default_azure_client_args
         )
 
     @mock.patch("azure.identity.DefaultAzureCredential")
+    @mock.patch("barman.cloud_providers.azure_blob_storage.requests.Session")
     @mock.patch("barman.cloud_providers.azure_blob_storage.ContainerClient")
     def test_uploader_default_credential_auth(
         self,
         container_client_mock,
+        mock_session,
         default_azure_credential,
         mock_account_url,
         mock_storage_url,
@@ -966,6 +977,7 @@ class TestAzureCloudInterface(object):
             account_url=mock_account_url,
             credential=default_azure_credential.return_value,
             container_name=container_name,
+            session=mock_session.return_value,
             **default_azure_client_args
         )
 

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -825,6 +825,13 @@ class TestAzureCloudInterface(object):
         mock_fileobj.tell.return_value = 42
         return mock_fileobj
 
+    @pytest.fixture
+    def default_azure_client_args(self):
+        return {
+            "max_block_size": 2 << 20,
+            "max_single_put_size": 4 << 20,
+        }
+
     @mock.patch.dict(
         os.environ,
         {
@@ -863,6 +870,7 @@ class TestAzureCloudInterface(object):
         mock_account_url,
         mock_object_path,
         mock_storage_url,
+        default_azure_client_args,
     ):
         """Specified credential option takes precedences over environment"""
         container_name = "container"
@@ -878,6 +886,7 @@ class TestAzureCloudInterface(object):
             account_url=mock_account_url,
             credential=credential,
             container_name=container_name,
+            **default_azure_client_args
         )
 
     @mock.patch.dict(
@@ -891,6 +900,7 @@ class TestAzureCloudInterface(object):
         mock_account_url,
         mock_storage_url,
         mock_object_path,
+        default_azure_client_args,
     ):
         """SAS token takes precedence over shared token"""
         container_name = "container"
@@ -904,6 +914,7 @@ class TestAzureCloudInterface(object):
             account_url=mock_account_url,
             credential=os.environ["AZURE_STORAGE_SAS_TOKEN"],
             container_name=container_name,
+            **default_azure_client_args
         )
 
     @mock.patch.dict(
@@ -917,6 +928,7 @@ class TestAzureCloudInterface(object):
         mock_account_url,
         mock_storage_url,
         mock_object_path,
+        default_azure_client_args,
     ):
         """Shared token is used if SAS token and connection string aren't set"""
         container_name = "container"
@@ -928,6 +940,7 @@ class TestAzureCloudInterface(object):
             account_url=mock_account_url,
             credential=os.environ["AZURE_STORAGE_KEY"],
             container_name=container_name,
+            **default_azure_client_args
         )
 
     @mock.patch("azure.identity.DefaultAzureCredential")
@@ -939,6 +952,7 @@ class TestAzureCloudInterface(object):
         mock_account_url,
         mock_storage_url,
         mock_object_path,
+        default_azure_client_args,
     ):
         """Uses DefaultAzureCredential if no other auth provided"""
         container_name = "container"
@@ -952,6 +966,7 @@ class TestAzureCloudInterface(object):
             account_url=mock_account_url,
             credential=default_azure_credential.return_value,
             container_name=container_name,
+            **default_azure_client_args
         )
 
     @mock.patch.dict(
@@ -1099,6 +1114,7 @@ class TestAzureCloudInterface(object):
             name=mock_key,
             data=mock_fileobj,
             overwrite=True,
+            max_concurrency=8,
             length=mock_fileobj.tell.return_value,
         )
 
@@ -1125,6 +1141,7 @@ class TestAzureCloudInterface(object):
             data=mock_fileobj,
             overwrite=True,
             length=mock_fileobj.tell.return_value,
+            max_concurrency=8,
             encryption_scope=encryption_scope,
         )
 
@@ -1177,6 +1194,7 @@ class TestAzureCloudInterface(object):
             data=mock_fileobj,
             overwrite=True,
             length=mock_fileobj.tell.return_value,
+            max_concurrency=8,
             tags=expected_tags,
         )
 


### PR DESCRIPTION
Improves the way we use the Azure container client to upload WALs so that concurrent uploading of chunks can be used, if so desired. This can yield more than double the throughput achieved with single-request uploads.

The defaults are set in the cloud interface to the values which have experimentally yielded a measurable improvement however the defaults in the CLI arguments have been set to keep the behaviour consistent with previous versions of Barman Cloud. This is so that users can opt-in to the concurrent upload method. If things go well we can change the CLI argument defaults to match those in the cloud interface.

Closes #472