### PR TITLE
Set current_action at start of stop_backup method

### DIFF
--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -1749,8 +1749,8 @@ class ConcurrentBackupStrategy(BackupStrategy):
 
         :param barman.infofile.BackupInfo backup_info: backup information
         """
-        pg_version = self.postgres.server_version
         self.current_action = "issuing stop backup command"
+        pg_version = self.postgres.server_version
         if pg_version >= 90600:
             # On 9.6+ execute native concurrent stop backup
             self.current_action += " (native concurrent)"


### PR DESCRIPTION
Moves the line in ConcurrentBackupStrategy.stop_backup which sets the
current_action to the very beginning of the function.

This resolves an issue where a failure retrieving the server_version
from the PostgreSQL connection would result in a misleading error
message due to the current_action still being set to
"issuing start backup command".

Closes #496