### PR TITLE
Allow backups against `archive_mode = always` standbys to complete

### DIFF
--- a/barman/command_wrappers.py
+++ b/barman/command_wrappers.py
@@ -340,11 +340,26 @@ class Command(object):
         """
         out = []
         err = []
+
+        def out_handler(line):
+            out.append(line)
+            if self.out_handler is not None:
+                self.out_handler(line)
+
+        def err_handler(line):
+            err.append(line)
+            if self.err_handler is not None:
+                self.err_handler(line)
+
         # If check is true, it must be handled here
         check = kwargs.pop("check", self.check)
         allowed_retval = kwargs.pop("allowed_retval", self.allowed_retval)
         self.execute(
-            out_handler=out.append, err_handler=err.append, check=False, *args, **kwargs
+            out_handler=out_handler,
+            err_handler=err_handler,
+            check=False,
+            *args,
+            **kwargs
         )
         self.out = "\n".join(out)
         self.err = "\n".join(err)

--- a/barman/config.py
+++ b/barman/config.py
@@ -465,6 +465,7 @@ class ServerConfig(object):
         "pre_recovery_script",
         "pre_wal_delete_script",
         "pre_wal_delete_retry_script",
+        "primary_conninfo",
         "primary_ssh_command",
         "recovery_options",
         "recovery_staging_path",

--- a/barman/server.py
+++ b/barman/server.py
@@ -262,139 +262,152 @@ class Server(RemoteStatusMixin):
 
         # Postgres configuration is available only if node is not passive
         if not self.passive_node:
-            # Initialize the main PostgreSQL connection
-            try:
-                # Check that 'conninfo' option is properly set
-                if config.conninfo is None:
-                    raise ConninfoException(
-                        "Missing 'conninfo' parameter for server '%s'" % config.name
-                    )
-                # If primary_conninfo is set then we're connecting to a standby
-                if config.primary_conninfo is not None:
-                    # The standby needs a connection to the primary so that it can
-                    # perform WAL switches itself when calling pg_backup_stop.
-                    primary = PostgreSQLConnection(
-                        config.primary_conninfo,
-                    )
-                    self.postgres = StandbyPostgreSQLConnection(
-                        config.conninfo,
-                        primary,
-                        config.immediate_checkpoint,
-                        config.slot_name,
-                    )
-                else:
-                    self.postgres = PostgreSQLConnection(
-                        config.conninfo, config.immediate_checkpoint, config.slot_name
-                    )
-            # If the PostgreSQLConnection creation fails, disable the Server
-            except ConninfoException as e:
-                self.config.update_msg_list_and_disable_server(
-                    "PostgreSQL connection: " + force_str(e).strip()
-                )
-
-            # Initialize the streaming PostgreSQL connection only when
-            # backup_method is postgres or the streaming_archiver is in use
-            if config.backup_method == "postgres" or config.streaming_archiver:
-                try:
-                    if config.streaming_conninfo is None:
-                        raise ConninfoException(
-                            "Missing 'streaming_conninfo' parameter for "
-                            "server '%s'" % config.name
-                        )
-                    self.streaming = StreamingConnection(config.streaming_conninfo)
-                # If the StreamingConnection creation fails, disable the server
-                except ConninfoException as e:
-                    self.config.update_msg_list_and_disable_server(
-                        "Streaming connection: " + force_str(e).strip()
-                    )
+            self._init_postgres(config)
 
         # Initialize the backup manager
         self.backup_manager = BackupManager(self)
 
         if not self.passive_node:
-            # Initialize the StreamingWalArchiver
-            # WARNING: Order of items in self.archivers list is important!
-            # The files will be archived in that order.
-            if self.config.streaming_archiver:
-                try:
-                    self.archivers.append(StreamingWalArchiver(self.backup_manager))
-                # If the StreamingWalArchiver creation fails,
-                # disable the server
-                except AttributeError as e:
-                    _logger.debug(e)
-                    self.config.update_msg_list_and_disable_server(
-                        "Unable to initialise the streaming archiver"
+            self._init_archivers()
+
+        # Set global and tablespace bandwidth limits
+        self._init_bandwidth_limits()
+
+        # Initialize minimum redundancy
+        self._init_minimum_redundancy()
+
+        # Initialise retention policies
+        self._init_retention_policies()
+
+    def _init_postgres(self, config):
+        # Initialize the main PostgreSQL connection
+        try:
+            # Check that 'conninfo' option is properly set
+            if config.conninfo is None:
+                raise ConninfoException(
+                    "Missing 'conninfo' parameter for server '%s'" % config.name
+                )
+            # If primary_conninfo is set then we're connecting to a standby
+            if config.primary_conninfo is not None:
+                # The standby needs a connection to the primary so that it can
+                # perform WAL switches itself when calling pg_backup_stop.
+                primary = PostgreSQLConnection(
+                    config.primary_conninfo,
+                )
+                self.postgres = StandbyPostgreSQLConnection(
+                    config.conninfo,
+                    primary,
+                    config.immediate_checkpoint,
+                    config.slot_name,
+                )
+            else:
+                self.postgres = PostgreSQLConnection(
+                    config.conninfo, config.immediate_checkpoint, config.slot_name
+                )
+        # If the PostgreSQLConnection creation fails, disable the Server
+        except ConninfoException as e:
+            self.config.update_msg_list_and_disable_server(
+                "PostgreSQL connection: " + force_str(e).strip()
+            )
+
+        # Initialize the streaming PostgreSQL connection only when
+        # backup_method is postgres or the streaming_archiver is in use
+        if config.backup_method == "postgres" or config.streaming_archiver:
+            try:
+                if config.streaming_conninfo is None:
+                    raise ConninfoException(
+                        "Missing 'streaming_conninfo' parameter for "
+                        "server '%s'" % config.name
                     )
-
-            # IMPORTANT: The following lines of code have been
-            # temporarily commented in order to make the code
-            # back-compatible after the introduction of 'archiver=off'
-            # as default value in Barman 2.0.
-            # When the back compatibility feature for archiver will be
-            # removed, the following lines need to be decommented.
-            # ARCHIVER_OFF_BACKCOMPATIBILITY - START OF CODE
-            # # At least one of the available archive modes should be enabled
-            # if len(self.archivers) < 1:
-            #     self.config.update_msg_list_and_disable_server(
-            #         "No archiver enabled for server '%s'. "
-            #         "Please turn on 'archiver', 'streaming_archiver' or both"
-            #         % config.name
-            #     )
-            # ARCHIVER_OFF_BACKCOMPATIBILITY - END OF CODE
-
-            # Sanity check: if file based archiver is disabled, and only
-            # WAL streaming is enabled, a replication slot name must be
-            # configured.
-            if (
-                not self.config.archiver
-                and self.config.streaming_archiver
-                and self.config.slot_name is None
-            ):
+                self.streaming = StreamingConnection(config.streaming_conninfo)
+            # If the StreamingConnection creation fails, disable the server
+            except ConninfoException as e:
                 self.config.update_msg_list_and_disable_server(
-                    "Streaming-only archiver requires 'streaming_conninfo' "
-                    "and 'slot_name' options to be properly configured"
+                    "Streaming connection: " + force_str(e).strip()
                 )
 
-            # ARCHIVER_OFF_BACKCOMPATIBILITY - START OF CODE
-            # IMPORTANT: This is a back-compatibility feature that has
-            # been added in Barman 2.0. It highlights a deprecated
-            # behaviour, and helps users during this transition phase.
-            # It forces 'archiver=on' when both archiver and streaming_archiver
-            # are set to 'off' (default values) and displays a warning,
-            # requesting users to explicitly set the value in the
-            # configuration.
-            # When this back-compatibility feature will be removed from Barman
-            # (in a couple of major releases), developers will need to remove
-            # this block completely and reinstate the block of code you find
-            # a few lines below (search for ARCHIVER_OFF_BACKCOMPATIBILITY
-            # throughout the code).
-            if (
-                self.config.archiver is False
-                and self.config.streaming_archiver is False
-            ):
-                output.warning(
-                    "No archiver enabled for server '%s'. "
-                    "Please turn on 'archiver', "
-                    "'streaming_archiver' or both",
-                    self.config.name,
+    def _init_archivers(self):
+        # Initialize the StreamingWalArchiver
+        # WARNING: Order of items in self.archivers list is important!
+        # The files will be archived in that order.
+        if self.config.streaming_archiver:
+            try:
+                self.archivers.append(StreamingWalArchiver(self.backup_manager))
+            # If the StreamingWalArchiver creation fails,
+            # disable the server
+            except AttributeError as e:
+                _logger.debug(e)
+                self.config.update_msg_list_and_disable_server(
+                    "Unable to initialise the streaming archiver"
                 )
-                output.warning("Forcing 'archiver = on'")
-                self.config.archiver = True
-            # ARCHIVER_OFF_BACKCOMPATIBILITY - END OF CODE
 
-            # Initialize the FileWalArchiver
-            # WARNING: Order of items in self.archivers list is important!
-            # The files will be archived in that order.
-            if self.config.archiver:
-                try:
-                    self.archivers.append(FileWalArchiver(self.backup_manager))
-                except AttributeError as e:
-                    _logger.debug(e)
-                    self.config.update_msg_list_and_disable_server(
-                        "Unable to initialise the file based archiver"
-                    )
+        # IMPORTANT: The following lines of code have been
+        # temporarily commented in order to make the code
+        # back-compatible after the introduction of 'archiver=off'
+        # as default value in Barman 2.0.
+        # When the back compatibility feature for archiver will be
+        # removed, the following lines need to be decommented.
+        # ARCHIVER_OFF_BACKCOMPATIBILITY - START OF CODE
+        # # At least one of the available archive modes should be enabled
+        # if len(self.archivers) < 1:
+        #     self.config.update_msg_list_and_disable_server(
+        #         "No archiver enabled for server '%s'. "
+        #         "Please turn on 'archiver', 'streaming_archiver' or both"
+        #         % config.name
+        #     )
+        # ARCHIVER_OFF_BACKCOMPATIBILITY - END OF CODE
 
-        # Set bandwidth_limit
+        # Sanity check: if file based archiver is disabled, and only
+        # WAL streaming is enabled, a replication slot name must be
+        # configured.
+        if (
+            not self.config.archiver
+            and self.config.streaming_archiver
+            and self.config.slot_name is None
+        ):
+            self.config.update_msg_list_and_disable_server(
+                "Streaming-only archiver requires 'streaming_conninfo' "
+                "and 'slot_name' options to be properly configured"
+            )
+
+        # ARCHIVER_OFF_BACKCOMPATIBILITY - START OF CODE
+        # IMPORTANT: This is a back-compatibility feature that has
+        # been added in Barman 2.0. It highlights a deprecated
+        # behaviour, and helps users during this transition phase.
+        # It forces 'archiver=on' when both archiver and streaming_archiver
+        # are set to 'off' (default values) and displays a warning,
+        # requesting users to explicitly set the value in the
+        # configuration.
+        # When this back-compatibility feature will be removed from Barman
+        # (in a couple of major releases), developers will need to remove
+        # this block completely and reinstate the block of code you find
+        # a few lines below (search for ARCHIVER_OFF_BACKCOMPATIBILITY
+        # throughout the code).
+        if self.config.archiver is False and self.config.streaming_archiver is False:
+            output.warning(
+                "No archiver enabled for server '%s'. "
+                "Please turn on 'archiver', "
+                "'streaming_archiver' or both",
+                self.config.name,
+            )
+            output.warning("Forcing 'archiver = on'")
+            self.config.archiver = True
+        # ARCHIVER_OFF_BACKCOMPATIBILITY - END OF CODE
+
+        # Initialize the FileWalArchiver
+        # WARNING: Order of items in self.archivers list is important!
+        # The files will be archived in that order.
+        if self.config.archiver:
+            try:
+                self.archivers.append(FileWalArchiver(self.backup_manager))
+            except AttributeError as e:
+                _logger.debug(e)
+                self.config.update_msg_list_and_disable_server(
+                    "Unable to initialise the file based archiver"
+                )
+
+    def _init_bandwidth_limits(self):
+        # Global bandwidth limits
         if self.config.bandwidth_limit:
             try:
                 self.config.bandwidth_limit = int(self.config.bandwidth_limit)
@@ -406,7 +419,7 @@ class Server(RemoteStatusMixin):
                 )
                 self.config.bandwidth_limit = None
 
-        # set tablespace_bandwidth_limit
+        # Tablespace bandwidth limits
         if self.config.tablespace_bandwidth_limit:
             rules = {}
             for rule in self.config.tablespace_bandwidth_limit.split():
@@ -424,6 +437,7 @@ class Server(RemoteStatusMixin):
             else:
                 self.config.tablespace_bandwidth_limit = None
 
+    def _init_minimum_redundancy(self):
         # Set minimum redundancy (default 0)
         try:
             self.config.minimum_redundancy = int(self.config.minimum_redundancy)
@@ -440,9 +454,6 @@ class Server(RemoteStatusMixin):
                 '(fallback to "0")' % (self.config.minimum_redundancy, self.config.name)
             )
             self.config.minimum_redundancy = 0
-
-        # Initialise retention policies
-        self._init_retention_policies()
 
     def _init_retention_policies(self):
         # Set retention policy mode

--- a/barman/server.py
+++ b/barman/server.py
@@ -77,7 +77,11 @@ from barman.lockfile import (
     ServerWalSyncLock,
     ServerXLOGDBLock,
 )
-from barman.postgres import PostgreSQLConnection, StreamingConnection
+from barman.postgres import (
+    PostgreSQLConnection,
+    StandbyPostgreSQLConnection,
+    StreamingConnection,
+)
 from barman.process import ProcessManager
 from barman.remote_status import RemoteStatusMixin
 from barman.retention_policies import RetentionPolicyFactory, RetentionPolicy
@@ -265,9 +269,23 @@ class Server(RemoteStatusMixin):
                     raise ConninfoException(
                         "Missing 'conninfo' parameter for server '%s'" % config.name
                     )
-                self.postgres = PostgreSQLConnection(
-                    config.conninfo, config.immediate_checkpoint, config.slot_name
-                )
+                # If primary_conninfo is set then we're connecting to a standby
+                if config.primary_conninfo is not None:
+                    # The standby needs a connection to the primary so that it can
+                    # perform WAL switches itself when calling pg_backup_stop.
+                    primary = PostgreSQLConnection(
+                        config.primary_conninfo,
+                    )
+                    self.postgres = StandbyPostgreSQLConnection(
+                        config.conninfo,
+                        primary,
+                        config.immediate_checkpoint,
+                        config.slot_name,
+                    )
+                else:
+                    self.postgres = PostgreSQLConnection(
+                        config.conninfo, config.immediate_checkpoint, config.slot_name
+                    )
             # If the PostgreSQLConnection creation fails, disable the Server
             except ConninfoException as e:
                 self.config.update_msg_list_and_disable_server(

--- a/doc/barman.5
+++ b/doc/barman.5
@@ -609,6 +609,30 @@ Global/Server.
 .RS
 .RE
 .TP
+.B primary_conninfo
+The connection string used by Barman to connect to the primary Postgres
+server during backup of a standby Postgres server.
+Barman will use this connection to carry out any required WAL switches
+on the primary during the backup of the standby.
+This allows backups to complete even when
+\f[C]archive_mode\ =\ always\f[] is set on the standby and write traffic
+to the primary is not sufficient to trigger a natural WAL switch.
+.RS
+.PP
+If primary_conninfo is set then it \f[I]must\f[] be pointing to a
+primary Postgres instance and conninfo \f[I]must\f[] be pointing to a
+standby Postgres instance.
+Furthermore both instances must share the same systemid.
+If these conditions are not met then \f[C]barman\ check\f[] will fail.
+.PP
+The primary_conninfo value must be a libpq connection string; consult
+the PostgreSQL
+manual (https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING)
+for more information.
+Commonly used keys are: host, hostaddr, port, dbname, user, password.
+Server.
+.RE
+.TP
 .B primary_ssh_command
 Parameter that identifies a Barman server as \f[C]passive\f[].
 In a passive node, the source of a backup server is a Barman

--- a/doc/barman.5.d/50-primary_conninfo.md
+++ b/doc/barman.5.d/50-primary_conninfo.md
@@ -1,0 +1,18 @@
+primary_conninfo
+:   The connection string used by Barman to connect to the primary Postgres
+    server during backup of a standby Postgres server. Barman will use this
+    connection to carry out any required WAL switches on the primary during
+    the backup of the standby. This allows backups to complete even when
+    `archive_mode = always` is set on the standby and write traffic to the
+    primary is not sufficient to trigger a natural WAL switch.
+
+    If primary_conninfo is set then it *must* be pointing to a primary
+    Postgres instance and conninfo *must* be pointing to a standby Postgres
+    instance. Furthermore both instances must share the same systemid. If
+    these conditions are not met then `barman check` will fail.
+
+    The primary_conninfo value must be a libpq connection string; consult the
+    [PostgreSQL manual][conninfo] for more information. Commonly used
+    keys are: host, hostaddr, port, dbname, user, password. Server.
+
+[conninfo]: https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING

--- a/tests/test_command_wrappers.py
+++ b/tests/test_command_wrappers.py
@@ -452,6 +452,37 @@ class TestCommand(object):
         assert cmd.out == out
         assert cmd.err == err
 
+    def test_get_output_handlers(self, popen, pipe_processor_loop):
+        """Verify that command out/err handlers are called during get_output"""
+        # GIVEN a command which outputs to stdout and stderr
+        command = "command"
+        ret = 0
+        out = "out"
+        err = "err"
+        stdin = "in"
+        # AND a mocked pipe which provides the specified output
+        _mock_pipe(popen, pipe_processor_loop, ret, out, err)
+
+        # WHEN the command is called with a custom out and err handlers
+        out_handler = mock.Mock()
+        err_handler = mock.Mock()
+        cmd = command_wrappers.Command(
+            command, out_handler=out_handler, err_handler=err_handler
+        )
+        # AND get_output is called on the command
+        result = cmd.get_output(stdin=stdin)
+
+        # THEN the custom out_handler and err_handler functions were called
+        out_handler.assert_called_with(out)
+        err_handler.assert_called_with(err)
+
+        # AND the out/err members of the command contain stdout and stderr
+        assert cmd.out == out
+        assert cmd.err == err
+
+        # AND the stdout and stderr output are returned in the result
+        assert result == (out, err)
+
     def test_execute_invocation(self, popen, pipe_processor_loop, caplog):
         # See all logs
         caplog.set_level(0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -174,6 +174,7 @@ class TestConfig(object):
                 "custom_decompression_filter": "bzip2 -c -d",
                 "backup_method": "rsync",
                 "max_incoming_wals_queue": None,
+                "primary_conninfo": None,
             }
         )
         assert main.__dict__ == expected
@@ -209,6 +210,7 @@ class TestConfig(object):
                 "streaming_wals_directory": "/some/barman/home/web/streaming",
                 "errors_directory": "/some/barman/home/web/errors",
                 "max_incoming_wals_queue": None,
+                "primary_conninfo": None,
             }
         )
         assert web.__dict__ == expected

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -167,6 +167,26 @@ class TestServer(object):
             "'slot_name' options to be properly configured" in server.config.msg_list
         )
 
+    def test_primary_init(self):
+        """Verify standby properties do not exist when no primary_conninfo is set"""
+        # GIVEN a server with a default config
+        cfg = build_config_from_dicts().get_server("main")
+        # WHEN the server is instantiated
+        server = Server(cfg)
+        # THEN the postgres connection has no primary connection
+        assert not hasattr(server.postgres, "primary")
+
+    def test_standby_init(self):
+        """Verify standby properties exist when primary_conninfo is set"""
+        # GIVEN a server with primary_conninfo set
+        cfg = build_config_from_dicts(
+            main_conf={"primary_conninfo": "db=primary"},
+        ).get_server("main")
+        # WHEN the server is instantiated
+        server = Server(cfg)
+        # THEN the postgres connection has a primary connection
+        assert server.postgres.primary is not None
+
     def test_check_config_missing(self, tmpdir):
         """
         Verify the check method can be called on an empty configuration

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -311,6 +311,7 @@ def build_config_dictionary(config_keys=None):
         "parallel_jobs": 1,
         "create_slot": "manual",
         "forward_config_path": False,
+        "primary_conninfo": None,
     }
     # Check for overriding keys
     if config_keys is not None:


### PR DESCRIPTION
Fully implemented for both `backup_method = rsync` and `backup_method = postgres`. Unit tests included in this PR and integration tests up for review at https://github.com/EnterpriseDB/barman-testing/pull/59.