### PR TITLE
remove redundant check

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -50,6 +50,7 @@ from barman.utils import (
     BarmanEncoder,
     check_non_negative,
     check_positive,
+    check_tli,
     configure_logging,
     drop_privileges,
     force_str,
@@ -583,7 +584,7 @@ def rebuild_xlogdb(args):
             completer=server_completer,
             help="specifies the server name for the command ",
         ),
-        argument("--target-tli", help="target timeline", type=check_positive),
+        argument("--target-tli", help="target timeline", type=check_tli),
         argument(
             "--target-time",
             help="target time. You can use any valid unambiguous representation. "

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -457,9 +457,13 @@ class RecoveryExecutor(object):
         """
         target_epoch = None
         target_datetime = None
+        calculated_target_tli = target_tli
+        if target_tli and type(target_tli) is str:
+          if target_tli in ["current","latest"]:
+            calculated_target_tli = backup_info.timeline
         d_immediate = backup_info.version >= 90400 and target_immediate
         d_lsn = backup_info.version >= 100000 and target_lsn
-        d_tli = target_tli and target_tli != backup_info.timeline
+        d_tli = target_tli and calculated_target_tli != backup_info.timeline
         # Detect PITR
         if target_time or target_xid or d_tli or target_name or d_immediate or d_lsn:
             recovery_info["is_pitr"] = True

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -502,7 +502,7 @@ class RecoveryExecutor(object):
                 targets["xid"] = str(target_xid)
             if d_lsn:
                 targets["lsn"] = str(d_lsn)
-            if d_tli and target_tli != backup_info.timeline:
+            if d_tli:
                 targets["timeline"] = str(d_tli)
             if target_name:
                 targets["name"] = str(target_name)

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -459,8 +459,8 @@ class RecoveryExecutor(object):
         target_datetime = None
         calculated_target_tli = target_tli
         if target_tli and type(target_tli) is str:
-          if target_tli in ["current","latest"]:
-            calculated_target_tli = backup_info.timeline
+            if target_tli in ["current", "latest"]:
+                calculated_target_tli = backup_info.timeline
         d_immediate = backup_info.version >= 90400 and target_immediate
         d_lsn = backup_info.version >= 100000 and target_lsn
         d_tli = target_tli and calculated_target_tli != backup_info.timeline

--- a/barman/server.py
+++ b/barman/server.py
@@ -1556,9 +1556,8 @@ class Server(RemoteStatusMixin):
         end = backup.end_wal
         # If timeline isn't specified, assume it is the same timeline
         # of the backup
-        calculated_target_tli = None
-        if not target_tli or (type(target_tli) is str and target_tli in ["current", "latest"]):
-            calculated_target_tli, _, _ = xlog.decode_segment_name(end)
+        if not target_tli:
+            target_tli, _, _ = xlog.decode_segment_name(end)
         with self.xlogdb() as fxlogdb:
             for line in fxlogdb:
                 wal_info = WalFileInfo.from_xlogdb_line(line)
@@ -1570,7 +1569,7 @@ class Server(RemoteStatusMixin):
                 if wal_info.name < begin:
                     continue
                 tli, _, _ = xlog.decode_segment_name(wal_info.name)
-                if tli > calculated_target_tli:
+                if tli > target_tli:
                     continue
                 yield wal_info
                 if wal_info.name > end:

--- a/barman/utils.py
+++ b/barman/utils.py
@@ -614,6 +614,26 @@ def check_positive(value):
     return int_value
 
 
+def check_tli(value):
+    """
+    Check for a positive integer option, and also make "current" and "latest" acceptable values
+
+    :param value: str containing the value to check
+    """
+    if value is None:
+        return None
+    try:
+        int_value = int(value)
+    except Exception:
+        if not value.isdigit():
+            assert(value in ["current","latest"]), "'%s' is not a valid TLI" % value
+        else:
+            raise ArgumentTypeError("'%s' is not a valid positive integer" % value)
+    if value < 1:
+        raise ArgumentTypeError("'%s' is not a valid positive integer" % value)
+    return value
+
+
 def check_size(value):
     """
     Check user input for a human readable size

--- a/barman/utils.py
+++ b/barman/utils.py
@@ -623,10 +623,10 @@ def check_tli(value):
     if value is None:
         return None
     try:
-        int_value = int(value)
+        int(value)
     except Exception:
         if not value.isdigit():
-            assert(value in ["current","latest"]), "'%s' is not a valid TLI" % value
+            assert(value in ["current", "latest"]), "'%s' is not a valid TLI" % value
         else:
             raise ArgumentTypeError("'%s' is not a valid positive integer" % value)
     if value < 1:


### PR DESCRIPTION
`d_tli` is already a boolean based on `target_tli != backup_info.timeline`, so no need to check it again