### PR TITLE
Fix google dependencies for python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,11 @@ setup(
         "snappy": [
             "python-snappy == 0.6.0"
         ],  # version is limited py python2.7 see issue #529
-        "google": ["google-cloud-storage"],
+        "google": [
+            "google-cloud-storage",
+            # python 3.5 support was dropped in 3.18
+            "protobuf<3.18",
+        ],
     },
     platforms=["Linux", "Mac OS X"],
     classifiers=[


### PR DESCRIPTION
Pins protobuf to below 3.18 as python 3.5 support was formally dropped
in 3.18.