### PR TITLE
Add PostgreSQL 15 support

### DIFF
--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -1669,6 +1669,23 @@ class ExclusiveBackupStrategy(BackupStrategy):
                     False,
                     hint="cannot perform exclusive backup on a standby",
                 )
+        check_strategy.init_check("exclusive backup supported")
+        try:
+            if self.postgres and self.postgres.server_version < 150000:
+                check_strategy.result(self.server_name, True)
+            else:
+                check_strategy.result(
+                    self.server_name,
+                    False,
+                    hint="exclusive backups not supported "
+                    "on PostgreSQL %s" % self.postgres.server_major_version,
+                )
+        except PostgresConnectionError:
+            check_strategy.result(
+                self.server_name,
+                False,
+                hint="unable to determine postgres version",
+            )
 
 
 class ConcurrentBackupStrategy(BackupStrategy):

--- a/barman/exceptions.py
+++ b/barman/exceptions.py
@@ -263,6 +263,13 @@ class PostgresUnsupportedFeature(PostgresException):
     """
 
 
+class PostgresObsoleteFeature(PostgresException):
+    """
+    Obsolete feature, i.e. one which has been deprecated and since
+    removed.
+    """
+
+
 class PostgresDuplicateReplicationSlot(PostgresException):
     """
     The creation of a physical replication slot failed because

--- a/barman/postgres_plumbing.py
+++ b/barman/postgres_plumbing.py
@@ -70,24 +70,10 @@ def function_name_map(server_version):
         is None, default to the latest PostgreSQL version
     :rtype: dict[str]
     """
-
-    if server_version and server_version < 100000:
-        return {
-            "pg_switch_wal": "pg_switch_xlog",
-            "pg_walfile_name": "pg_xlogfile_name",
-            "pg_wal": "pg_xlog",
-            "pg_walfile_name_offset": "pg_xlogfile_name_offset",
-            "pg_last_wal_replay_lsn": "pg_last_xlog_replay_location",
-            "pg_current_wal_lsn": "pg_current_xlog_location",
-            "pg_current_wal_insert_lsn": "pg_current_xlog_insert_location",
-            "pg_last_wal_receive_lsn": "pg_last_xlog_receive_location",
-            "sent_lsn": "sent_location",
-            "write_lsn": "write_location",
-            "flush_lsn": "flush_location",
-            "replay_lsn": "replay_location",
-        }
-
-    return {
+    # Start by defining the current names in name_map
+    name_map = {
+        "pg_backup_start": "pg_backup_start",
+        "pg_backup_stop": "pg_backup_stop",
         "pg_switch_wal": "pg_switch_wal",
         "pg_walfile_name": "pg_walfile_name",
         "pg_wal": "pg_wal",
@@ -101,3 +87,33 @@ def function_name_map(server_version):
         "flush_lsn": "flush_lsn",
         "replay_lsn": "replay_lsn",
     }
+    if server_version and server_version < 150000:
+        # For versions below 15, pg_backup_start and pg_backup_stop are named
+        # pg_start_backup and pg_stop_backup respectively
+        name_map.update(
+            {
+                "pg_backup_start": "pg_start_backup",
+                "pg_backup_stop": "pg_stop_backup",
+            }
+        )
+    if server_version and server_version < 100000:
+        # For versions below 10, xlog is used in place of wal and location is
+        # used in place of lsn
+        name_map.update(
+            {
+                "pg_switch_wal": "pg_switch_xlog",
+                "pg_walfile_name": "pg_xlogfile_name",
+                "pg_wal": "pg_xlog",
+                "pg_walfile_name_offset": "pg_xlogfile_name_offset",
+                "pg_last_wal_replay_lsn": "pg_last_xlog_replay_location",
+                "pg_current_wal_lsn": "pg_current_xlog_location",
+                "pg_current_wal_insert_lsn": "pg_current_xlog_insert_location",
+                "pg_last_wal_receive_lsn": "pg_last_xlog_receive_location",
+                "sent_lsn": "sent_location",
+                "write_lsn": "write_location",
+                "flush_lsn": "flush_location",
+                "replay_lsn": "replay_location",
+            }
+        )
+
+    return name_map

--- a/barman/server.py
+++ b/barman/server.py
@@ -55,6 +55,7 @@ from barman.exceptions import (
     PostgresException,
     PostgresInvalidReplicationSlot,
     PostgresIsInRecovery,
+    PostgresObsoleteFeature,
     PostgresReplicationSlotInUse,
     PostgresReplicationSlotsFull,
     PostgresSuperuserRequired,
@@ -2923,6 +2924,8 @@ class Server(RemoteStatusMixin):
                 )
         except PostgresUnsupportedFeature as e:
             output.info("  Requires PostgreSQL %s or higher", e)
+        except PostgresObsoleteFeature as e:
+            output.info("  Requires PostgreSQL lower than %s", e)
         except PostgresSuperuserRequired:
             output.info("  Requires superuser rights")
 

--- a/doc/manual/21-preliminary_steps.en.md
+++ b/doc/manual/21-preliminary_steps.en.md
@@ -40,6 +40,16 @@ GRANT pg_read_all_settings TO barman;
 GRANT pg_read_all_stats TO barman;
 ```
 
+In the PostgreSQL 15 beta and any subsequent PostgreSQL versions the functions
+`pg_start_backup` and `pg_stop_backup` have been renamed and have different
+signatures. You will therefore need to replace the first three lines in the
+above block with:
+
+``` sql
+GRANT EXECUTE ON FUNCTION pg_backup_start(text, boolean) to barman;
+GRANT EXECUTE ON FUNCTION pg_backup_stop(boolean) to barman;
+```
+
 It is worth noting that without a real superuser, the `--force` option
 of the `barman switch-wal` command will not work.
 

--- a/tests/requirements_dev.txt
+++ b/tests/requirements_dev.txt
@@ -7,3 +7,6 @@ pytest
 mock
 pytest-timeout==1.4.2
 py
+# msrest is a transitive dependency of azure-storage-blob and
+# is broken on python 2 for versions >= 0.7.0
+msrest<0.7.0

--- a/tests/requirements_minimal.txt
+++ b/tests/requirements_minimal.txt
@@ -9,3 +9,6 @@ mock
 pytest-timeout==1.4.2
 argcomplete
 python-dateutil==1.5
+# msrest is a transitive dependency of azure-storage-blob and
+# is broken on python 2 for versions >= 0.7.0
+msrest<0.7.0


### PR DESCRIPTION
Adds support for PostgreSQL 15.

This has been tested locally using a [barman-testing branch](https://github.com/EnterpriseDB/barman-testing/tree/add-pg15-support) and we can also use a [barman-it-set branch](https://github.com/EnterpriseDB/barman-it-set/tree/test-on-pg15) to test this in CI before merging.

Edit: Actually we need to use a [barman-packaging branch](https://github.com/EnterpriseDB/barman-packaging/tree/pg15-test) to test with since the integration tests always pull built packages and it's easier to just point the acceptance tests in barman-packaging to the updated integration tests branch.