### PR TITLE
Stop using `enum.Enum` in barman cloud

### DIFF
--- a/barman/clients/cloud_cli.py
+++ b/barman/clients/cloud_cli.py
@@ -20,7 +20,6 @@ import argparse
 
 import csv
 import logging
-from enum import Enum
 
 import barman
 from barman.utils import force_str
@@ -57,7 +56,7 @@ class GeneralErrorExit(SystemExit):
         super(GeneralErrorExit, self).__init__(4)
 
 
-class UrlArgumentType(Enum):
+class UrlArgumentType(object):
     source = "source"
     destination = "destination"
 
@@ -114,12 +113,12 @@ def create_argument_parser(description, source_or_destination=UrlArgumentType.so
         add_help=False,
     )
     parser.add_argument(
-        "%s_url" % source_or_destination.value,
+        "%s_url" % source_or_destination,
         help=(
             "URL of the cloud %s, such as a bucket in AWS S3."
             " For example: `s3://bucket/path/to/folder`."
         )
-        % source_or_destination.value,
+        % source_or_destination,
     )
     parser.add_argument(
         "server_name", help="the name of the server as configured in Barman."


### PR DESCRIPTION
Replaces `enum.Enum` as a base class for UrlArgumentType and uses
`object` instead such that the "enum values" now become class variables.

This means we no longer rely on the enum34 library (the library which
contains the `Enum` backport`) on python2 systems. Relying on enum34
was bad for a number of reasons:

 1. We didn't declare it as a dependency and instead relied on other
    libraries to bring it in as a transtitive dep.
 2. The package is not available as an OS package on all supported
    systems which means users need to install it with pip.

Since the Enum was only acting as syntactic sugar it is preferable
to just avoid the dependency altogether.

This fixes a packaging bug where the enum34 library did not behave as
expected on some systems leading to import errors when running barman
cloud.

Note there are no test changes required because most of the barman
cloud unit tests are using UrlArgumentType indirectly and therefore
the class is adequately covered by those tests.

Closes #603.

Thanks to Ravi160492 for reporting this issue.