### PR TITLE
Rename streaming to streaming-backups to avoid misleading information…

### DIFF
--- a/doc/barman.d/streaming-server.conf-template
+++ b/doc/barman.d/streaming-server.conf-template
@@ -5,7 +5,7 @@
 ; only streaming replication protocol
 ;
 
-[streaming]
+[streaming-server]
 ; Human readable description
 description =  "Example of PostgreSQL Database (Streaming-Only)"
 


### PR DESCRIPTION
… (#532)

Should be merged after 2.19 is out because it will probably impact functional tests. 
