### PR TITLE
Dev/rework compression classes

### DIFF
--- a/barman/backup.py
+++ b/barman/backup.py
@@ -91,8 +91,7 @@ class BackupManager(RemoteStatusMixin, KeepManagerMixin):
             else:
                 self.executor = RsyncBackupExecutor(self)
         except SshCommandException as e:
-            self.config.disabled = True
-            self.config.msg_list.append(force_str(e).strip())
+            self.config.update_msg_list_and_disable_server(force_str(e).strip())
 
     @property
     def mode(self):

--- a/barman/command_wrappers.py
+++ b/barman/command_wrappers.py
@@ -971,26 +971,25 @@ class PgBaseBackup(PostgreSQLClient):
         compression_args = []
 
         if compression is not None:
-            if compression.format is not None:
-                compression_format = compression.format
+            if compression.config.format is not None:
+                compression_format = compression.config.format
             else:
                 compression_format = "tar"
             compression_args.append("--format=%s" % compression_format)
             # For clients >= 15 we use the new --compress argument format
             if version and version >= Version("15"):
                 compress_arg = "--compress="
-                if compression.location is not None:
-                    compress_arg += "%s-" % compression.location
-                compress_arg += compression.type
-                if compression.level:
-                    compress_arg += ":level=%d" % compression.level
+                if compression.config.location is not None:
+                    compress_arg += "%s-" % compression.config.location
+                compress_arg += compression.config.type
+                if compression.config.level:
+                    compress_arg += ":level=%d" % compression.config.level
                 compression_args.append(compress_arg)
             # For clients < 15 we use the old style argument format
             else:
-                compression_args.append("--%s" % compression.type)
-                if compression.level:
-                    compression_args.append("--compress=%d" % compression.level)
-
+                compression_args.append("--%s" % compression.config.type)
+                if compression.config.level:
+                    compression_args.append("--compress=%d" % compression.config.level)
         return compression_args
 
 

--- a/barman/compression.py
+++ b/barman/compression.py
@@ -26,15 +26,17 @@ import gzip
 import logging
 import shutil
 from abc import ABCMeta, abstractmethod, abstractproperty
-from contextlib import closing, contextmanager
+from contextlib import closing
 from distutils.version import LooseVersion as Version
 
 import barman.infofile
 from barman.command_wrappers import Command
+from barman.fs import unix_command_factory
 from barman.exceptions import (
     CommandFailedException,
     CompressionException,
     CompressionIncompatibility,
+    FileNotFoundException,
 )
 from barman.utils import force_str, with_metaclass
 
@@ -44,7 +46,9 @@ _logger = logging.getLogger(__name__)
 class CompressionManager(object):
     def __init__(self, config, path):
         """
-        Compression manager
+
+        :param config: barman.config.ServerConfig
+        :param path: str
         """
         self.config = config
         self.path = path
@@ -146,6 +150,12 @@ class Compressor(with_metaclass(ABCMeta, object)):
     MAGIC = None
 
     def __init__(self, config, compression, path=None):
+        """
+
+        :param config: barman.config.ServerConfig
+        :param compression: str compression name
+        :param path: str|None
+        """
         self.config = config
         self.compression = compression
         self.path = path
@@ -187,6 +197,11 @@ class CommandCompressor(Compressor):
     """
 
     def __init__(self, config, compression, path=None):
+        """
+        :param config: barman.config.ServerConfig
+        :param compression: str compression name
+        :param path: str|None
+        """
         super(CommandCompressor, self).__init__(config, compression, path)
 
         self._compress = None
@@ -288,6 +303,12 @@ class GZipCompressor(CommandCompressor):
     MAGIC = b"\x1f\x8b\x08"
 
     def __init__(self, config, compression, path=None):
+        """
+
+        :param config: barman.config.ServerConfig
+        :param compression: str compression name
+        :param path: str|None
+        """
         super(GZipCompressor, self).__init__(config, compression, path)
         self._compress = self._build_command("gzip -c")
         self._decompress = self._build_command("gzip -c -d")
@@ -301,6 +322,12 @@ class PyGZipCompressor(InternalCompressor):
     MAGIC = b"\x1f\x8b\x08"
 
     def __init__(self, config, compression, path=None):
+        """
+
+        :param config: barman.config.ServerConfig
+        :param compression: str compression name
+        :param path: str|None
+        """
         super(PyGZipCompressor, self).__init__(config, compression, path)
 
         # Default compression level used in system gzip utility
@@ -324,6 +351,12 @@ class PigzCompressor(CommandCompressor):
     MAGIC = b"\x1f\x8b\x08"
 
     def __init__(self, config, compression, path=None):
+        """
+
+        :param config: barman.config.ServerConfig
+        :param compression: str compression name
+        :param path: str|None
+        """
         super(PigzCompressor, self).__init__(config, compression, path)
         self._compress = self._build_command("pigz -c")
         self._decompress = self._build_command("pigz -c -d")
@@ -337,6 +370,12 @@ class BZip2Compressor(CommandCompressor):
     MAGIC = b"\x42\x5a\x68"
 
     def __init__(self, config, compression, path=None):
+        """
+
+        :param config: barman.config.ServerConfig
+        :param compression: str compression name
+        :param path: str|None
+        """
         super(BZip2Compressor, self).__init__(config, compression, path)
         self._compress = self._build_command("bzip2 -c")
         self._decompress = self._build_command("bzip2 -c -d")
@@ -350,6 +389,12 @@ class PyBZip2Compressor(InternalCompressor):
     MAGIC = b"\x42\x5a\x68"
 
     def __init__(self, config, compression, path=None):
+        """
+
+        :param config: barman.config.ServerConfig
+        :param compression: str compression name
+        :param path: str|None
+        """
         super(PyBZip2Compressor, self).__init__(config, compression, path)
 
         # Default compression level used in system gzip utility
@@ -368,6 +413,12 @@ class CustomCompressor(CommandCompressor):
     """
 
     def __init__(self, config, compression, path=None):
+        """
+
+        :param config: barman.config.ServerConfig
+        :param compression: str compression name
+        :param path: str|None
+        """
         if (
             config.custom_compression_filter is None
             or type(config.custom_compression_filter) != str
@@ -405,40 +456,139 @@ def get_pg_basebackup_compression(server):
 
     :param barman.server.Server server: the server for which the
       PgBaseBackupCompression should be constructed
+    :return GZipPgBaseBackupCompression
     """
     if server.config.backup_compression is None:
         return
-    try:
-        return {"gzip": GZipPgBaseBackupCompression}[server.config.backup_compression](
-            server.config
+    pg_base_backup_cfg = PgBaseBackupCompressionConfig(
+        server.config.backup_compression,
+        server.config.backup_compression_format,
+        server.config.backup_compression_level,
+        server.config.backup_compression_location,
+    )
+
+    if server.config.backup_compression == "gzip":
+        # Create PgBaseBackupCompressionOption
+        base_backup_compression_option = GZipPgBaseBackupCompressionOption(
+            pg_base_backup_cfg
         )
-    except KeyError:
-        raise CompressionException(
-            "Barman does not support pg_basebackup compression: %s"
-            % server.config.backup_compression
+        compression = GZipCompression(unix_command_factory())
+        return PgBaseBackupCompression(
+            pg_base_backup_cfg, base_backup_compression_option, compression
         )
+    # We got to the point where the compression is not handled
+    raise CompressionException(
+        "Barman does not support pg_basebackup compression: %s"
+        % server.config.backup_compression
+    )
 
 
-class PgBaseBackupCompression(with_metaclass(ABCMeta, object)):
+class PgBaseBackupCompressionConfig(object):
+    """Should become a dataclass"""
+
+    def __init__(
+        self,
+        backup_compression,
+        backup_compression_format,
+        backup_compression_level,
+        backup_compression_location,
+    ):
+        self.type = backup_compression
+        self.format = backup_compression_format
+        self.level = backup_compression_level
+        self.location = backup_compression_location
+
+
+class PgBaseBackupCompressionOption(object):
+    """This class is in charge of validating pg_basebackup compression options"""
+
+    def __init__(self, pg_base_backup_config):
+        """
+
+        :param pg_base_backup_config: PgBaseBackupCompressionConfig
+        """
+        self.config = pg_base_backup_config
+
+    def validate(self, pg_server_version, remote_status):
+        """
+        Validate pg_basebackup compression options.
+
+        :param pg_server_version int: the server for which the
+          compression options should be validated.
+        :param dict remote_status: the status of the pg_basebackup command
+        :return List: List of Issues (str) or empty list
+        """
+        issues = []
+        if self.config.location is not None and self.config.location == "server":
+            # "backup_location = server" requires pg_basebackup >= 15
+            if remote_status["pg_basebackup_version"] < Version("15"):
+                issues.append(
+                    "backup_compression_location = server requires "
+                    "pg_basebackup 15 or greater"
+                )
+            # "backup_location = server" requires PostgreSQL >= 15
+            if pg_server_version < 150000:
+                issues.append(
+                    "backup_compression_location = server requires "
+                    "PostgreSQL 15 or greater"
+                )
+
+        # plain backup format is only allowed when compression is on the server
+        if self.config.format == "plain" and self.config.location != "server":
+            issues.append(
+                "backup_compression_format plain is not compatible with "
+                "backup_compression_location %s" % self.config.location
+            )
+        return issues
+
+
+class GZipPgBaseBackupCompressionOption(PgBaseBackupCompressionOption):
+    def validate(self, pg_server_version, remote_status):
+        """
+        Validate gzip-specific options.
+
+        :param pg_server_version int: the server for which the
+          compression options should be validated.
+        :param dict remote_status: the status of the pg_basebackup command
+        :return List: List of Issues (str) or empty list
+        """
+        issues = super(GZipPgBaseBackupCompressionOption, self).validate(
+            pg_server_version, remote_status
+        )
+        if self.config.level is not None and (
+            self.config.level < 1 or self.config.level > 9
+        ):
+            issues.append(
+                "backup_compression_level %d unsupported by "
+                "pg_basebackup compression %s" % (self.config.level, self.config.type)
+            )
+        return issues
+
+
+class PgBaseBackupCompression(object):
     """
     Represents the pg_basebackup compression options and provides functionality
     required by the backup process which depends on those options.
+    This is a facade that interacts with appropriate classes
     """
 
-    def __init__(self, config):
+    def __init__(
+        self,
+        pg_basebackup_compression_cfg,
+        pg_basebackup_compression_option,
+        compression,
+    ):
         """
-        Constructor for the PgBaseBackupCompression abstract base class.
+        Constructor for the PgBaseBackupCompression facade that handles base_backup class related.
 
-        :param barman.config.ServerConfig config: the server configuration
+        :param pg_basebackup_compression_cfg PgBaseBackupCompressionConfig: pg_basebackup compression  configuration
+        :param pg_basebackup_compression_option PgBaseBackupCompressionOption:
+        :param compression Compression:
+
         """
-        self.type = config.backup_compression
-        self.format = config.backup_compression_format
-        self.level = config.backup_compression_level
-        self.location = config.backup_compression_location
-
-    @abstractproperty
-    def suffix(self):
-        """The filename suffix expected for this compression"""
+        self.config = pg_basebackup_compression_cfg
+        self.options = pg_basebackup_compression_option
+        self.compression = compression
 
     def with_suffix(self, basename):
         """
@@ -447,76 +597,131 @@ class PgBaseBackupCompression(with_metaclass(ABCMeta, object)):
         :param str basename: The basename (without compression suffix) of the
           file to be opened.
         """
-        return ".".join((basename, self.suffix))
+        return "%s.%s" % (basename, self.compression.file_extension)
 
-    @abstractmethod
-    @contextmanager
-    def open(self, basename):
+    def get_file_content(self, filename, archive):
         """
-        Open file at path/basename for reading.
-
-        :param str basename: The basename (without compression suffix) of the
-          file to be opened.
+        Returns archive specific file content
+        :param filename: str
+        :param archive: str
+        :return: str
         """
+        return self.compression.get_file_content(filename, archive)
 
-    def validate(self, server, remote_status):
+    def validate(self, pg_server_version, remote_status):
         """
         Validate pg_basebackup compression options.
 
-        :param barman.server.Server server: the server for which the
+        :param pg_server_version int: the server for which the
           compression options should be validated.
         :param dict remote_status: the status of the pg_basebackup command
+        :return List: List of Issues (str) or empty list
         """
-        if self.location is not None and self.location == "server":
-            # "backup_location = server" requires pg_basebackup >= 15
-            if remote_status["pg_basebackup_version"] < Version("15"):
-                server.config.disabled = True
-                server.config.msg_list.append(
-                    "backup_compression_location = server requires "
-                    "pg_basebackup 15 or greater"
-                )
-            # "backup_location = server" requires PostgreSQL >= 15
-            if server.postgres.server_version < 150000:
-                server.config.disabled = True
-                server.config.msg_list.append(
-                    "backup_compression_location = server requires "
-                    "PostgreSQL 15 or greater"
-                )
+        return self.options.validate(pg_server_version, remote_status)
 
-        # plain backup format is only allowed when compression is on the server
-        if self.format == "plain" and self.location != "server":
-            server.config.disabled = True
-            server.config.msg_list.append(
-                "backup_compression_format plain is not compatible with "
-                "backup_compression_location %s" % self.location
+
+class Compression(with_metaclass(ABCMeta, object)):
+    """
+    Abstract class meant to represent compression interface
+    """
+
+    @abstractproperty
+    def name(self):
+        """
+
+        :return:
+        """
+
+    @abstractproperty
+    def file_extension(self):
+        """
+
+        :return:
+        """
+
+    @abstractmethod
+    def uncompress(self, src, dst, exclude=None, include_args=None):
+        """
+
+        :param src: source file path without compression extension
+        :param dst: destination path
+        :param exclude: list of filepath in the archive to exclude from the extraction
+        :param include_args: list of filepath in the archive to extract.
+        :return:
+        """
+
+    @abstractmethod
+    def get_file_content(self, filename, archive):
+        """
+
+        :param filename: str file to search for in the archive (requires its full path within the archive)
+        :param archive: str archive path/name without extension
+        :return: string content
+        """
+
+
+class GZipCompression(Compression):
+    name = "gzip"
+    file_extension = "tar.gz"
+
+    def __init__(self, command):
+        """
+
+        :param command: barman.fs.UnixLocalCommand
+        """
+        self.command = command
+
+    def uncompress(self, src, dst, exclude=None, include_args=None):
+        """
+
+        :param src: should specify if compression extension is included or not
+        :param dst: destination path
+        :param exclude: list of filepath in the archive to exclude from the extraction
+        :param include_args: list of filepath in the archive to extract.
+        :return:
+        """
+        if src is None or src == "":
+            raise ValueError("Source path should be a string")
+        if dst is None or dst == "":
+            raise ValueError("Destination path should be a string")
+        exclude = [] if exclude is None else exclude
+        exclude_args = []
+        for name in exclude:
+            exclude_args.append("--exclude")
+            exclude_args.append(name)
+        include_args = [] if include_args is None else include_args
+        args = ["xzf", src, "--directory", dst]
+        args.extend(exclude_args)
+        args.extend(include_args)
+        ret = self.command.cmd("tar", args=args)
+        out, err = self.command.get_last_output()
+        if ret != 0:
+            raise CommandFailedException(
+                "Error decompressing %s into %s: %s" % (src, dst, err)
             )
+        else:
+            return self.command.get_last_output()
 
-
-class GZipPgBaseBackupCompression(PgBaseBackupCompression):
-    suffix = "gz"
-
-    @contextmanager
-    def open(self, basename):
+    def get_file_content(self, filename, archive):
         """
-        Open file at path/basename for reading, uncompressing with the GZip algorithm.
 
-        :param str basename: The basename (without compression suffix) of the
-          file to be opened.
+        :param filename: str file to search for in the archive (requires its full path within the archive)
+        :param archive: str archive path/name without extension
+        :return: string content
         """
-        yield gzip.open(self.with_suffix(basename), "rb")
-
-    def validate(self, server, remote_status):
-        """
-        Validate gzip-specific options.
-
-        :param barman.server.Server server: the server for which the
-          compression options should be validated.
-        :param dict remote_status: the status of the pg_basebackup command
-        """
-        super(GZipPgBaseBackupCompression, self).validate(server, remote_status)
-        if self.level is not None and (self.level < 1 or self.level > 9):
-            server.config.disabled = True
-            server.config.msg_list.append(
-                "backup_compression_level %d unsupported by "
-                "pg_basebackup compression %s" % (self.level, self.type)
-            )
+        full_archive_name = "%s.%s" % (archive, self.file_extension)
+        args = ["-xzf", full_archive_name, "-O", filename, "--occurrence"]
+        ret = self.command.cmd("tar", args=args)
+        out, err = self.command.get_last_output()
+        if ret != 0:
+            if "Not found in archive" in err:
+                raise FileNotFoundException(
+                    err + "archive name: %s" % full_archive_name
+                )
+            else:
+                raise CommandFailedException(
+                    "Error reading %s into archive %s: (%s)"
+                    % (filename, full_archive_name, err)
+                )
+        else:
+            return out

--- a/barman/config.py
+++ b/barman/config.py
@@ -724,6 +724,19 @@ class ServerConfig(object):
 
         return bwlimit
 
+    def update_msg_list_and_disable_server(self, msg_list):
+        """
+        Will take care of upgrading msg_list
+        :param msg_list: str|list can be either a string or a list of strings
+        """
+        if not msg_list:
+            return
+        if type(msg_list) is not list:
+            msg_list = [msg_list]
+
+        self.msg_list.extend(msg_list)
+        self.disabled = True
+
 
 class Config(object):
     """This class represents the barman configuration.

--- a/barman/exceptions.py
+++ b/barman/exceptions.py
@@ -188,6 +188,12 @@ class CompressionIncompatibility(CompressionException):
     """
 
 
+class FileNotFoundException(CompressionException):
+    """
+    Exception for file not found in archive
+    """
+
+
 class FsOperationFailed(CommandException):
     """
     Exception which represents a failed execution of a command on FS

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -22,7 +22,6 @@ This module contains the methods necessary to perform a recovery
 
 from __future__ import print_function
 
-from abc import ABCMeta, abstractmethod, abstractproperty
 import collections
 import datetime
 import logging
@@ -50,9 +49,10 @@ from barman.exceptions import (
     RecoveryStandbyModeException,
     RecoveryTargetActionException,
 )
+from barman.compression import GZipCompression
 import barman.fs as fs
 from barman.infofile import BackupInfo, LocalBackupInfo
-from barman.utils import force_str, mkpath, with_metaclass
+from barman.utils import force_str, mkpath
 
 # generic logger for this module
 _logger = logging.getLogger(__name__)
@@ -1428,72 +1428,6 @@ def recovery_executor_factory(backup_manager, command, compression=None):
         return TarballRecoveryExecutor(backup_manager, GZipCompression(command))
 
     raise AttributeError("Unexpected compression format: %s" % compression)
-
-
-class Compression(with_metaclass(ABCMeta, object)):
-    """
-    Class meant to manage compression action using external program with linux command
-    """
-
-    @abstractproperty
-    def name(self):
-        """
-
-        :return:
-        """
-
-    @abstractproperty
-    def file_extension(self):
-        """
-
-        :return:
-        """
-
-    @abstractmethod
-    def uncompress(self, src, dst, exclude=[], include_args=[]):
-        """
-
-        :param src:
-        :param dst:
-        :param exclude:
-        :param include_args:
-        :return:
-        """
-
-
-class GZipCompression(Compression):
-    name = "gzip"
-    file_extension = "tar.gz"
-
-    def __init__(self, command):
-        """
-
-        :param command: barman.fs.UnixLocalCommand
-        """
-        self.command = command
-
-    def uncompress(self, src, dst, exclude=None, include_args=None):
-        if src is None or src == "":
-            raise ValueError("Source path should be a string")
-        if dst is None or dst == "":
-            raise ValueError("Destination path should be a string")
-        exclude = [] if exclude is None else exclude
-        exclude_args = []
-        for name in exclude:
-            exclude_args.append("--exclude")
-            exclude_args.append(name)
-        include_args = [] if include_args is None else include_args
-        args = ["xfz", src, "--directory", dst]
-        args.extend(exclude_args)
-        args.extend(include_args)
-        ret = self.command.cmd("tar", args=args)
-        out, err = self.command.get_last_output()
-        if ret != 0:
-            raise CommandFailedException(
-                "Error decompressing %s into %s: %s" % (src, dst, err)
-            )
-        else:
-            return self.command.get_last_output()
 
 
 class ConfigurationFileMangeler:

--- a/barman/server.py
+++ b/barman/server.py
@@ -270,8 +270,7 @@ class Server(RemoteStatusMixin):
                 )
             # If the PostgreSQLConnection creation fails, disable the Server
             except ConninfoException as e:
-                self.config.disabled = True
-                self.config.msg_list.append(
+                self.config.update_msg_list_and_disable_server(
                     "PostgreSQL connection: " + force_str(e).strip()
                 )
 
@@ -287,8 +286,7 @@ class Server(RemoteStatusMixin):
                     self.streaming = StreamingConnection(config.streaming_conninfo)
                 # If the StreamingConnection creation fails, disable the server
                 except ConninfoException as e:
-                    self.config.disabled = True
-                    self.config.msg_list.append(
+                    self.config.update_msg_list_and_disable_server(
                         "Streaming connection: " + force_str(e).strip()
                     )
 
@@ -306,8 +304,7 @@ class Server(RemoteStatusMixin):
                 # disable the server
                 except AttributeError as e:
                     _logger.debug(e)
-                    self.config.disabled = True
-                    self.config.msg_list.append(
+                    self.config.update_msg_list_and_disable_server(
                         "Unable to initialise the streaming archiver"
                     )
 
@@ -320,11 +317,11 @@ class Server(RemoteStatusMixin):
             # ARCHIVER_OFF_BACKCOMPATIBILITY - START OF CODE
             # # At least one of the available archive modes should be enabled
             # if len(self.archivers) < 1:
-            #     self.config.disabled = True
-            #     self.config.msg_list.append(
+            #     self.config.update_msg_list_and_disable_server(
             #         "No archiver enabled for server '%s'. "
             #         "Please turn on 'archiver', 'streaming_archiver' or both"
-            #         % config.name)
+            #         % config.name
+            #     )
             # ARCHIVER_OFF_BACKCOMPATIBILITY - END OF CODE
 
             # Sanity check: if file based archiver is disabled, and only
@@ -335,8 +332,7 @@ class Server(RemoteStatusMixin):
                 and self.config.streaming_archiver
                 and self.config.slot_name is None
             ):
-                self.config.disabled = True
-                self.config.msg_list.append(
+                self.config.update_msg_list_and_disable_server(
                     "Streaming-only archiver requires 'streaming_conninfo' "
                     "and 'slot_name' options to be properly configured"
                 )
@@ -376,8 +372,7 @@ class Server(RemoteStatusMixin):
                     self.archivers.append(FileWalArchiver(self.backup_manager))
                 except AttributeError as e:
                     _logger.debug(e)
-                    self.config.disabled = True
-                    self.config.msg_list.append(
+                    self.config.update_msg_list_and_disable_server(
                         "Unable to initialise the file based archiver"
                     )
 

--- a/tests/test_barman_wal_restore.py
+++ b/tests/test_barman_wal_restore.py
@@ -79,13 +79,14 @@ class TestRemoteGetWal(object):
         ) in err
 
     @mock.patch("barman.clients.walrestore.RemoteGetWal")
-    def test_ssh_connectivity_error(self, remote_get_wal_mock, capsys):
+    def test_ssh_connectivity_error(self, remote_get_wal_mock, capsys, tmpdir):
         """Verifies exit status is 2 when ssh connectivity fails."""
         mock_ssh_process = remote_get_wal_mock.return_value
         mock_ssh_process.returncode = 255
 
+        dest_path = tmpdir.join("dummy_dest").strpath
         with pytest.raises(SystemExit) as exc:
-            walrestore.main(["a.host", "a-server", "dummy_wal", "dummy_dest"])
+            walrestore.main(["a.host", "a-server", "dummy_wal", dest_path])
 
         assert exc.value.code == 2
         out, err = capsys.readouterr()
@@ -93,13 +94,14 @@ class TestRemoteGetWal(object):
         assert ("ERROR: Connection problem with ssh\n") in err
 
     @mock.patch("barman.clients.walrestore.RemoteGetWal")
-    def test_ssh_exit_code_is_passed_through(self, remote_get_wal_mock, capsys):
+    def test_ssh_exit_code_is_passed_through(self, remote_get_wal_mock, capsys, tmpdir):
         """Verifies non-255 SSH exit codes are passed through."""
         mock_ssh_process = remote_get_wal_mock.return_value
         mock_ssh_process.returncode = 1
 
+        dest_path = tmpdir.join("dummy_dest").strpath
         with pytest.raises(SystemExit) as exc:
-            walrestore.main(["a.host", "a-server", "dummy_wal", "dummy_dest"])
+            walrestore.main(["a.host", "a-server", "dummy_wal", dest_path])
 
         assert exc.value.code == 1
         out, err = capsys.readouterr()

--- a/tests/test_command_wrappers.py
+++ b/tests/test_command_wrappers.py
@@ -1196,7 +1196,7 @@ class TestPgBaseBackup(object):
         assert ("PgBaseBackup", WARNING, err) in caplog.record_tuples
 
     @pytest.mark.parametrize(
-        ("compression", "expected_args", "unexpected_args"),
+        ("compression_config", "expected_args", "unexpected_args"),
         [
             # If no compression is provided then no compression args are expected
             (None, [], ["--gzip", "--compress", "--format"]),
@@ -1216,7 +1216,7 @@ class TestPgBaseBackup(object):
             ),
         ],
     )
-    def test_compression_gzip(self, compression, expected_args, unexpected_args):
+    def test_compression_gzip(self, compression_config, expected_args, unexpected_args):
         """
         Verifies the expected pg_basebackup options are added for the specified
         compression. Only cares whether the correct arguments are created and does
@@ -1225,6 +1225,10 @@ class TestPgBaseBackup(object):
         """
         connection_mock = mock.MagicMock()
         connection_mock.get_connection_string.return_value = "fake_connstring"
+        compression_mock = None
+        if compression_config is not None:
+            compression_mock = mock.MagicMock()
+            compression_mock.config = compression_config
 
         # GIVEN a PgBaseBackup command initialised with the specified compression
         # WHEN the wrapper is instantiated
@@ -1234,7 +1238,7 @@ class TestPgBaseBackup(object):
             connection=connection_mock,
             version="14",
             app_name="test_app_name",
-            compression=compression,
+            compression=compression_mock,
         )
 
         # THEN all expected arguments are present
@@ -1245,7 +1249,7 @@ class TestPgBaseBackup(object):
             assert not any(expected_arg == arg.split("=")[0] for arg in cmd.args)
 
     @pytest.mark.parametrize(
-        ("compression", "expected_args", "unexpected_args"),
+        ("compression_config", "expected_args", "unexpected_args"),
         [
             # If no compression is provided then no compression args are expected
             (None, [], ["--gzip", "--compress", "--format"]),
@@ -1292,13 +1296,17 @@ class TestPgBaseBackup(object):
         ],
     )
     def test_compression_gzip_version_gte_15(
-        self, compression, expected_args, unexpected_args
+        self, compression_config, expected_args, unexpected_args
     ):
         """
         Verifies the expected pg_basebackup options are added for pg_basebackup>=15.
         """
         connection_mock = mock.MagicMock()
         connection_mock.get_connection_string.return_value = "fake_connstring"
+        compression_mock = None
+        if compression_config is not None:
+            compression_mock = mock.MagicMock()
+            compression_mock.config = compression_config
 
         # GIVEN a PgBaseBackup command initialised with the specified compression
         # WHEN the wrapper is instantiated
@@ -1308,7 +1316,7 @@ class TestPgBaseBackup(object):
             connection=connection_mock,
             version="15",
             app_name="test_app_name",
-            compression=compression,
+            compression=compression_mock,
         )
 
         # THEN all expected arguments are present

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -539,6 +539,35 @@ class TestConfig(object):
                 parse_backup_compression(format)
 
 
+class TestServerConfig(object):
+    def test_update_msg_list_and_disable_server(self):
+        c = testing_helpers.build_config_from_dicts(
+            global_conf={
+                "archiver": "on",
+                "backup_options": BackupOptions.EXCLUSIVE_BACKUP,
+            },
+            main_conf={"backup_options": ""},
+        )
+        main = c.get_server("main")
+        assert main.disabled is False
+        msg1 = "An issue occurred"
+        main.update_msg_list_and_disable_server(msg1)
+
+        assert main.disabled is True
+        assert main.msg_list == [msg1]
+
+        msg2 = "This config is not valid"
+        main.update_msg_list_and_disable_server(msg2)
+        assert main.msg_list == [msg1, msg2]
+        assert main.disabled is True
+
+        msg3 = "error wrong path"
+        msg4 = "No idea"
+        main.update_msg_list_and_disable_server([msg3, msg4])
+        assert main.msg_list == [msg1, msg2, msg3, msg4]
+        assert main.disabled is True
+
+
 # noinspection PyMethodMayBeStatic
 class TestCsvParsing(object):
     """

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1301,7 +1301,7 @@ class TestPostgresBackupExecutor(object):
         # WHEN a PostgresBackupExecutor is created
         executor = PostgresBackupExecutor(server.backup_manager)
         # THEN a PgBaseBackupCompression is created with type == "gzip"
-        assert executor.backup_compression.type == "gzip"
+        assert executor.backup_compression.config.type == "gzip"
 
     def test_no_backup_compression(self):
         """
@@ -1315,8 +1315,8 @@ class TestPostgresBackupExecutor(object):
         # THEN the backup_compression attribute of the executor is None
         assert executor.backup_compression is None
 
-    @patch("barman.compression.GZipPgBaseBackupCompression")
-    def test_validate_config_compression(self, mock_gzip_pgbb_compression):
+    @patch("barman.compression.PgBaseBackupCompression")
+    def test_validate_config_compression(self, mock_pgbb_compression):
         """
         Checks that the validate_config method validates compression options.
         We do not care about the details of the validation here, we only care
@@ -1326,10 +1326,12 @@ class TestPostgresBackupExecutor(object):
         server = build_mocked_server(
             global_conf={"backup_method": "postgres", "backup_compression": "gzip"}
         )
+        # WITH a valid compression configuration
+        mock_pgbb_compression.return_value.validate.return_value = []
         # WHEN a PostgresBackupExecutor is created
         PostgresBackupExecutor(server.backup_manager)
         # THEN the validate method of the executor's PgBaseBackupCompression object
         # is called
-        mock_gzip_pgbb_compression.return_value.validate.assert_called_once()
+        mock_pgbb_compression.return_value.validate.assert_called_once()
         # AND the server config message list has no errors
         assert len(server.config.msg_list) == 0

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -37,7 +37,6 @@ from barman.exceptions import (
 from barman.infofile import BackupInfo, WalFileInfo
 from barman.recovery_executor import (
     Assertion,
-    GZipCompression,
     RecoveryExecutor,
     TarballRecoveryExecutor,
     ConfigurationFileMangeler,
@@ -1420,102 +1419,6 @@ class TestRecoveryExecutorFactory(object):
                 mock_backup_manager, mock_command, compression
             )
             assert type(executor) is expected_executor
-
-
-class TestGZipCompression(object):
-    @pytest.mark.parametrize(
-        ("src", "dst", "exclude", "include", "expected_error"),
-        [
-            # Simple src, dest case should cause the correct command to be called
-            ("/path/to/source", "/path/to/dest", None, None, None),
-            # Empty strings and None values for src or dst should raise an error
-            ("", "/path/to/dest", None, None, ValueError),
-            (None, "/path/to/dest", None, None, ValueError),
-            ("/path/to/src", "", None, None, ValueError),
-            ("/path/to/src", None, None, None, ValueError),
-            # Exclude arguments should be appended
-            (
-                "/path/to/source",
-                "/path/to/dest",
-                ["/path/to/exclude", "/another/path/to/exclude"],
-                None,
-                None,
-            ),
-            # Include arguments should be appended
-            (
-                "/path/to/source",
-                "/path/to/dest",
-                None,
-                ["path/to/include", "/another/path/to/include"],
-                None,
-            ),
-            # Both include and exclude arguments should be appended
-            (
-                "/path/to/source",
-                "/path/to/dest",
-                ["/path/to/exclude", "/another/path/to/exclude"],
-                ["path/to/include", "/another/path/to/include"],
-                None,
-            ),
-        ],
-    )
-    def test_uncompress(self, src, dst, exclude, include, expected_error):
-        # GIVEN a GZipCompression object
-        command = mock.Mock()
-        command.cmd.return_value = 0
-        command.get_last_output.return_value = ("all good", "")
-        gzip_compression = GZipCompression(command)
-
-        # WHEN uncompress is called with the source and destination
-        # THEN the command is called once
-        # AND if we expect an error, that error is raised
-        if expected_error is not None:
-            with pytest.raises(ValueError):
-                gzip_compression.uncompress(
-                    src, dst, exclude=exclude, include_args=include
-                )
-            # THEN command.cmd was not called
-            command.cmd.assert_not_called()
-        # OR if we don't expect an error
-        else:
-            gzip_compression.uncompress(src, dst, exclude=exclude, include_args=include)
-            # THEN command.cmd was called
-            assert command.cmd.called_once()
-            # AND the first argument was "tar"
-            assert command.cmd.call_args_list[0][0][0] == "tar"
-            # AND the basic arguments are present
-            assert command.cmd.call_args_list[0][1]["args"][:4] == [
-                "xfz",
-                src,
-                "--directory",
-                dst,
-            ]
-            # AND if we expected exclude args they are present
-            remaining_args = " ".join(command.cmd.call_args_list[0][1]["args"][4:])
-            if exclude is not None:
-                for exclude_arg in exclude:
-                    assert "--exclude %s" % exclude_arg in remaining_args
-            # AND if we expected include args they are present
-            if include is not None:
-                for include_arg in include:
-                    assert include_arg in remaining_args
-
-    def test_tar_failure_raises_exception(self):
-        """Verify a nonzero return code from tar raises an exception"""
-        # GIVEN a GZipCompression object
-        # AND a tar command which returns status 2 and an error
-        command = mock.Mock()
-        command.cmd.return_value = 2
-        command.get_last_output.return_value = ("", "some error")
-        gzip_compression = GZipCompression(command)
-
-        # WHEN uncompress is called
-        # THEN a CommandFailedException is raised
-        with pytest.raises(CommandFailedException) as exc:
-            gzip_compression.uncompress("/path/to/src", "/path/to/dst")
-
-        # AND the exception message contains the command stderr
-        assert "some error" in str(exc.value)
 
 
 class TestConfigurationFileMangeler:

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -25,6 +25,7 @@ from dateutil import tz
 
 from barman.backup import BackupManager
 from barman.config import BackupOptions, Config
+from barman.compression import PgBaseBackupCompressionConfig
 from barman.infofile import BackupInfo, LocalBackupInfo, Tablespace, WalFileInfo
 from barman.server import Server
 from barman.utils import mkpath
@@ -314,6 +315,27 @@ def build_config_dictionary(config_keys=None):
     if config_keys is not None:
         base_config.update(config_keys)
     return base_config
+
+
+def get_compression_config(compression_options):
+    """
+    Generates a default base backup compression option updated with options to overwrite.
+    :param compression_options: dict with options to overwrite
+    :return: PgBaseBackupCompressionConfig
+    """
+    options = {
+        "backup_compression": None,
+        "backup_compression_format": None,
+        "backup_compression_level": None,
+        "backup_compression_location": None,
+    }
+    options.update(compression_options)
+    return PgBaseBackupCompressionConfig(
+        options["backup_compression"],
+        options["backup_compression_format"],
+        options["backup_compression_level"],
+        options["backup_compression_location"],
+    )
 
 
 def build_real_server(global_conf=None, main_conf=None):


### PR DESCRIPTION
This pull request does a bit of refactoring. Its main purpose is to have a common compression base between pg_basebackup compression and recovery

Here is a list of main changes:
- Around pg_basebackup compression classes
- Server_config
- use tmpdir in dummy_dest file creation (test_barman_wal_restore)

