### PR TITLE
Set wait_for_archive false when calling pg stop_backup

### DIFF
--- a/barman/postgres.py
+++ b/barman/postgres.py
@@ -1240,10 +1240,10 @@ class PostgreSQLConnection(PostgreSQL):
             # want to wait for the required WALs to be archived. This is because
             # barman will do its own waiting at a later stage of the backup process.
             cur.execute(
-                "SELECT location, "
-                "({pg_walfile_name_offset}(location)).*, "
+                "SELECT end_row.lsn AS location, "
+                "({pg_walfile_name_offset}(end_row.lsn)).*, "
                 "now() AS timestamp "
-                "FROM {pg_backup_stop}(TRUE, FALSE) AS location".format(**self.name_map)
+                "FROM {pg_backup_stop}(TRUE, FALSE) AS end_row".format(**self.name_map)
             )
 
             return cur.fetchone()

--- a/barman/postgres.py
+++ b/barman/postgres.py
@@ -1235,11 +1235,15 @@ class PostgreSQLConnection(PostgreSQL):
             if self.server_version >= 150000:
                 raise PostgresObsoleteFeature("15")
 
+            # Call pg_stop_backup with TRUE, FALSE.
+            # TRUE indicates exclusive backup and FALSE tells PostgreSQL we do not
+            # want to wait for the required WALs to be archived. This is because
+            # barman will do its own waiting at a later stage of the backup process.
             cur.execute(
                 "SELECT location, "
                 "({pg_walfile_name_offset}(location)).*, "
                 "now() AS timestamp "
-                "FROM {pg_backup_stop}() AS location".format(**self.name_map)
+                "FROM {pg_backup_stop}(TRUE, FALSE) AS location".format(**self.name_map)
             )
 
             return cur.fetchone()
@@ -1276,15 +1280,16 @@ class PostgreSQLConnection(PostgreSQL):
             if self.server_version >= 150000:
                 # The pg_backup_stop function accepts one argument, a boolean
                 # wait_for_archive indicating whether PostgreSQL should wait
-                # until all required WALs are archived. This is not set so that
-                # we get the default behaviour which is to wait for the wals.
-                pg_backup_args = ""
+                # until all required WALs are archived. This is set to FALSE
+                # because barman will do its own waiting for those WALs and
+                # there is no need for PostgreSQL to also wait.
+                pg_backup_args = "FALSE"
             else:
                 # For PostgreSQLs below 15 the function accepts two arguments -
                 # a boolean to indicate exclusive or concurrent backup and the
-                # wait_for_archive boolean. We set exclusive to FALSE and leave
-                # wait_for_archive unset as with PG >= 15.
-                pg_backup_args = "FALSE"
+                # wait_for_archive boolean. We set exclusive to FALSE and set
+                # wait_for_archive to FALSE as with PG >= 15.
+                pg_backup_args = "FALSE, FALSE"
 
             # Stop the backup  using the api introduced with version 9.6
             cur = conn.cursor(cursor_factory=DictCursor)

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -274,7 +274,7 @@ class TestPostgres(object):
             "SELECT location, "
             "(pg_xlogfile_name_offset(location)).*, "
             "now() AS timestamp "
-            "FROM pg_stop_backup() AS location"
+            "FROM pg_stop_backup(TRUE, FALSE) AS location"
         )
 
         # Test call on master, PostgreSQL 10
@@ -288,7 +288,7 @@ class TestPostgres(object):
             "SELECT location, "
             "(pg_walfile_name_offset(location)).*, "
             "now() AS timestamp "
-            "FROM pg_stop_backup() AS location"
+            "FROM pg_stop_backup(TRUE, FALSE) AS location"
         )
 
         # Test call on PostgreSQL 15
@@ -309,7 +309,7 @@ class TestPostgres(object):
 
     @pytest.mark.parametrize(
         ("server_version", "expected_stop_call"),
-        [(140000, "pg_stop_backup(FALSE)"), (150000, "pg_backup_stop()")],
+        [(140000, "pg_stop_backup(FALSE, FALSE)"), (150000, "pg_backup_stop(FALSE)")],
     )
     @patch("barman.postgres.PostgreSQLConnection.connect")
     def test_stop_concurrent_backup(self, conn, server_version, expected_stop_call):

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -271,10 +271,10 @@ class TestPostgres(object):
         # check the correct invocation of the execute method
         cursor_mock = conn_mock.return_value.cursor.return_value
         cursor_mock.execute.assert_called_once_with(
-            "SELECT location, "
-            "(pg_xlogfile_name_offset(location)).*, "
+            "SELECT end_row.lsn AS location, "
+            "(pg_xlogfile_name_offset(end_row.lsn)).*, "
             "now() AS timestamp "
-            "FROM pg_stop_backup(TRUE, FALSE) AS location"
+            "FROM pg_stop_backup(TRUE, FALSE) AS end_row"
         )
 
         # Test call on master, PostgreSQL 10
@@ -285,10 +285,10 @@ class TestPostgres(object):
         # check the correct invocation of the execute method
         cursor_mock = conn_mock.return_value.cursor.return_value
         cursor_mock.execute.assert_called_once_with(
-            "SELECT location, "
-            "(pg_walfile_name_offset(location)).*, "
+            "SELECT end_row.lsn AS location, "
+            "(pg_walfile_name_offset(end_row.lsn)).*, "
             "now() AS timestamp "
-            "FROM pg_stop_backup(TRUE, FALSE) AS location"
+            "FROM pg_stop_backup(TRUE, FALSE) AS end_row"
         )
 
         # Test call on PostgreSQL 15


### PR DESCRIPTION
Based on https://github.com/EnterpriseDB/barman/pull/579 because it touches the code affected by the PG15 changes so it makes sense to update that first, then change the wait_for_archive behaviour.

They should stay as two separate PRs though since they both have the potential to break things and it would be easier to figure out which change is responsible if they're separate PRs.

Closes #448.