### PR TITLE
Improve documentation of --get-wal/--no-get-wal

### DIFF
--- a/doc/manual/42-server-commands.en.md
+++ b/doc/manual/42-server-commands.en.md
@@ -122,6 +122,10 @@ fetch the required WAL files.
 Similarly, one can use the `--get-wal` option for the `recover` command
 at run-time.
 
+If `get-wal` is set in `recovery_options` but not required during a
+recovery operation then the `--no-get-wal` option can be used with the
+`recover` command to disable the `get-wal` recovery option.
+
 This is an example of a `restore_command` for a local recovery:
 
 ``` ini

--- a/doc/manual/43-backup-commands.en.md
+++ b/doc/manual/43-backup-commands.en.md
@@ -296,6 +296,20 @@ as a standby by creating a `standby.signal` file (from PostgreSQL 12)
 or by adding `standby_mode = on` to the generated recovery configuration.
 Further information on _standby mode_ is available in the PostgreSQL documentation.
 
+### Fetching WALs from the Barman server
+
+The `barman recover` command can optionally configure PostgreSQL to fetch
+WALs from Barman during recovery. This is enabled by setting the
+`recovery_options` global/server configuration option to `'get-wal'` as
+described in the [get-wal section](#get-wal). If `recovery_options` is not
+set or is empty then Barman will instead copy the WALs required for recovery
+while executing the `barman recover` command.
+
+The `--get-wal` and `--no-get-wal` options can be used to override the
+behaviour defined by `recovery_options`. Use `--get-wal` with `barman recover`
+to enable the fetching of WALs from the Barman server, alternatively use
+`--no-get-wal` to disable it.
+
 ## `show-backup`
 
 You can retrieve all the available information for a particular backup of


### PR DESCRIPTION
Updates the documentation around barman recover to describe how
--get-wal and --no-get-wal interact with recovery_options to determine
whether WALs are copied to the PostgreSQL server or fetched from the
Barman server.

Closes #521.

Thanks to @bmejiasedb for reporting this gap in the documentation.