### PR TITLE
Fix epoch timestamps in json output

### DIFF
--- a/barman/output.py
+++ b/barman/output.py
@@ -35,6 +35,7 @@ from barman.utils import (
     human_readable_timedelta,
     pretty_size,
     redact_passwords,
+    timestamp,
 )
 from barman.xlog import diff_lsn
 
@@ -1299,7 +1300,7 @@ class JsonOutputWriter(ConsoleOutputWriter):
         if backup_info.status in BackupInfo.STATUS_COPY_DONE:
             output.update(
                 dict(
-                    end_time_timestamp=backup_info.end_time.strftime("%s"),
+                    end_time_timestamp=str(int(timestamp(backup_info.end_time))),
                     end_time=backup_info.end_time.ctime(),
                     size_bytes=backup_size,
                     wal_size_bytes=wal_size,
@@ -1387,9 +1388,9 @@ class JsonOutputWriter(ConsoleOutputWriter):
                 )
             output["base_backup_information"].update(
                 dict(
-                    begin_time_timestamp=data["begin_time"].strftime("%s"),
+                    begin_time_timestamp=str(int(timestamp(data["begin_time"]))),
                     begin_time=data["begin_time"].isoformat(sep=" "),
-                    end_time_timestamp=data["end_time"].strftime("%s"),
+                    end_time_timestamp=str(int(timestamp(data["end_time"]))),
                     end_time=data["end_time"].isoformat(sep=" "),
                 )
             )

--- a/barman/output.py
+++ b/barman/output.py
@@ -28,6 +28,8 @@ import json
 import logging
 import sys
 
+from dateutil import tz
+
 from barman.infofile import BackupInfo
 from barman.utils import (
     BarmanEncoder,
@@ -582,10 +584,9 @@ class ConsoleOutputWriter(object):
             "Recovery completed (start time: %s, elapsed time: %s)",
             results["recovery_start_time"],
             human_readable_timedelta(
-                datetime.datetime.now() - results["recovery_start_time"]
+                datetime.datetime.now(tz.tzlocal()) - results["recovery_start_time"]
             ),
         )
-        self.info("")
         self.info("Your PostgreSQL server has been successfully prepared for recovery!")
 
     def _record_check(self, server_name, check, status, hint, perfdata):
@@ -1225,14 +1226,14 @@ class JsonOutputWriter(ConsoleOutputWriter):
         self.json_output.update(
             {
                 "recovery_start_time": results["recovery_start_time"].isoformat(" "),
-                "recovery_start_time_timestamp": results[
-                    "recovery_start_time"
-                ].strftime("%s"),
+                "recovery_start_time_timestamp": str(
+                    int(timestamp(results["recovery_start_time"]))
+                ),
                 "recovery_elapsed_time": human_readable_timedelta(
-                    datetime.datetime.now() - results["recovery_start_time"]
+                    datetime.datetime.now(tz.tzlocal()) - results["recovery_start_time"]
                 ),
                 "recovery_elapsed_time_seconds": (
-                    datetime.datetime.now() - results["recovery_start_time"]
+                    datetime.datetime.now(tz.tzlocal()) - results["recovery_start_time"]
                 ).total_seconds(),
             }
         )

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -351,7 +351,7 @@ class RecoveryExecutor(object):
             "delete_barman_wal": False,
             "missing_files": [],
             "get_wal": False,
-            "recovery_start_time": datetime.datetime.now(),
+            "recovery_start_time": datetime.datetime.now(dateutil.tz.tzlocal()),
         }
         recovery_info["results"] = results
 

--- a/barman/utils.py
+++ b/barman/utils.py
@@ -36,6 +36,7 @@ import sys
 from argparse import ArgumentTypeError
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
+from dateutil import tz
 
 from distutils.version import Version
 
@@ -251,6 +252,22 @@ def total_seconds(timedelta):
     else:
         secs = (timedelta.seconds + timedelta.days * 24 * 3600) * 10**6
         return (timedelta.microseconds + secs) / 10.0**6
+
+
+def timestamp(datetime_value):
+    """
+    Compatibility method because datetime.timestamp is not available in Python 2.7.
+
+    :param datetime.datetime datetime_value: A datetime object to be converted
+        into a timestamp.
+    :rtype: float
+    """
+    try:
+        return datetime_value.timestamp()
+    except AttributeError:
+        return total_seconds(
+            datetime_value - datetime.datetime(1970, 1, 1, tzinfo=tz.tzutc())
+        )
 
 
 def which(executable, path=None):


### PR DESCRIPTION
Closes #618 by fixing the epoch timestamps in the JSON output to account for timezones.