### PR TITLE
Fix inactive server show-servers output with --format=json #488

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -872,11 +872,13 @@ def show_servers(args):
 
         # If the server has been manually disabled
         if not server.config.active:
-            name += " (inactive)"
+            description = "(inactive)"
         # If server has configuration errors
         elif server.config.disabled:
-            name += " (WARNING: disabled)"
-        output.init("show_server", name)
+            description = "(WARNING: disabled)"
+        else:
+            description = None
+        output.init("show_server", name, description=description)
         with closing(server):
             server.show()
     output.close_and_exit()


### PR DESCRIPTION
Changes the implementation of show-servers so that the status
description is passed to the output writer as a separate variable
instead of appending it directly to the name of the server. This allows
the JsonOutputWriter to use just the name of the server as the key when
creating the entry in the output dict.

This fixes a bug where the key was previously the name *and* the
description, meaning the result_show_server method would then cause a
KeyError when it attempted to access the results dict by the server
name alone.

Because the JSON output is keyed by server name the description is
simply added under the description key in the output. So that this
does not get overwritten the output logic is changed so that message
values of None are skipped if there is already a value for a particular
key in the output dict.

Closes #488.