### PR TITLE
Support pg_basebackup compression options

### DIFF
--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -295,6 +295,7 @@ class PostgresBackupExecutor(BackupExecutor):
                 "postgres backup_method"
             )
 
+        remote_status = None
         # bandwidth_limit option is supported by pg_basebackup executable
         # starting from Postgres 9.4
         if self.server.config.bandwidth_limit:
@@ -315,7 +316,9 @@ class PostgresBackupExecutor(BackupExecutor):
 
         # validate compression options
         if self.backup_compression:
-            self.backup_compression.validate(self.server)
+            if remote_status is None:
+                remote_status = self.fetch_remote_status()
+            self.backup_compression.validate(self.server, remote_status)
 
     def backup(self, backup_info):
         """

--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -1609,7 +1609,7 @@ class PostgresBackupStrategy(BackupStrategy):
 
         :param barman.infofile.LocalBackupInfo backup_info: backup information
         """
-        if self.backup_compression:
+        if self.backup_compression and self.backup_compression.format == "tar":
             backup_info.set_attribute("compression", self.backup_compression.type)
 
         self._read_backup_label(backup_info)

--- a/barman/command_wrappers.py
+++ b/barman/command_wrappers.py
@@ -891,6 +891,7 @@ class PgBaseBackup(PostgreSQLClient):
         tbs_mapping=None,
         immediate=False,
         check=True,
+        compression=None,
         args=None,
         **kwargs
     ):
@@ -908,6 +909,8 @@ class PgBaseBackup(PostgreSQLClient):
         :param bool immediate: fast checkpoint identifier for pg_basebackup
         :param bool check: check if the return value is in the list of
           allowed values of the Command obj
+        :param barman.compression.PgBaseBackupCompression compression:
+          the pg_basebackup compression options used for this backup
         :param List[str] args: additional arguments
         """
         PostgreSQLClient.__init__(
@@ -946,6 +949,15 @@ class PgBaseBackup(PostgreSQLClient):
         # Immediate checkpoint
         if immediate:
             self.args.append("--checkpoint=fast")
+
+        # Add any supplied compression arguments
+        if compression is not None:
+            # The tar format is required by pg_basebackup if compression is to
+            # be used
+            self.args.append("--format=tar")
+            self.args.append("--%s" % compression.type)
+            if compression.level is not None:
+                self.args.append("--compress=%d" % compression.level)
 
         # Manage additional args
         if args:

--- a/barman/command_wrappers.py
+++ b/barman/command_wrappers.py
@@ -976,6 +976,8 @@ class PgBaseBackup(PostgreSQLClient):
             # For clients >= 15 we use the new --compress argument format
             if version and version >= Version("15"):
                 compress_arg = "--compress="
+                if compression.location is not None:
+                    compress_arg += "%s-" % compression.location
                 compress_arg += compression.type
                 if compression.level:
                     compress_arg += ":level=%d" % compression.level

--- a/barman/command_wrappers.py
+++ b/barman/command_wrappers.py
@@ -971,8 +971,11 @@ class PgBaseBackup(PostgreSQLClient):
         compression_args = []
 
         if compression is not None:
-            # Format is always tar until client/server compression is supported
-            compression_args.append("--format=tar")
+            if compression.format is not None:
+                compression_format = compression.format
+            else:
+                compression_format = "tar"
+            compression_args.append("--format=%s" % compression_format)
             # For clients >= 15 we use the new --compress argument format
             if version and version >= Version("15"):
                 compress_arg = "--compress="

--- a/barman/compression.py
+++ b/barman/compression.py
@@ -28,6 +28,7 @@ import shutil
 import sys
 from abc import ABCMeta, abstractmethod, abstractproperty
 from contextlib import closing, contextmanager
+from distutils.version import LooseVersion as Version
 
 import barman.infofile
 from barman.command_wrappers import Command
@@ -443,6 +444,7 @@ class PgBaseBackupCompression(with_metaclass(ABCMeta, object)):
         """
         self.type = config.backup_compression
         self.level = config.backup_compression_level
+        self.location = self.config.backup_compression_location
 
     @abstractproperty
     def suffix(self):
@@ -467,14 +469,29 @@ class PgBaseBackupCompression(with_metaclass(ABCMeta, object)):
           file to be opened.
         """
 
-    def validate(self, server):
+    def validate(self, server, remote_status):
         """
         Validate pg_basebackup compression options.
 
         :param barman.server.Server server: the server for which the
           compression options should be validated.
+        :param dict remote_status: the status of the pg_basebackup command
         """
-        pass
+        if self.location is not None and self.location == "server":
+            # "backup_location = server" requires pg_basebackup >= 15
+            if remote_status["pg_basebackup_version"] < Version("15"):
+                server.config.disabled = True
+                server.config.msg_list.append(
+                    "backup_compression_location = server requires "
+                    "pg_basebackup 15 or greater"
+                )
+            # "backup_location = server" requires PostgreSQL >= 15
+            if server.postgres.server_version < 150000:
+                server.config.disabled = True
+                server.config.msg_list.append(
+                    "backup_compression_location = server requires "
+                    "PostgreSQL 15 or greater"
+                )
 
 
 class GZipPgBaseBackupCompression(PgBaseBackupCompression):
@@ -490,14 +507,15 @@ class GZipPgBaseBackupCompression(PgBaseBackupCompression):
         """
         yield gzip.open(self.with_suffix(basename), "rb")
 
-    def validate(self, server):
+    def validate(self, server, remote_status):
         """
         Validate gzip-specific options.
 
         :param barman.server.Server server: the server for which the
           compression options should be validated.
+        :param dict remote_status: the status of the pg_basebackup command
         """
-        super(GZipPgBaseBackupCompression, self).validate(server)
+        super(GZipPgBaseBackupCompression, self).validate(server, remote_status)
         if self.level is not None and (self.level < 1 or self.level > 9):
             server.config.disabled = True
             server.config.msg_list.append(

--- a/barman/compression.py
+++ b/barman/compression.py
@@ -443,8 +443,9 @@ class PgBaseBackupCompression(with_metaclass(ABCMeta, object)):
         :param barman.config.ServerConfig config: the server configuration
         """
         self.type = config.backup_compression
+        self.format = config.backup_compression_format
         self.level = config.backup_compression_level
-        self.location = self.config.backup_compression_location
+        self.location = config.backup_compression_location
 
     @abstractproperty
     def suffix(self):
@@ -492,6 +493,14 @@ class PgBaseBackupCompression(with_metaclass(ABCMeta, object)):
                     "backup_compression_location = server requires "
                     "PostgreSQL 15 or greater"
                 )
+
+        # plain backup format is only allowed when compression is on the server
+        if self.format == "plain" and self.location != "server":
+            server.config.disabled = True
+            server.config.msg_list.append(
+                "backup_compression_format plain is not compatible with "
+                "backup_compression_location %s" % self.location
+            )
 
 
 class GZipPgBaseBackupCompression(PgBaseBackupCompression):

--- a/barman/config.py
+++ b/barman/config.py
@@ -307,6 +307,21 @@ def parse_backup_compression(value):
         "Invalid value (must be one in: '%s')" % ("', '".join(BASEBACKUP_COMPRESSIONS))
     )
 
+def parse_backup_compression_location(value):
+    """
+    Parse a string to a valid backup_compression location value.
+
+    Valid values are "client" and "server"
+
+    :param str value: backup_compression_location value
+    :raises ValueError: if the value is invalid
+    """
+    if value is None:
+        return None
+    if value.lower() in ("client", "server"):
+        return value.lower()
+    raise ValueError("Invalid value (must be either `client` or `server`)")
+
 
 def parse_backup_method(value):
     """
@@ -377,6 +392,7 @@ class ServerConfig(object):
         "archiver_batch_size",
         "backup_compression",
         "backup_compression_level",
+        "backup_compression_location",
         "backup_directory",
         "backup_method",
         "backup_options",
@@ -448,6 +464,7 @@ class ServerConfig(object):
         "archiver_batch_size",
         "backup_compression",
         "backup_compression_level",
+        "backup_compression_location",
         "backup_method",
         "backup_options",
         "bandwidth_limit",
@@ -508,6 +525,7 @@ class ServerConfig(object):
         "active": "true",
         "archiver": "off",
         "archiver_batch_size": "0",
+        "backup_compression_location": "client",
         "backup_directory": "%(barman_home)s/%(name)s",
         "backup_method": "rsync",
         "backup_options": "",
@@ -546,6 +564,7 @@ class ServerConfig(object):
         "archiver_batch_size": int,
         "backup_compression": parse_backup_compression,
         "backup_compression_level": int,
+        "backup_compression_location": parse_backup_compression_location,
         "backup_method": parse_backup_method,
         "backup_options": BackupOptions,
         "basebackup_retry_sleep": int,

--- a/barman/config.py
+++ b/barman/config.py
@@ -307,6 +307,23 @@ def parse_backup_compression(value):
         "Invalid value (must be one in: '%s')" % ("', '".join(BASEBACKUP_COMPRESSIONS))
     )
 
+
+def parse_backup_compression_format(value):
+    """
+    Parse a string to a valid backup_compression format value.
+
+    Valid values are "plain" and "tar"
+
+    :param str value: backup_compression_location value
+    :raises ValueError: if the value is invalid
+    """
+    if value is None:
+        return None
+    if value.lower() in ("plain", "tar"):
+        return value.lower()
+    raise ValueError("Invalid value (must be either `plain` or `tar`)")
+
+
 def parse_backup_compression_location(value):
     """
     Parse a string to a valid backup_compression location value.
@@ -391,6 +408,7 @@ class ServerConfig(object):
         "archiver",
         "archiver_batch_size",
         "backup_compression",
+        "backup_compression_format",
         "backup_compression_level",
         "backup_compression_location",
         "backup_directory",
@@ -463,6 +481,7 @@ class ServerConfig(object):
         "archiver",
         "archiver_batch_size",
         "backup_compression",
+        "backup_compression_format",
         "backup_compression_level",
         "backup_compression_location",
         "backup_method",
@@ -525,6 +544,7 @@ class ServerConfig(object):
         "active": "true",
         "archiver": "off",
         "archiver_batch_size": "0",
+        "backup_compression_format": "tar",
         "backup_compression_location": "client",
         "backup_directory": "%(barman_home)s/%(name)s",
         "backup_method": "rsync",
@@ -563,6 +583,7 @@ class ServerConfig(object):
         "archiver": parse_boolean,
         "archiver_batch_size": int,
         "backup_compression": parse_backup_compression,
+        "backup_compression_format": parse_backup_compression_format,
         "backup_compression_level": int,
         "backup_compression_location": parse_backup_compression_location,
         "backup_method": parse_backup_method,

--- a/barman/config.py
+++ b/barman/config.py
@@ -70,6 +70,9 @@ BACKUP_METHOD_VALUES = ["rsync", "postgres", "local-rsync"]
 
 CREATE_SLOT_VALUES = ["manual", "auto"]
 
+# Config values relating to pg_basebackup compression
+BASEBACKUP_COMPRESSIONS = ["gzip"]
+
 
 class CsvOption(set):
 
@@ -287,6 +290,24 @@ def parse_reuse_backup(value):
     )
 
 
+def parse_backup_compression(value):
+    """
+    Parse a string to a valid backup_compression value.
+
+    Valid values are contained in compression.basebackup_compressions list
+
+    :param str value: backup_compression value
+    :raises ValueError: if the value is invalid
+    """
+    if value is None:
+        return None
+    if value.lower() in BASEBACKUP_COMPRESSIONS:
+        return value.lower()
+    raise ValueError(
+        "Invalid value (must be one in: '%s')" % ("', '".join(BASEBACKUP_COMPRESSIONS))
+    )
+
+
 def parse_backup_method(value):
     """
     Parse a string to a valid backup_method value.
@@ -354,6 +375,8 @@ class ServerConfig(object):
         "active",
         "archiver",
         "archiver_batch_size",
+        "backup_compression",
+        "backup_compression_level",
         "backup_directory",
         "backup_method",
         "backup_options",
@@ -423,6 +446,8 @@ class ServerConfig(object):
     BARMAN_KEYS = [
         "archiver",
         "archiver_batch_size",
+        "backup_compression",
+        "backup_compression_level",
         "backup_method",
         "backup_options",
         "bandwidth_limit",
@@ -519,6 +544,8 @@ class ServerConfig(object):
         "active": parse_boolean,
         "archiver": parse_boolean,
         "archiver_batch_size": int,
+        "backup_compression": parse_backup_compression,
+        "backup_compression_level": int,
         "backup_method": parse_backup_method,
         "backup_options": BackupOptions,
         "basebackup_retry_sleep": int,

--- a/barman/infofile.py
+++ b/barman/infofile.py
@@ -471,6 +471,7 @@ class BackupInfo(FieldListFile):
         "xlog_segment_size", load=int, default=xlog.DEFAULT_XLOG_SEG_SIZE
     )
     systemid = Field("systemid")
+    compression = Field("compression")
 
     __slots__ = "backup_id", "backup_version"
 

--- a/tests/test_backup_strategy.py
+++ b/tests/test_backup_strategy.py
@@ -1,0 +1,242 @@
+# -*- coding: utf-8 -*-
+# © Copyright EnterpriseDB UK Limited 2013-2022
+#
+# This file is part of Barman.
+#
+# Barman is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Barman is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Barman.  If not, see <http://www.gnu.org/licenses/>.
+
+import mock
+import os
+import pytest
+
+from io import BytesIO
+from tarfile import TarFile, TarInfo
+
+from barman.backup_executor import PostgresBackupStrategy
+from barman.compression import GZipPgBaseBackupCompression
+from barman.exceptions import BackupException
+from barman.infofile import LocalBackupInfo
+
+from testing_helpers import build_mocked_server
+
+
+def _tar_file(items):
+    """Helper to create an in-memory tar file with multiple files."""
+    tar_fileobj = BytesIO()
+    tf = TarFile.open(mode="w|", fileobj=tar_fileobj)
+    for item_name, item_bytes in items:
+        ti = TarInfo(name=item_name)
+        content_as_bytes = item_bytes.encode("utf-8")
+        ti.size = len(content_as_bytes)
+        tf.addfile(ti, BytesIO(content_as_bytes))
+    tf.close()
+    tar_fileobj.seek(0)
+    return tar_fileobj
+
+
+class TestPostgresBackupStrategy(object):
+    """
+    Tests for behaviour specific to PostgresBackupStrategy.
+    """
+
+    @pytest.mark.parametrize(
+        "compression",
+        (None, "gzip"),
+    )
+    @mock.patch("barman.backup_executor.PostgresBackupStrategy._read_backup_label")
+    @mock.patch(
+        "barman.backup_executor.PostgresBackupStrategy._backup_info_from_backup_label"
+    )
+    @mock.patch(
+        "barman.backup_executor.PostgresBackupStrategy._backup_info_from_stop_location"
+    )
+    def test_stop_backup_sets_backup_info(
+        self,
+        _mock_backup_info_from_stop_location,
+        _mock_backup_info_from_backup_label,
+        _mock_read_backup_label,
+        compression,
+    ):
+        """
+        Verifies that the compression is set in backup_info when stopping the
+        backup.
+        """
+        # GIVEN a server comfigured for pg_basebackup compression
+        server = build_mocked_server(
+            global_conf={
+                "backup_method": "postgres",
+                "backup_compression": compression,
+            }
+        )
+        # AND a PgBaseBackupCompression for the configured compression
+        if compression is not None:
+            backup_compression = GZipPgBaseBackupCompression(server.config)
+        else:
+            backup_compression = None
+        # AND a BackupInfo representing an ongoing backup
+        backup_info = LocalBackupInfo(server=server, backup_id="fake_id")
+        # AND a PostgresBackupStrategy with the configured compression
+        mock_postgres = mock.Mock()
+        strategy = PostgresBackupStrategy(
+            mock_postgres, "test-server", backup_compression
+        )
+
+        # WHEN stop_backup is called with the BackupInfo
+        strategy.stop_backup(backup_info)
+
+        # THEN the compression field of the BackupInfo is set to the
+        # expected compression
+        assert backup_info.compression == compression
+
+    @pytest.mark.parametrize(
+        "archive_content",
+        [
+            [
+                (
+                    "backup_label",
+                    "mock_backup_label_content",
+                )
+            ],
+            [
+                ("some_other_file", "some_other_content"),
+                (
+                    "backup_label",
+                    "mock_backup_label_content",
+                ),
+            ],
+        ],
+    )
+    def test_read_backup_label_from_compressed_backup(
+        self,
+        archive_content,
+    ):
+        """
+        Verifies that the backup_label can be read from the backup archive
+        when PgBaseBackupCompression.open returns a readable file-like object.
+        """
+        expected_backup_label = "mock_backup_label_content"
+        backup_archive_path = "/path/to/backup/archive"
+
+        # GIVEN a (mock) PgBaseBackupCompression for the configured compression
+        backup_compression = mock.Mock()
+        backup_compression.type = "gzip"
+        # AND the PgBaseBackupCompression returns a file-like object containing the
+        # backup archive
+        backup_compression.open.return_value = _tar_file(archive_content)
+        # AND a BackupInfo representing an ongoing backup
+        backup_info = mock.Mock()
+        backup_info.compression = "gzip"
+        backup_info.get_data_directory.return_value = backup_archive_path
+        # AND a PostgresBackupStrategy with the configured compression
+        mock_postgres = mock.Mock()
+        strategy = PostgresBackupStrategy(
+            mock_postgres, "test-server", backup_compression
+        )
+
+        # WHEN _read_backup_label is called with the BackupInfo
+        strategy._read_backup_label(backup_info)
+
+        # THEN the backup_label is extracted and set in the backup_info
+        backup_info.set_attribute.assert_called_once_with(
+            "backup_label", expected_backup_label
+        )
+
+        # AND PgBaseBackupCompression.open was called with the correct path
+        backup_compression.open.assert_called_once_with(
+            os.path.join(backup_archive_path, "/path/to/backup/archive", "base.tar")
+        )
+
+    @pytest.mark.parametrize(
+        "archive_content",
+        [
+            [],
+            [
+                ("some_other_file", "some_other_content"),
+            ],
+        ],
+    )
+    def test_read_backup_label_from_compressed_backup_not_found(
+        self,
+        archive_content,
+    ):
+        """
+        Verifies that an exception is raised if the backup_label cannot be found
+        when PgBaseBackupCompression returns a readable file-like object.
+        """
+        backup_archive_path = "/path/to/backup/archive"
+
+        # GIVEN a (mock) PgBaseBackupCompression for the configured compression
+        backup_compression = mock.Mock()
+        backup_compression.type = "gzip"
+        backup_compression.with_suffix.return_value = os.path.join(
+            backup_archive_path, "base.tar.gz"
+        )
+        # AND the PgBaseBackupCompression returns a file-like object containing the
+        # backup archive
+        backup_compression.open.return_value = _tar_file(archive_content)
+        # AND a BackupInfo representing an ongoing backup
+        backup_info = mock.Mock()
+        backup_info.compression = "gzip"
+        backup_info.get_data_directory.return_value = backup_archive_path
+        # AND a PostgresBackupStrategy with the configured compression
+        mock_postgres = mock.Mock()
+        strategy = PostgresBackupStrategy(
+            mock_postgres, "test-server", backup_compression
+        )
+
+        # WHEN _read_backup_label is called with the BackupInfo
+        # THEN a BackupException is raised
+        with pytest.raises(BackupException) as exc:
+            strategy._read_backup_label(backup_info)
+
+        # AND the exception has the expected message
+        assert str(exc.value) == "Could not find backup_label in %s" % os.path.join(
+            backup_archive_path, "base.tar.gz"
+        )
+
+    @mock.patch("barman.backup_executor.BackupStrategy._read_backup_label")
+    @mock.patch(
+        "barman.backup_executor.PostgresBackupStrategy._read_compressed_backup_label"
+    )
+    @mock.patch(
+        "barman.backup_executor.PostgresBackupStrategy._backup_info_from_backup_label"
+    )
+    @mock.patch(
+        "barman.backup_executor.PostgresBackupStrategy._backup_info_from_stop_location"
+    )
+    def test_read_backup_label_from_uncompressed_backup(
+        self,
+        _mock_backup_info_from_stop_location,
+        _mock_backup_info_from_backup_label,
+        _mock_read_compressed_backup_label,
+        _mock_read_backup_label,
+    ):
+        """
+        Verifies that the BackupStrategy._read_backup_label method is used when
+        backups are not compressed.
+        """
+        # GIVEN a backup_info with the default compression of None
+        backup_info = mock.Mock()
+        backup_info.compression = None
+        # AND a PostgresBackupStrategy with no compression
+        mock_postgres = mock.Mock()
+        strategy = PostgresBackupStrategy(mock_postgres, "test-server", None)
+
+        # WHEN _read_backup_label is called with the BackupInfo
+        strategy._read_backup_label(backup_info)
+
+        # THEN the we do not attempt to read the compressed backup label
+        _mock_read_compressed_backup_label.assert_not_called()
+        # AND the superclass method to read the backup label is called
+        _mock_read_backup_label.assert_called_once()

--- a/tests/test_command_wrappers.py
+++ b/tests/test_command_wrappers.py
@@ -1253,7 +1253,7 @@ class TestPgBaseBackup(object):
             # --compress=gzip and --format=tar arguments.
             # We do not expect the PG<15 --gzip style option.
             (
-                mock.Mock(type="gzip", level=None),
+                mock.Mock(type="gzip", level=None, location=None),
                 ["--compress=gzip", "--format=tar"],
                 ["--gzip"],
             ),
@@ -1261,8 +1261,20 @@ class TestPgBaseBackup(object):
             # --compress=gzip:level=5 and --format=tar arguments.
             # We do not expect the PG<15 --gzip style option.
             (
-                mock.Mock(type="gzip", level=5),
+                mock.Mock(type="gzip", level=5, location=None),
                 ["--compress=gzip:level=5", "--format=tar"],
+                ["--gzip"],
+            ),
+            # If compression location is specified we expect to see it
+            # prefixing the compression algorithm.
+            (
+                mock.Mock(type="gzip", level=5, location="client"),
+                ["--compress=client-gzip:level=5", "--format=tar"],
+                ["--gzip"],
+            ),
+            (
+                mock.Mock(type="gzip", level=5, location="server"),
+                ["--compress=server-gzip:level=5", "--format=tar"],
                 ["--gzip"],
             ),
         ],

--- a/tests/test_command_wrappers.py
+++ b/tests/test_command_wrappers.py
@@ -1203,14 +1203,14 @@ class TestPgBaseBackup(object):
             # If gzip compression is provided with no level then we expect only
             # the --gzip and --format=tar arguments
             (
-                mock.Mock(type="gzip", level=None),
+                mock.Mock(type="gzip", format=None, level=None),
                 ["--gzip", "--format=tar"],
                 ["--compress"],
             ),
             # If gzip compression is provided with level then we expect the --gzip,
             # --format=tar and --compress=level arguments
             (
-                mock.Mock(type="gzip", level=5),
+                mock.Mock(type="gzip", format=None, level=5),
                 ["--gzip", "--format=tar", "--compress=5"],
                 [],
             ),
@@ -1253,7 +1253,7 @@ class TestPgBaseBackup(object):
             # --compress=gzip and --format=tar arguments.
             # We do not expect the PG<15 --gzip style option.
             (
-                mock.Mock(type="gzip", level=None, location=None),
+                mock.Mock(type="gzip", format=None, level=None, location=None),
                 ["--compress=gzip", "--format=tar"],
                 ["--gzip"],
             ),
@@ -1261,20 +1261,32 @@ class TestPgBaseBackup(object):
             # --compress=gzip:level=5 and --format=tar arguments.
             # We do not expect the PG<15 --gzip style option.
             (
-                mock.Mock(type="gzip", level=5, location=None),
+                mock.Mock(type="gzip", format=None, level=5, location=None),
                 ["--compress=gzip:level=5", "--format=tar"],
                 ["--gzip"],
             ),
             # If compression location is specified we expect to see it
             # prefixing the compression algorithm.
             (
-                mock.Mock(type="gzip", level=5, location="client"),
+                mock.Mock(type="gzip", format=None, level=5, location="client"),
                 ["--compress=client-gzip:level=5", "--format=tar"],
                 ["--gzip"],
             ),
             (
-                mock.Mock(type="gzip", level=5, location="server"),
+                mock.Mock(type="gzip", format=None, level=5, location="server"),
                 ["--compress=server-gzip:level=5", "--format=tar"],
+                ["--gzip"],
+            ),
+            # If compression format is specified it should be used as the --format
+            # value
+            (
+                mock.Mock(type="gzip", format="tar", level=None, location="server"),
+                ["--compress=server-gzip", "--format=tar"],
+                ["--gzip"],
+            ),
+            (
+                mock.Mock(type="gzip", format="plain", level=None, location="server"),
+                ["--compress=server-gzip", "--format=plain"],
                 ["--gzip"],
             ),
         ],

--- a/tests/test_compressor.py
+++ b/tests/test_compressor.py
@@ -392,10 +392,71 @@ class TestPgBaseBackupCompression(object):
         # THEN with_suffix appends the suffix
         assert basic_compression.with_suffix("append_to_this") == "append_to_this.basic"
 
-    def test_validate(self):
+    @pytest.mark.parametrize(
+        ("client_version", "server_version", "compression_options", "expected_errors"),
+        [
+            # For pg_basebackup < 15 backup_location = client is allowed for any server
+            # version because it is the only option supported by the client
+            (
+                "14",
+                140000,
+                {"backup_compression": "gzip", "backup_compression_location": "client"},
+                [],
+            ),
+            (
+                "14",
+                150000,
+                {"backup_compression": "gzip", "backup_compression_location": "client"},
+                [],
+            ),
+            # backup_location = server is not allowed for pg_basebackup < 15 regardless
+            # of server version
+            (
+                "14",
+                140000,
+                {"backup_compression": "gzip", "backup_compression_location": "server"},
+                [
+                    "backup_compression_location = server requires pg_basebackup 15 or greater",
+                    "backup_compression_location = server requires PostgreSQL 15 or greater",
+                ],
+            ),
+            (
+                "14",
+                150000,
+                {"backup_compression": "gzip", "backup_compression_location": "server"},
+                [
+                    "backup_compression_location = server requires pg_basebackup 15 or greater",
+                ],
+            ),
+            # For pg_basebackup >= 15 and PG < 15, backup_location = client is allowed
+            # implicitly because it is the only available option supported by the server
+            (
+                "15",
+                140000,
+                {"backup_compression": "gzip", "backup_compression_location": "client"},
+                [],
+            ),
+            # For pg_basebackup >= 15 and PG >= 15, both client and server are allowed
+            # because they are both supported on the client and the server
+            (
+                "15",
+                150000,
+                {"backup_compression": "gzip", "backup_compression_location": "client"},
+                [],
+            ),
+            (
+                "15",
+                150000,
+                {"backup_compression": "gzip", "backup_compression_location": "server"},
+                [],
+            ),
+        ],
+    )
+    def test_validate(
+        self, client_version, server_version, compression_options, expected_errors
+    ):
         """
         Verifies PgBaseBackupCompression.validate behaviour.
-        Currently this will always pass because there is no general validation.
         """
         # GIVEN a concrete PgBaseBackupCompression which defines its suffix
         class BasicPgBaseBackupCompression(PgBaseBackupCompression):
@@ -404,20 +465,31 @@ class TestPgBaseBackupCompression(object):
             def open(self, _base):
                 pass
 
-        basic_compression = BasicPgBaseBackupCompression(mock.Mock())
         # AND a server with compression enabled
-        server = build_mocked_server(
-            global_conf={"backup_method": "postgres", "backup_compression": "gzip"}
-        )
+        server_options = {"backup_method": "postgres"}
+        server_options.update(compression_options)
+        server = build_mocked_server(global_conf=server_options)
+        # AND the server is of the specified version
+        server.postgres.server_version = server_version
+        # AND the remote status reports the pg_basebackup version
+        remote_status = {"pg_basebackup_version": client_version}
+        # AND the PgBaseBackupCompression is created from the server config
+        basic_compression = BasicPgBaseBackupCompression(server.config)
 
         # WHEN validate is called
-        basic_compression.validate(server)
+        basic_compression.validate(server, remote_status)
 
-        # THEN the server is not disabled
-        assert not server.config.disabled
-
-        # AND no errors are added to the server's list
-        assert len(server.config.msg_list) == 0
+        # THEN if no errors are expected, the server is not disabled
+        if len(expected_errors) == 0:
+            assert not server.config.disabled
+            # AND there are no messages in the msg_list
+            assert len(server.config.msg_list) == 0
+        # OR if errors are expected, the server is disabled
+        else:
+            assert server.config.disabled
+            # AND the expected errors are in the server's list
+            assert len(server.config.msg_list) == len(expected_errors)
+            assert sorted(server.config.msg_list) == sorted(expected_errors)
 
 
 class TestGZipPgBaseBackupCompression(object):
@@ -451,9 +523,11 @@ class TestGZipPgBaseBackupCompression(object):
         server = build_mocked_server(global_conf=compression_options)
         # AND a GZipPgBaseBackupCompression for that server
         backup_compression = GZipPgBaseBackupCompression(server.config)
+        # AND a remote_status object
+        remote_status = mock.Mock()
 
         # WHEN the compression is validated
-        backup_compression.validate(server)
+        backup_compression.validate(server, remote_status)
 
         # THEN if no errors are expected the server is not disabled
         if len(expected_errors) == 0:

--- a/tests/test_compressor.py
+++ b/tests/test_compressor.py
@@ -450,6 +450,52 @@ class TestPgBaseBackupCompression(object):
                 {"backup_compression": "gzip", "backup_compression_location": "server"},
                 [],
             ),
+            # backup_compression_format = tar is allowed regardless of compression location
+            (
+                "15",
+                150000,
+                {
+                    "backup_compression": "gzip",
+                    "backup_compression_location": "client",
+                    "backup_compression_format": "tar",
+                },
+                [],
+            ),
+            (
+                "15",
+                150000,
+                {
+                    "backup_compression": "gzip",
+                    "backup_compression_location": "server",
+                    "backup_compression_format": "tar",
+                },
+                [],
+            ),
+            # backup_compression_format = plain is allowed if compression location = server
+            (
+                "15",
+                150000,
+                {
+                    "backup_compression": "gzip",
+                    "backup_compression_location": "server",
+                    "backup_compression_format": "plain",
+                },
+                [],
+            ),
+            # backup_compression_format = plain is not allowed if compression is
+            # performed on the client
+            (
+                "15",
+                150000,
+                {
+                    "backup_compression": "gzip",
+                    "backup_compression_location": "client",
+                    "backup_compression_format": "plain",
+                },
+                [
+                    "backup_compression_format plain is not compatible with backup_compression_location client"
+                ],
+            ),
         ],
     )
     def test_validate(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,7 @@ from barman.config import (
     Config,
     RecoveryOptions,
     parse_backup_compression,
+    parse_backup_compression_format,
     parse_backup_compression_location,
     parse_si_suffix,
     parse_slot_name,
@@ -153,6 +154,7 @@ class TestConfig(object):
             {
                 "config": main.config,
                 "backup_compression": None,
+                "backup_compression_format": "tar",
                 "backup_compression_level": None,
                 "backup_compression_location": "client",
                 "compression": "gzip",
@@ -182,6 +184,7 @@ class TestConfig(object):
                 "backup_directory": "/some/barman/home/web",
                 "basebackups_directory": "/some/barman/home/web/base",
                 "backup_compression": None,
+                "backup_compression_format": "tar",
                 "backup_compression_level": None,
                 "backup_compression_location": "client",
                 "compression": None,
@@ -505,6 +508,25 @@ class TestConfig(object):
         else:
             with pytest.raises(ValueError):
                 parse_backup_compression(location)
+
+    @pytest.mark.parametrize(
+        ("format", "is_allowed"),
+        (
+            ("tar", True),
+            ("plain", True),
+            ("lizard", False),
+            ("1", False),
+        ),
+    )
+    def test_parse_backup_compression_format(self, format, is_allowed):
+        """
+        Test allowed and disallowed backup_compression_format values
+        """
+        if is_allowed:
+            assert parse_backup_compression_format(format) == format
+        else:
+            with pytest.raises(ValueError):
+                parse_backup_compression(format)
 
 
 # noinspection PyMethodMayBeStatic

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,7 @@ from barman.config import (
     Config,
     RecoveryOptions,
     parse_backup_compression,
+    parse_backup_compression_location,
     parse_si_suffix,
     parse_slot_name,
     parse_time_interval,
@@ -153,6 +154,7 @@ class TestConfig(object):
                 "config": main.config,
                 "backup_compression": None,
                 "backup_compression_level": None,
+                "backup_compression_location": "client",
                 "compression": "gzip",
                 "last_backup_maximum_age": timedelta(1),
                 "last_backup_minimum_size": 1048576,
@@ -181,6 +183,7 @@ class TestConfig(object):
                 "basebackups_directory": "/some/barman/home/web/base",
                 "backup_compression": None,
                 "backup_compression_level": None,
+                "backup_compression_location": "client",
                 "compression": None,
                 "conninfo": "host=web01 user=postgres port=5432",
                 "description": "Web applications database",
@@ -483,6 +486,25 @@ class TestConfig(object):
         else:
             with pytest.raises(ValueError):
                 parse_backup_compression(compression)
+
+    @pytest.mark.parametrize(
+        ("location", "is_allowed"),
+        (
+            ("client", True),
+            ("server", True),
+            ("lizard", False),
+            ("1", False),
+        ),
+    )
+    def test_parse_backup_compression_location(self, location, is_allowed):
+        """
+        Test allowed and disallowed backup_compression_location values
+        """
+        if is_allowed:
+            assert parse_backup_compression_location(location) == location
+        else:
+            with pytest.raises(ValueError):
+                parse_backup_compression(location)
 
 
 # noinspection PyMethodMayBeStatic

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -541,6 +541,24 @@ class TestRsyncBackupExecutor(object):
         # check for the presence of the warning in the stderr
         assert ("WARNING: The usage of include directives is not supported") not in err
 
+    def test_validate_config_compression(self):
+        # GIVEN a server with backup_method = rysnc and backup_method = gzip
+        server = build_mocked_server(
+            global_conf={"backup_method": "rsync", "backup_compression": "gzip"}
+        )
+
+        # WHEN an RsyncBackupExecutor is created
+        RsyncBackupExecutor(server.backup_manager)
+
+        # THEN the server is disabled
+        assert server.config.disabled
+        # AND the server config has a single error message
+        assert len(server.config.msg_list) == 1
+        assert (
+            "backup_compression option is not supported by rsync backup_method"
+            in server.config.msg_list[0]
+        )
+
 
 # noinspection PyMethodMayBeStatic
 class TestStrategy(object):
@@ -1064,6 +1082,7 @@ class TestPostgresBackupExecutor(object):
                 retry_sleep=30,
                 retry_handler=mock.ANY,
                 path=mock.ANY,
+                compression=None,
             ),
             mock.call()(),
         ]
@@ -1098,6 +1117,7 @@ class TestPostgresBackupExecutor(object):
                 retry_sleep=30,
                 retry_handler=mock.ANY,
                 path=mock.ANY,
+                compression=None,
             ),
             mock.call()(),
         ]
@@ -1131,6 +1151,7 @@ class TestPostgresBackupExecutor(object):
                 retry_sleep=30,
                 retry_handler=mock.ANY,
                 path=mock.ANY,
+                compression=None,
             ),
             mock.call()(),
         ]
@@ -1159,6 +1180,7 @@ class TestPostgresBackupExecutor(object):
                 retry_sleep=30,
                 retry_handler=mock.ANY,
                 path=mock.ANY,
+                compression=None,
             ),
             mock.call()(),
         ]
@@ -1221,3 +1243,48 @@ class TestPostgresBackupExecutor(object):
         assert backup_info.begin_wal is None
         assert backup_info.begin_offset is None
         assert backup_info.begin_time == start_time
+
+    def test_backup_compression_gzip(self):
+        """
+        Checks that a backup_compression object is created if the backup_compression
+        option is set.
+        """
+        # GIVEN a server with backup_method postgres and backup_compression gzip
+        server = build_mocked_server(
+            global_conf={"backup_method": "postgres", "backup_compression": "gzip"}
+        )
+        # WHEN a PostgresBackupExecutor is created
+        executor = PostgresBackupExecutor(server.backup_manager)
+        # THEN a PgBaseBackupCompression is created with type == "gzip"
+        assert executor.backup_compression.type == "gzip"
+
+    def test_no_backup_compression(self):
+        """
+        Checks that backup_compression is None if the backup_compression option is
+        not set.
+        """
+        # GIVEN a server with backup_method postgres and no backup_compression
+        server = build_mocked_server(global_conf={"backup_method": "postgres"})
+        # WHEN a PostgresBackupExecutor is created
+        executor = PostgresBackupExecutor(server.backup_manager)
+        # THEN the backup_compression attribute of the executor is None
+        assert executor.backup_compression is None
+
+    @patch("barman.compression.GZipPgBaseBackupCompression")
+    def test_validate_config_compression(self, mock_gzip_pgbb_compression):
+        """
+        Checks that the validate_config method validates compression options.
+        We do not care about the details of the validation here, we only care
+        that it is called.
+        """
+        # GIVEN a server with backup_method postgres and backup_compression gzip
+        server = build_mocked_server(
+            global_conf={"backup_method": "postgres", "backup_compression": "gzip"}
+        )
+        # WHEN a PostgresBackupExecutor is created
+        PostgresBackupExecutor(server.backup_manager)
+        # THEN the validate method of the executor's PgBaseBackupCompression object
+        # is called
+        mock_gzip_pgbb_compression.return_value.validate.assert_called_once()
+        # AND the server config message list has no errors
+        assert len(server.config.msg_list) == 0

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -73,6 +73,7 @@ EXPECTED_MINIMAL = {
             "copy_stats": None,
             "xlog_segment_size": 16777216,
             "systemid": None,
+            "compression": None,
         }
     },
     "config": {},

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -236,6 +236,8 @@ def build_config_dictionary(config_keys=None):
         "archiver": True,
         "archiver_batch_size": 0,
         "config": None,
+        "backup_compression": None,
+        "backup_compression_level": None,
         "backup_directory": "/some/barman/home/main",
         "backup_options": BackupOptions("", "", ""),
         "bandwidth_limit": None,

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -238,6 +238,7 @@ def build_config_dictionary(config_keys=None):
         "config": None,
         "backup_compression": None,
         "backup_compression_level": None,
+        "backup_compression_location": "client",
         "backup_directory": "/some/barman/home/main",
         "backup_options": BackupOptions("", "", ""),
         "bandwidth_limit": None,

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -237,6 +237,7 @@ def build_config_dictionary(config_keys=None):
         "archiver_batch_size": 0,
         "config": None,
         "backup_compression": None,
+        "backup_compression_format": "tar",
         "backup_compression_level": None,
         "backup_compression_location": "client",
         "backup_directory": "/some/barman/home/main",


### PR DESCRIPTION
Adds support for the compression-related pg_basebackup options.

This PR is code-complete however the documentation is not yet written - this will be added once we're definitely happy about the user-facing aspects of the PR.