### PR TITLE
Avoid copying contents of pg_tblspc to passive server

### DIFF
--- a/barman/server.py
+++ b/barman/server.py
@@ -3593,8 +3593,11 @@ class Server(RemoteStatusMixin):
                     # Exclude primary Barman metadata and state
                     exclude_and_protect = ["/backup.info", "/.backup.lock"]
                     # Exclude any tablespace symlinks created by pg_basebackup
-                    for tablespace in local_backup_info.tablespaces:
-                        exclude_and_protect += ["/data/pg_tblspc/%s" % tablespace.oid]
+                    if local_backup_info.tablespaces is not None:
+                        for tablespace in local_backup_info.tablespaces:
+                            exclude_and_protect += [
+                                "/data/pg_tblspc/%s" % tablespace.oid
+                            ]
                     copy_controller.add_directory(
                         "basebackup",
                         ":%s/%s/" % (remote_backup_dir, backup_name),

--- a/barman/server.py
+++ b/barman/server.py
@@ -3590,11 +3590,16 @@ class Server(RemoteStatusMixin):
                         retry_sleep=self.config.basebackup_retry_sleep,
                         workers=self.config.parallel_jobs,
                     )
+                    # Exclude primary Barman metadata and state
+                    exclude_and_protect = ["/backup.info", "/.backup.lock"]
+                    # Exclude any tablespace symlinks created by pg_basebackup
+                    for tablespace in local_backup_info.tablespaces:
+                        exclude_and_protect += ["/data/pg_tblspc/%s" % tablespace.oid]
                     copy_controller.add_directory(
                         "basebackup",
                         ":%s/%s/" % (remote_backup_dir, backup_name),
                         local_backup_info.get_basebackup_directory(),
-                        exclude_and_protect=["/backup.info", "/.backup.lock"],
+                        exclude_and_protect=exclude_and_protect,
                         bwlimit=self.config.bandwidth_limit,
                         reuse=reuse_dir,
                         item_class=RsyncCopyController.PGDATA_CLASS,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -339,6 +339,19 @@ class TestSync(object):
             with pytest.raises(SyncNothingToDo):
                 server.check_sync_required(backup_name, backups, local_backup_info_mock)
 
+    def _create_primary_info_file(self, base_tmpdir, backup_dir):
+        """
+        Helper for sync_backup tests which creates a primary info file on disk.
+        """
+        primary_info_file = backup_dir.join(barman.server.PRIMARY_INFO_FILE)
+        remote_basebackup_dir = base_tmpdir.mkdir("primary")
+        primary_info_content = dict(EXPECTED_MINIMAL)
+        primary_info_content["config"].update(
+            basebackups_directory=str(remote_basebackup_dir)
+        )
+        primary_info_file.write(json.dumps(primary_info_content))
+        return primary_info_content
+
     @mock.patch("barman.server.RsyncCopyController")
     @mock.patch("barman.server._logger")
     def test_sync_backup(self, logger_mock, rsync_mock, tmpdir, capsys):
@@ -358,15 +371,8 @@ class TestSync(object):
         backup_dir = tmpdir.mkdir(server_name)
         basebackup_dir = backup_dir.mkdir("base")
         full_backup_path = basebackup_dir.mkdir(backup_name)
-        primary_info_file = backup_dir.join(barman.server.PRIMARY_INFO_FILE)
 
-        # prepare the primary_info file
-        remote_basebackup_dir = tmpdir.mkdir("primary")
-        primary_info_content = dict(EXPECTED_MINIMAL)
-        primary_info_content["config"].update(
-            basebackups_directory=str(remote_basebackup_dir)
-        )
-        primary_info_file.write(json.dumps(primary_info_content))
+        self._create_primary_info_file(tmpdir, backup_dir)
 
         # Test 1: Not a passive node.
         # Expect SyncError
@@ -461,6 +467,55 @@ class TestSync(object):
         assert not rsync_mock.called
         (out, err) = capsys.readouterr()
         assert out.strip() == "Backup 1234567890 is already synced with main server"
+
+    @mock.patch("barman.server.RsyncCopyController")
+    def test_sync_backup_tablespaces(self, rsync_mock, tmpdir):
+        """
+        Verify that the top level tablespaces are synced but symlinks in pg_tblspc are
+        not.
+        """
+        # GIVEN a backup for server 'main'
+        backup_name = "1234567890"
+        server_name = "main"
+
+        # WITH a minimal set of files on disk
+        backup_dir = tmpdir.mkdir(server_name)
+        primary_info_content = self._create_primary_info_file(tmpdir, backup_dir)
+
+        # AND a primary server
+        server = build_real_server(
+            global_conf={"barman_lock_directory": tmpdir.strpath},
+            main_conf={
+                "backup_directory": backup_dir.strpath,
+                "primary_ssh_command": "ssh fakeuser@fakehost",
+            },
+        )
+
+        # WHEN sync_backup is called for the backup
+        server.sync_backup(backup_name)
+
+        # THEN the data directory of that backup is added to the copy controller
+        copy_controller = rsync_mock.return_value
+        copy_controller.add_directory.assert_called_once()
+        assert "basebackup" == copy_controller.add_directory.call_args_list[0][0][0]
+        assert (
+            ":%s/%s/"
+            % (primary_info_content["config"]["basebackups_directory"], backup_name)
+            == copy_controller.add_directory.call_args_list[0][0][1]
+        )
+
+        # AND the tablespace symlinks in /data/pg_tblspc are excluded along with
+        # the /backup.info and /.backup.lock files AND no other files or directories
+        # are excluded
+        expected_excludes = [
+            "/data/pg_tblspc/16387",
+            "/data/pg_tblspc/16405",
+            "/backup.info",
+            "/.backup.lock",
+        ]
+        assert set(expected_excludes) == set(
+            copy_controller.add_directory.call_args_list[0][1]["exclude_and_protect"]
+        )
 
     @mock.patch("barman.server.Rsync")
     def test_sync_wals(self, rsync_mock, tmpdir, capsys):


### PR DESCRIPTION
Adds `/data/pg_tblspc/*` to the exclude_and_protect filter during the
sync_backup operation so that any symlinks present are not transformed
into their referent directories by rsync during the sync of the backup
to a passive Barman server.

This is required in order to stop rsync from tranforming such symlinks
into their referent directories and copying them onto the passive server
along with the link targets in the root of the base backup directory.
This would result in the tablespace data being duplicated on the passive
server.

Such symlinks are only created on the primary Barman server when using
`backup_method=postgres`. When `backup_method=rsync` is used Barman
excludes the symlinks in `pg_tblspc` and therefore they are not present
when syncing to the passive server.

As a result of this patch the symlinks created during a backup with
`backup_method=postgres` will not be copied to the passive server at all
however this is not a problem because Barman will recreate the symlinks
itself during a `barman recover` using the information in `backup.info`.

Closes #309 and #516.