### PR TITLE
Treat timelines as hex when inferring from WAL segment

### DIFF
--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -465,7 +465,7 @@ class RecoveryExecutor(object):
                 calculated_target_tli = backup_info.timeline
             elif target_tli == "latest":
                 valid_timelines = self.backup_manager.get_latest_archived_wals_info()
-                calculated_target_tli = int(max(valid_timelines.keys()))
+                calculated_target_tli = int(max(valid_timelines.keys()), 16)
             elif not target_tli.isdigit():
                 raise ValueError("%s is not a valid timeline keyword" % target_tli)
 

--- a/barman/server.py
+++ b/barman/server.py
@@ -1563,7 +1563,7 @@ class Server(RemoteStatusMixin):
                 calculated_target_tli = backup.timeline
             elif target_tli == "latest":
                 valid_timelines = self.backup_manager.get_latest_archived_wals_info()
-                calculated_target_tli = int(max(valid_timelines.keys()))
+                calculated_target_tli = int(max(valid_timelines.keys()), 16)
             elif not target_tli.isdigit():
                 raise ValueError("%s is not a valid timeline keyword" % target_tli)
 

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -463,9 +463,9 @@ class TestRecoveryExecutor(object):
             # WHEN target_tli is current we expect no target timeline in the output
             # AND we expect that `is_pitr` is not set
             ("current", False, None),
-            # WHEN target_tli is latest we expect target timeline 4 in the output
+            # WHEN target_tli is latest we expect target timeline 10 in the output
             # AND we expect that `is_pitr` is set
-            ("latest", True, 4),
+            ("latest", True, 10),
         ],
     )
     @mock.patch("barman.backup.BackupManager.get_latest_archived_wals_info")
@@ -492,9 +492,12 @@ class TestRecoveryExecutor(object):
 
         # AND WALs in the archive for timelines 2, 3 and 4
         mock_get_latest_archived_wals_info.return_value = {
-            2: WalFileInfo(),
-            3: WalFileInfo(),
-            4: WalFileInfo(),
+            "00000001": WalFileInfo(),
+            "00000002": WalFileInfo(),
+            "00000003": WalFileInfo(),
+            # We deliberately use a latest timeline represented by a hexadecimal
+            # value in the WAL name to verify it is handled correctly
+            "0000000A": WalFileInfo(),
         }
 
         # WHEN _set_pitr_targets is called with the provided target_tli

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -271,8 +271,8 @@ class TestServer(object):
                     create_fake_info_file("00000001.history", 42, 43),
                     create_fake_info_file("000000020000000000000003", 42, 43),
                     create_fake_info_file("00000002.history", 42, 43),
-                    create_fake_info_file("000000030000000000000005", 42, 43),
-                    create_fake_info_file("00000003.history", 42, 43),
+                    create_fake_info_file("0000000A0000000000000005", 42, 43),
+                    create_fake_info_file("0000000A.history", 42, 43),
                 ],
                 # AND target_tli values None, 2 and current
                 (None, 2, "current"),
@@ -290,8 +290,8 @@ class TestServer(object):
                     create_fake_info_file("000000020000000000000003", 42, 43),
                     create_fake_info_file("000000020000000000000010", 42, 43),
                     create_fake_info_file("00000002.history", 42, 43),
-                    create_fake_info_file("000000030000000000000005", 42, 43),
-                    create_fake_info_file("00000003.history", 42, 43),
+                    create_fake_info_file("0000000A0000000000000005", 42, 43),
+                    create_fake_info_file("0000000A.history", 42, 43),
                 ],
                 # AND target_tli values None, 2 and current
                 (None, 2, "current"),
@@ -310,8 +310,8 @@ class TestServer(object):
                     create_fake_info_file("000000020000000000000005", 42, 45),
                     create_fake_info_file("000000020000000000000010", 42, 46),
                     create_fake_info_file("00000002.history", 42, 44),
-                    create_fake_info_file("000000030000000000000005", 42, 47),
-                    create_fake_info_file("00000003.history", 42, 47),
+                    create_fake_info_file("0000000A0000000000000005", 42, 47),
+                    create_fake_info_file("0000000A.history", 42, 47),
                 ],
                 # AND target_tli values None, 2 and current
                 (None, 2, "current"),
@@ -332,15 +332,15 @@ class TestServer(object):
                     create_fake_info_file("000000020000000000000003", 42, 43),
                     create_fake_info_file("000000020000000000000010", 42, 43),
                     create_fake_info_file("00000002.history", 42, 43),
-                    create_fake_info_file("000000030000000000000005", 42, 43),
-                    create_fake_info_file("00000003.history", 42, 43),
+                    create_fake_info_file("0000000A0000000000000005", 42, 43),
+                    create_fake_info_file("0000000A.history", 42, 43),
                 ],
-                # AND target_tli values of 3 and latest
-                (3, "latest"),
+                # AND target_tli values of 10 and latest
+                (10, "latest"),
                 # AND no target_time
                 None,
                 # WHEN get_required_xlog_files runs for a backup on tli 2
-                # all WALs on timelines 2 and 3 are returned along with all history
+                # all WALs on timelines 2 and 10 are returned along with all history
                 # files.
                 [1, 2, 3, 4, 5, 6],
             ),


### PR DESCRIPTION
Parses the timeline as a base 16 integer when resolving the special
value `latest` for the `--target-tli` option. This change is made in
Server.get_required_xlog_files and RecoveryExecutor._set_pitr_targets
which are the two places where the timeline is read from the WAL archive
and converted to a numeric ID.

This fixes a bug where `--target-tli=latest` would not resolve to the
correct timeline when the latest timeline was greater than 9.

Closes #581.