### PR TITLE
Improve docs for backing up standby servers

### DIFF
--- a/doc/manual/99-references.en.md
+++ b/doc/manual/99-references.en.md
@@ -34,6 +34,7 @@
   [azure-storage-auth]: https://docs.microsoft.com/en-us/azure/storage/blobs/authorize-data-operations-cli#set-environment-variables-for-authorization-parameters
   [pg_basebackup-documentation]: https://www.postgresql.org/docs/current/app-pgbasebackup.html
   [pg-backup-api]: https://github.com/EnterpriseDB/pg-backup-api
+  [config-options]: https://docs.pgbarman.org/barman.5.html#options
 
 
   [3]: https://github.com/EnterpriseDB/barman


### PR DESCRIPTION
Attempts to improve the documentation regarding the concurrent backup
of standby servers by:

  1. Removing references to unsupported PostgreSQL versions (and
     consequently PgEspresso).
  2. Clarifying that backups and WALs must come from the same server but
     this doesn't mean backups taken against a standby are no longer
     valid once it has been promoted to primary.
  3. Avoid recommending WAL streaming over archiving and instead refer
     to the relevant doc sections.
  4. Rewrite the warning about not streaming and archiving WALs from
     a standby - this only applied to PostgreSQL 10 and earlier.

Closes #615.