### PR TITLE
Clarify docs around verifying barman/pg connection

### DIFF
--- a/doc/manual/21-preliminary_steps.en.md
+++ b/doc/manual/21-preliminary_steps.en.md
@@ -55,7 +55,9 @@ You can choose your favourite client authentication method among those
 offered by PostgreSQL. More information can be found in the
 ["Client Authentication" section of the PostgreSQL Documentation][pghba].
 
-Make sure you test the following command before proceeding:
+Run the following command as the barman user on the `backup` host in
+order to verify that the `backup` host can connect to PostgreSQL on
+the `pg` host:
 
 ``` bash
 barman@backup$ psql -c 'SELECT version()' -U barman -h pg postgres


### PR DESCRIPTION
Updates the documentation around the following command in the docs:

    barman@backup$ psql -c 'SELECT version()' -U barman -h pg postgres

The documentation is updated so that it explains the reason for running
the command as well as stating the user and host which should be used.

Thanks to @elhananjair for reporting the issue.