### PR TITLE
Add --port option to barman-wal-restore and barman-wal-archive

### DIFF
--- a/barman/clients/walarchive.py
+++ b/barman/clients/walarchive.py
@@ -89,8 +89,10 @@ def build_ssh_command(config):
     :param argparse.Namespace config: the configuration from command line
     :return list[str]: the ssh command as list of string
     """
-    ssh_command = [
-        "ssh",
+    ssh_command = ["ssh"]
+    if config.port is not None:
+        ssh_command += ["-p", config.port]
+    ssh_command += [
         "-q",  # quiet mode - suppress warnings
         "-T",  # disable pseudo-terminal allocation
         "%s@%s" % (config.user, config.barman_host),
@@ -159,6 +161,10 @@ def parse_arguments(args=None):
         default=DEFAULT_USER,
         help="The user used for the ssh connection to the Barman server. "
         "Defaults to '%(default)s'.",
+    )
+    parser.add_argument(
+        "--port",
+        help="The port used for the ssh connection to the Barman server.",
     )
     parser.add_argument(
         "-c",

--- a/barman/clients/walrestore.py
+++ b/barman/clients/walrestore.py
@@ -180,8 +180,10 @@ def build_ssh_command(config, wal_name, peek=0):
     :param int peek: in
     :return list[str]: the ssh command as list of string
     """
-    ssh_command = [
-        "ssh",
+    ssh_command = ["ssh"]
+    if config.port is not None:
+        ssh_command += ["-p", config.port]
+    ssh_command += [
         "-q",  # quiet mode - suppress warnings
         "-T",  # disable pseudo-terminal allocation
         "%s@%s" % (config.user, config.barman_host),
@@ -315,6 +317,10 @@ def parse_arguments(args=None):
         default=DEFAULT_USER,
         help="The user used for the ssh connection to the Barman server. "
         "Defaults to '%(default)s'.",
+    )
+    parser.add_argument(
+        "--port",
+        help="The port used for the ssh connection to the Barman server.",
     )
     parser.add_argument(
         "-s",

--- a/doc/barman-wal-archive.1
+++ b/doc/barman-wal-archive.1
@@ -56,6 +56,11 @@ Defaults to \[aq]barman\[aq].
 .RS
 .RE
 .TP
+.B \-\-port \f[I]PORT\f[]
+the port used for the ssh connection to the Barman server.
+.RS
+.RE
+.TP
 .B \-c \f[I]CONFIG\f[], \-\-config \f[I]CONFIG\f[]
 configuration file on the Barman server
 .RS

--- a/doc/barman-wal-archive.1.md
+++ b/doc/barman-wal-archive.1.md
@@ -48,6 +48,9 @@ WAL_PATH
 :    the user used for the ssh connection to the Barman server. Defaults
      to 'barman'.
 
+--port *PORT*
+:    the port used for the ssh connection to the Barman server.
+
 -c *CONFIG*, --config *CONFIG*
 :    configuration file on the Barman server
 

--- a/doc/barman-wal-restore.1
+++ b/doc/barman-wal-restore.1
@@ -62,6 +62,11 @@ Defaults to \[aq]barman\[aq].
 .RS
 .RE
 .TP
+.B \-\-port \f[I]PORT\f[]
+the port used for the ssh connection to the Barman server.
+.RS
+.RE
+.TP
 .B \-s \f[I]SECONDS\f[], \-\-sleep \f[I]SECONDS\f[]
 sleep for SECONDS after a failure of get\-wal request.
 Defaults to 0 (nowait).

--- a/doc/barman-wal-restore.1.md
+++ b/doc/barman-wal-restore.1.md
@@ -50,6 +50,9 @@ WAL_DEST
 :    the user used for the ssh connection to the Barman server. Defaults
      to 'barman'.
 
+--port *PORT*
+:    the port used for the ssh connection to the Barman server.
+
 -s *SECONDS*, --sleep *SECONDS*
 :    sleep for SECONDS after a failure of get-wal request. Defaults
      to 0 (nowait).

--- a/doc/manual/24-wal_archiving.en.md
+++ b/doc/manual/24-wal_archiving.en.md
@@ -58,6 +58,12 @@ of the PostgreSQL server as configured in Barman and DUMMY is a placeholder
 (`barman-wal-archive` requires an argument for the WAL file name,
 which is ignored).
 
+Since it uses SSH to communicate with the Barman server, SSH key authentication
+is required for the `postgres` user to login as `barman` on the backup server.
+If a port other than the SSH default of 22 should be used then the `--port`
+option can be added to specify the port that should be used for the SSH
+connection.
+
 Edit the `postgresql.conf` file of the PostgreSQL instance on the `pg`
 database, activate the archive mode and set `archive_command` to use
 `barman-wal-archive`:

--- a/doc/manual/42-server-commands.en.md
+++ b/doc/manual/42-server-commands.en.md
@@ -158,6 +158,9 @@ restore_command = 'barman-wal-restore -U barman backup SERVER %f %p'
 
 Since it uses SSH to communicate with the Barman server, SSH key authentication
 is required for the `postgres` user to login as `barman` on the backup server.
+If a port other than the SSH default of 22 should be used then the `--port`
+option can be added to specify the port that should be used for the SSH
+connection.
 
 You can check that `barman-wal-restore` can connect to the Barman server,
 and that the required PostgreSQL server is configured in Barman to send

--- a/tests/test_barman_wal_restore.py
+++ b/tests/test_barman_wal_restore.py
@@ -78,6 +78,36 @@ class TestRemoteGetWal(object):
             "exit status 255"
         ) in err
 
+    @mock.patch("barman.clients.walrestore.subprocess.Popen")
+    def test_ssh_port(self, popen_mock):
+        # WHEN barman-wal-restore is called with the --port option
+        with pytest.raises(SystemExit):
+            walrestore.main(
+                [
+                    "test_host",
+                    "test_server",
+                    "test_wal",
+                    "test_wal_dest",
+                    "--port",
+                    "8888",
+                ]
+            )
+
+        # THEN the ssh command is called with the -p option
+        popen_mock.assert_called_once_with(
+            [
+                "ssh",
+                "-p",
+                "8888",
+                "-q",
+                "-T",
+                "barman@test_host",
+                "barman",
+                "get-wal 'test_server' 'test_wal'",
+            ],
+            stdout=mock.ANY,
+        )
+
     @mock.patch("barman.clients.walrestore.RemoteGetWal")
     def test_ssh_connectivity_error(self, remote_get_wal_mock, capsys):
         """Verifies exit status is 2 when ssh connectivity fails."""


### PR DESCRIPTION
Adds the --port option to barman-wal-restore and barman-wal-archive so
that the port used by the SSH command can be specified in the command.

This provides a direct alternative to using the SSH config file in
environments where SSH is not running on port 22.

Closes #621.