### PR TITLE
Update Black pipeline

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -31,9 +31,8 @@ jobs:
           fi
       - name: Step 4 - Commit changes
         if: contains(steps.git-status.outputs.status, 'true')
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@v8
         with:
           default_author: github_actions
           message: "black: reformat source code"
-          pull_strategy: "NO-PULL"
           push: true


### PR DESCRIPTION
update add-and-commit action to v8

This will remove deprecation warning  "The 'pull_strategy' input is deprecated, please use 'pull'"

`pull` default behavior is no pull in v8