### PR TITLE
[wip] Proof-of-concept fix for missing .partial WALs on recovery

### DIFF
--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -926,6 +926,8 @@ class RecoveryExecutor(object):
                     output.warning(
                         "Error removing temporary file '%s': %s", file_name, e
                     )
+            # Cleanup staging dir
+            shutil.rmtree(partial_staging_dir)
 
         _logger.info("Finished copying %s WAL files.", total_wals)
 

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -824,7 +824,6 @@ class RecoveryExecutor(object):
         for prefix in sorted(xlogs):
             batch_len = len(xlogs[prefix])
             partial_count += batch_len
-            source_dir = os.path.join(self.config.wals_directory, prefix)
             _logger.info(
                 "Starting copy of %s WAL files %s/%s from %s to %s",
                 batch_len,
@@ -837,7 +836,14 @@ class RecoveryExecutor(object):
             # compression check and decompression for each WAL files
             if compressors:
                 for segment in xlogs[prefix]:
-                    dst_file = os.path.join(wal_decompression_dest, segment.name)
+                    if xlog.is_partial_file(segment.name):
+                        source_dir = self.config.streaming_wals_directory
+                        dst_file = os.path.join(
+                            wal_decompression_dest, segment.name.strip(".partial")
+                        )
+                    else:
+                        source_dir = os.path.join(self.config.wals_directory, prefix)
+                        dst_file = os.path.join(wal_decompression_dest, segment.name)
                     if segment.compression is not None:
                         compressors[segment.compression].decompress(
                             os.path.join(source_dir, segment.name), dst_file
@@ -848,7 +854,10 @@ class RecoveryExecutor(object):
                     try:
                         # Transfer the WAL files
                         rsync.from_file_list(
-                            list(segment.name for segment in xlogs[prefix]),
+                            list(
+                                segment.name.strip(".partial")
+                                for segment in xlogs[prefix]
+                            ),
                             wal_decompression_dest,
                             wal_dest,
                         )
@@ -861,7 +870,9 @@ class RecoveryExecutor(object):
 
                     # Cleanup files after the transfer
                     for segment in xlogs[prefix]:
-                        file_name = os.path.join(wal_decompression_dest, segment.name)
+                        file_name = os.path.join(
+                            wal_decompression_dest, segment.name.strip(".partial")
+                        )
                         try:
                             os.unlink(file_name)
                         except OSError as e:

--- a/barman/server.py
+++ b/barman/server.py
@@ -1683,7 +1683,7 @@ class Server(RemoteStatusMixin):
                     if os.path.basename(file_name) < begin:
                         continue
                     tli, _, _ = xlog.decode_segment_name(file_name)
-                    if tli > calculated_target_tli:
+                    if tli > calculated_target_tli or tli < calculated_target_tli:
                         continue
                     required_partial_files.append(file_name)
             if required_partial_files:

--- a/barman/server.py
+++ b/barman/server.py
@@ -1661,21 +1661,6 @@ class Server(RemoteStatusMixin):
                 if xlog.is_history_file(wal_info.name):
                     yield wal_info
 
-        # Finally, check the `streaming` directory to see if there are any
-        # relevant .partial files
-        file_names = sorted(
-            glob(os.path.join(self.config.streaming_wals_directory, "*"))
-        )
-        for file_name in file_names:
-            if xlog.is_partial_file(file_name):
-                # We have a partial file - do we need it?
-                if os.path.basename(file_name) < begin:
-                    continue
-                tli, _, _ = xlog.decode_segment_name(file_name)
-                if tli > calculated_target_tli:
-                    continue
-                yield WalFileInfo.from_file(file_name, compression=None)
-
     # TODO: merge with the previous
     def get_wal_until_next_backup(self, backup, include_history=False):
         """

--- a/barman/server.py
+++ b/barman/server.py
@@ -1661,6 +1661,21 @@ class Server(RemoteStatusMixin):
                 if xlog.is_history_file(wal_info.name):
                     yield wal_info
 
+        # Finally, check the `streaming` directory to see if there are any
+        # relevant .partial files
+        file_names = sorted(
+            glob(os.path.join(self.config.streaming_wals_directory, "*"))
+        )
+        for file_name in file_names:
+            if xlog.is_partial_file(file_name):
+                # We have a partial file - do we need it?
+                if os.path.basename(file_name) < begin:
+                    continue
+                tli, _, _ = xlog.decode_segment_name(file_name)
+                if tli > calculated_target_tli:
+                    continue
+                yield WalFileInfo.from_file(file_name, compression=None)
+
     # TODO: merge with the previous
     def get_wal_until_next_backup(self, backup, include_history=False):
         """


### PR DESCRIPTION
Updated with a different approach where `.partial` files are handled after copying the WALs in the archive.

There are a few upsides to doing this:

* We no longer need special cases in the code branch for compressed WALs.
* We can use `Rsync.from_file_list` to copy the .partial files when WALs are uncompressed, since all `.partial` files now get copied and renamed in a temporary staging directory.

Including the `.partial` WAL files in the `get_required_xlog_files` response *seems* a bit odd since one of the first things we do in `_xlog_copy` is put them in a separate list so they can be handled after the WALs in the archive are copied, however it feels like the right thing to do given that the `.partial` file *is* a required xlog file (unless the requested recovery timeline or time dictate otherwise).