### PR TITLE
Default to concurrent backups #600

### DIFF
--- a/barman/backup.py
+++ b/barman/backup.py
@@ -484,12 +484,11 @@ class BackupManager(RemoteStatusMixin, KeepManagerMixin):
             # If there is a next backup then all unused WALs up to the begin_wal
             # of the next backup can be removed.
             # If there is no next backup then there are no remaining backups so:
-            #   - In the case of exclusive backup (default), remove all unused
-            #     WAL files.
-            #   - In the case of concurrent backup, removes only unused WAL files
-            #     prior to the start of the backup being deleted, as they
-            #     might be useful to any concurrent backup started immediately
-            #     after.
+            #   - In the case of exclusive backup, remove all unused WAL files.
+            #   - In the case of concurrent backup (the default), removes only
+            #     unused WAL files prior to the start of the backup being deleted,
+            #     as they might be useful to any concurrent backup started
+            #     immediately after.
             remove_until = None  # means to remove all WAL files
             if next_backup:
                 remove_until = next_backup

--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -712,16 +712,11 @@ class FsBackupExecutor(with_metaclass(ABCMeta, BackupExecutor)):
         concurrent_backup = BackupOptions.CONCURRENT_BACKUP in backup_options
         exclusive_backup = BackupOptions.EXCLUSIVE_BACKUP in backup_options
         if not concurrent_backup and not exclusive_backup:
-            self.config.backup_options.add(BackupOptions.EXCLUSIVE_BACKUP)
+            self.config.backup_options.add(BackupOptions.CONCURRENT_BACKUP)
             output.warning(
                 "No backup strategy set for server '%s' "
-                "(using default 'exclusive_backup').",
+                "(using default 'concurrent_backup').",
                 self.config.name,
-            )
-            output.warning(
-                "The default backup strategy will change "
-                "to 'concurrent_backup' in the future. "
-                "Explicitly set 'backup_options' to silence this warning."
             )
 
         # Depending on the backup options value, create the proper strategy

--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -1417,7 +1417,7 @@ class BackupStrategy(with_metaclass(ABCMeta, object)):
         :param barman.infofile.BackupInfo backup_info: object
         representing a
             backup
-        :param DictCursor start_info: the result of the pg_start_backup
+        :param DictCursor start_info: the result of the pg_backup_start
         command
         """
         backup_info.set_attribute("status", BackupInfo.STARTED)

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -1296,7 +1296,7 @@ class CloudBackupUploader(with_metaclass(ABCMeta)):
         """
         Coordinate the upload of a Backup to cloud storage
 
-        Any necessary coordination, such as calling pg_start_backup in PostgreSQL,
+        Any necessary coordination, such as calling pg_backup_start in PostgreSQL,
         should happen here.
         """
 

--- a/doc/barman.5
+++ b/doc/barman.5
@@ -122,19 +122,19 @@ It is a comma\-separated list of values that accepts the following
 options:
 .RS
 .IP \[bu] 2
-\f[C]exclusive_backup\f[] (default when
-\f[C]backup_method\ =\ rsync\f[]): \f[C]barman\ backup\f[] executes
-backup operations using the standard exclusive backup approach
-(technically through \f[C]pg_start_backup\f[] and
-\f[C]pg_stop_backup\f[])
-.IP \[bu] 2
-\f[C]concurrent_backup\f[] (default when
-\f[C]backup_method\ =\ postgres\f[]): if using PostgreSQL 9.2, 9.3, 9.4,
-and 9.5, Barman requires the \f[C]pgespresso\f[] module to be installed
-on the PostgreSQL server and can be used to perform a backup from a
+\f[C]concurrent_backup\f[] (default): \f[C]barman\ backup\f[] executes
+backup operations using concurrent backup which is the recommended
+backup approach for PostgreSQL versions >= 9.6 and uses the PostgreSQL
+API.
+If using PostgreSQL 9.2, 9.3, 9.4, or 9.5, Barman requires the
+\f[C]pgespresso\f[] module to be installed on the PostgreSQL server.
+\f[C]concurrent_backup\f[] can also be used to perform a backup from a
 standby server.
-Starting from PostgreSQL 9.6, Barman uses the new PostgreSQL API to
-perform backups from a standby server.
+.IP \[bu] 2
+\f[C]exclusive_backup\f[] (PostgreSQL versions older than 15 only):
+\f[C]barman\ backup\f[] executes backup operations using the deprecated
+exclusive backup approach (technically through \f[C]pg_start_backup\f[]
+and \f[C]pg_stop_backup\f[])
 .IP \[bu] 2
 \f[C]external_configuration\f[]: if present, any warning regarding
 external configuration files is suppressed during the execution of a

--- a/doc/barman.5.d/50-backup_options.md
+++ b/doc/barman.5.d/50-backup_options.md
@@ -3,16 +3,17 @@ backup_options
     for backups. It is a comma-separated list of values that accepts the
     following options:
 
-    * `exclusive_backup` (default when `backup_method = rsync`):
-      `barman backup` executes backup operations using the standard
+    * `concurrent_backup` (default):
+      `barman backup` executes backup operations using concurrent
+      backup which is the recommended backup approach for PostgreSQL
+      versions >= 9.6 and uses the PostgreSQL API. If using PostgreSQL
+      9.2, 9.3, 9.4, or 9.5, Barman requires the `pgespresso` module to
+      be installed on the PostgreSQL server. `concurrent_backup` can
+      also be used to perform a backup from a standby server.
+    * `exclusive_backup` (PostgreSQL versions older than 15 only):
+      `barman backup` executes backup operations using the deprecated
       exclusive backup approach (technically through `pg_start_backup`
       and `pg_stop_backup`)
-    * `concurrent_backup` (default when `backup_method = postgres`):
-      if using PostgreSQL 9.2, 9.3, 9.4, and 9.5, Barman requires the
-      `pgespresso` module to be installed on the PostgreSQL server
-      and can be used to perform a backup from a standby server.
-      Starting from PostgreSQL 9.6, Barman uses the new PostgreSQL API to
-      perform backups from a standby server.
     * `external_configuration`: if present, any warning regarding
       external configuration files is suppressed during the execution
       of a backup.

--- a/doc/barman.d/ssh-server.conf-template
+++ b/doc/barman.d/ssh-server.conf-template
@@ -26,9 +26,9 @@ backup_method = rsync
 ; Incremental backup support: possible values are None (default), link or copy
 ;reuse_backup = link
 ; Identify the standard behavior for backup operations: possible values are
-; exclusive_backup (default), concurrent_backup
+; exclusive_backup, concurrent_backup (default)
 ; concurrent_backup is the preferred method with PostgreSQL >= 9.6
-backup_options = exclusive_backup
+backup_options = concurrent_backup
 
 ; Number of parallel workers to perform file copy during backup and recover
 ;parallel_jobs = 1

--- a/doc/manual/50-feature-details.en.md
+++ b/doc/manual/50-feature-details.en.md
@@ -123,20 +123,19 @@ to `false`.
 ### Concurrent Backup and backup from a standby
 
 Normally, during backup operations, Barman uses PostgreSQL native
-functions `pg_start_backup` and `pg_stop_backup` for _exclusive
-backup_. These operations are not allowed on a read-only standby
-server.
-
-Barman is also capable of performing backups of PostgreSQL from 9.2 or
-greater database servers in a **concurrent way**, primarily through
-the `backup_options` configuration parameter.[^ABOUT_CONCURRENT_BACKUP]
+functions `pg_start_backup` and `pg_stop_backup` for _concurrent
+backup_.[^ABOUT_CONCURRENT_BACKUP] This is the recommended way of
+taking backups for PostgreSQL 9.6 and above (though note the
+functions have been renamed to `pg_backup_start` and `pg_backup_stop`
+in the PostgreSQL 15 beta).
 
 [^ABOUT_CONCURRENT_BACKUP]:
   Concurrent backup is a technology that has been available in
   PostgreSQL since version 9.2, through the _streaming replication
   protocol_ (for example, using a tool like `pg_basebackup`).
 
-This introduces a new architecture scenario with Barman: **backup from
+As well as being the recommended backup approach, concurrent backup
+also allows the following architecture scenario with Barman: **backup from
 a standby server**, using `rsync`.
 
 > **IMPORTANT:** **Concurrent backup** requires users of PostgreSQL
@@ -148,14 +147,9 @@ a standby server**, using `rsync`.
 > `pgespresso` extension to perform concurrent backups from this
 > version of PostgreSQL.
 
-By default, `backup_options` is transparently set to
-`exclusive_backup` for backwards compatibility reasons.
-Users of PostgreSQL 9.6 and later versions should set `backup_options`
-to `concurrent_backup`.
-
-> **IMPORTANT:** When PostgreSQL 9.5 is declared EOL by the Community,
-> Barman will by default set `backup_options` to `concurrent_backup`.
-> Support for `pgespresso` will be ceased then.
+By default, `backup_options` is transparently set to `concurrent_backup`.
+If exclusive backup is required for PostgreSQL servers older than version
+15 then users should set `backup_options` to `exclusive_backup`.
 
 When `backup_options` is set to `concurrent_backup`, Barman activates
 the _concurrent backup mode_ for a server and follows these two simple

--- a/tests/test_infofile.py
+++ b/tests/test_infofile.py
@@ -397,7 +397,7 @@ class TestBackupInfo(object):
         # build a backup manager with a rsync executor (exclusive)
         backup_manager = build_backup_manager()
         # check the result of the mode property
-        assert backup_manager.executor.mode == "rsync-exclusive"
+        assert backup_manager.executor.mode == "rsync-concurrent"
         # build a backup manager with a postgres executor
         #  (strategy without mode)
         backup_manager = build_backup_manager(global_conf={"backup_method": "postgres"})

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -65,7 +65,7 @@ EXPECTED_MINIMAL = {
                 ["tbs2", 16405, "/another/location"],
             ],
             "begin_wal": "000000010000000000000002",
-            "mode": "rsync-exclusive",
+            "mode": "rsync-concurrent",
             "error": None,
             "begin_offset": 40,
             "backup_label": None,


### PR DESCRIPTION
Updates the default backup approach from exclusive to concurrent.

The code change is fairly straightforward but the docs changes are a bit trickier - hopefully I haven't missed any references to exclusive backup being the default but it's definitely worth a second pair of eyes on the docs side of things.