### PR TITLE
Update conditions to allow run SQ on master (Closes #518)

### DIFF
--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -11,7 +11,7 @@ jobs:
   sonarQube:
     name: SonarQube-Job
     runs-on: ubuntu-latest
-    if: (github.event_name != 'pull_request' && github.ref == 'master') || github.event.pull_request.head.repo.full_name == 'EnterpriseDB/barman'
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'EnterpriseDB/barman'
     steps:
       - name: Checkout source repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Update conditions to allow run SQ on master (Closes #518)

Could use following condition:
```
github.event_name != 'pull_request' && github.ref == 'refs/heads/master' || github.event.pull_request.head.repo.full_name == 'EnterpriseDB/barman'
```
Trigger on push is always on master so github.ref is not necessary.
So ended with something more simple that will allow push on master and manual trigger.
```
github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'EnterpriseDB/barman'
```