### PR TITLE
Make python-snappy dependency optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup_requires = pytest_runner
 install_requires = [
     "psycopg2 >= 2.4.2",
     "python-dateutil",
-    "python-snappy >= 0.6.0",
     "argcomplete",
 ]
 
@@ -101,6 +100,7 @@ setup(
     extras_require={
         "cloud": ["boto3"],
         "azure": ["azure-identity", "azure-storage-blob"],
+        "snappy": ["python-snappy >= 0.6.0"],
     },
     platforms=["Linux", "Mac OS X"],
     classifiers=[

--- a/tests/requirements_dev.txt
+++ b/tests/requirements_dev.txt
@@ -1,6 +1,7 @@
 .
 .[cloud]
 .[azure]
+.[snappy]
 pytest
 mock
 pytest-timeout==1.4.2

--- a/tests/requirements_minimal.txt
+++ b/tests/requirements_minimal.txt
@@ -1,6 +1,7 @@
  .
  .[cloud]
  .[azure]
+ .[snappy]
 pytest==4.6.11
 boto3<1.11
 mock


### PR DESCRIPTION
Moves the python-snappy dependency to extras_require and lazily
imports it.

This is required so that we do not break barman on platforms which do
not have a sufficiently recent python-snappy package available in their
OS packages.

Users who wish to use --snappy compression will need to install
python-snappy with pip, the same way the cloud dependencies boto3,
azure-identity and azure-storage-blob are installed.

In the future we should look at resolving these dependencies at the OS
package level so that barman cloud does not require the manual
installation of any additional python packages.