### PR TITLE
Fix barman-cloud-check-wal-archive to observe -t option

### DIFF
--- a/barman/clients/cloud_check_wal_archive.py
+++ b/barman/clients/cloud_check_wal_archive.py
@@ -47,6 +47,9 @@ def main(args=None):
         if not cloud_interface.test_connectivity():
             # Deliberately raise an error if we cannot connect
             raise NetworkErrorExit()
+        # If test is requested, just exit after connectivity test
+        elif config.test:
+            raise SystemExit(0)
         if not cloud_interface.bucket_exists:
             # If the bucket does not exist then the check should pass
             return

--- a/barman/utils.py
+++ b/barman/utils.py
@@ -249,8 +249,8 @@ def total_seconds(timedelta):
     if hasattr(timedelta, "total_seconds"):
         return timedelta.total_seconds()
     else:
-        secs = (timedelta.seconds + timedelta.days * 24 * 3600) * 10 ** 6
-        return (timedelta.microseconds + secs) / 10.0 ** 6
+        secs = (timedelta.seconds + timedelta.days * 24 * 3600) * 10**6
+        return (timedelta.microseconds + secs) / 10.0**6
 
 
 def which(executable, path=None):

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -70,8 +70,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"Barman"
-copyright = u"2011-2022 EnterpriseDB UK Limited]"
+project = "Barman"
+copyright = "2011-2022 EnterpriseDB UK Limited]"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -230,8 +230,8 @@ latex_documents = [
     (
         "index",
         "Barman.tex",
-        u"Barman Documentation",
-        u"EnterpriseDB UK Limited",
+        "Barman Documentation",
+        "EnterpriseDB UK Limited",
         "manual",
     ),
 ]
@@ -262,7 +262,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ("index", "barman", u"Barman Documentation", [u"EnterpriseDB UK Limited"], 1)
+    ("index", "barman", "Barman Documentation", ["EnterpriseDB UK Limited"], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -278,8 +278,8 @@ texinfo_documents = [
     (
         "index",
         "Barman",
-        u"Barman Documentation",
-        u"EnterpriseDB UK Limited",
+        "Barman Documentation",
+        "EnterpriseDB UK Limited",
         "Barman",
         "Barman, Backup and Recovery Manager for PostgreSQL",
         "Miscellaneous",
@@ -299,10 +299,10 @@ texinfo_documents = [
 # -- Options for Epub output --------------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = u"Barman"
-epub_author = u"EnterpriseDB UK Limited"
-epub_publisher = u"EnterpriseDB UK Limited"
-epub_copyright = u"2011-2022, EnterpriseDB UK Limited"
+epub_title = "Barman"
+epub_author = "EnterpriseDB UK Limited"
+epub_publisher = "EnterpriseDB UK Limited"
+epub_copyright = "2011-2022, EnterpriseDB UK Limited"
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.

--- a/tests/test_barman_cloud_check_wal_archive.py
+++ b/tests/test_barman_cloud_check_wal_archive.py
@@ -33,6 +33,16 @@ class TestCloudCheckWalArchive(object):
         }
         return cloud_backup_catalog
 
+    @mock.patch("barman.clients.cloud_check_wal_archive.get_cloud_interface")
+    def test_exits_on_connectivity_test(self, get_cloud_interface_mock):
+        """If the -t option is used we check connectivity and exit."""
+        cloud_interface_mock = get_cloud_interface_mock.return_value
+        cloud_interface_mock.test_connectivity.return_value = True
+        with pytest.raises(SystemExit) as exc:
+            cloud_check_wal_archive.main(["cloud_storage_url", "test_server", "-t"])
+        assert exc.value.code == 0
+        cloud_interface_mock.test_connectivity.assert_called_once()
+
     @mock.patch("barman.clients.cloud_check_wal_archive.check_archive_usable")
     @mock.patch("barman.clients.cloud_check_wal_archive.CloudBackupCatalog")
     @mock.patch("barman.clients.cloud_check_wal_archive.get_cloud_interface")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -641,7 +641,7 @@ class TestForceText(object):
         """
         Force text normal usage
         """
-        accented = u"\u0227\u0188\u0188\u1e17\u019e\u0167\u1e17\u1e13"
+        accented = "\u0227\u0188\u0188\u1e17\u019e\u0167\u1e17\u1e13"
 
         class Test:
             if sys.version_info[0] >= 3:
@@ -708,10 +708,10 @@ class TestCheckSize(object):
             ["300MB", 300 << 20],
             ["20GB", 20 << 30],
             ["1TB", 1 << 40],
-            ["12kiB", 12 * 10 ** 3],
-            ["300MiB", 300 * 10 ** 6],
-            ["20GiB", 20 * 10 ** 9],
-            ["1TiB", 1 * 10 ** 12],
+            ["12kiB", 12 * 10**3],
+            ["300MiB", 300 * 10**6],
+            ["20GiB", 20 * 10**9],
+            ["1TiB", 1 * 10**12],
         ],
     )
     def test_parse(self, size, bytes):

--- a/tests/test_xlog.py
+++ b/tests/test_xlog.py
@@ -75,17 +75,14 @@ class Test(object):
             "000000010000000200000001",
             "000000010000000200000002",
         )
-        assert (
-            tuple(
-                xlog.generate_segment_names(
-                    "0000000100000001000000FD",
-                    "0000000100000001000000FF",
-                    90200,
-                    xlog.DEFAULT_XLOG_SEG_SIZE,
-                )
+        assert tuple(
+            xlog.generate_segment_names(
+                "0000000100000001000000FD",
+                "0000000100000001000000FF",
+                90200,
+                xlog.DEFAULT_XLOG_SEG_SIZE,
             )
-            == ("0000000100000001000000FD", "0000000100000001000000FE")
-        )
+        ) == ("0000000100000001000000FD", "0000000100000001000000FE")
 
         assert tuple(
             xlog.generate_segment_names(
@@ -565,15 +562,11 @@ class TestCheckArchiveUsable(object):
                 wals,
                 timeline=timeline,
             )
-        assert (
-            self.EXPECTED_ARCHIVE_CONTENT_ERROR
-            % (
-                num_expected_newer_files,
-                num_expected_newer_files > 1 and "s" or "",
-                timeline,
-            )
-            == str(exc.value)
-        )
+        assert self.EXPECTED_ARCHIVE_CONTENT_ERROR % (
+            num_expected_newer_files,
+            num_expected_newer_files > 1 and "s" or "",
+            timeline,
+        ) == str(exc.value)
 
     @pytest.mark.parametrize(
         "wals,timeline",
@@ -637,15 +630,11 @@ class TestCheckArchiveUsable(object):
                 wals,
                 timeline=timeline,
             )
-        assert (
-            self.EXPECTED_ARCHIVE_CONTENT_ERROR
-            % (
-                num_expected_illegal_files,
-                num_expected_illegal_files > 1 and "s" or "",
-                timeline,
-            )
-            == str(exc.value)
-        )
+        assert self.EXPECTED_ARCHIVE_CONTENT_ERROR % (
+            num_expected_illegal_files,
+            num_expected_illegal_files > 1 and "s" or "",
+            timeline,
+        ) == str(exc.value)
 
     @pytest.mark.parametrize(
         "wals",


### PR DESCRIPTION
Closes #503

---

This is the same as #505 but pushed directly to the repo so that all the checks can run.