### PR TITLE
Rename backup_manifest files on recovery

### DIFF
--- a/barman/backup_manifest.py
+++ b/barman/backup_manifest.py
@@ -16,11 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
 import os
 import json
 
-from barman import output
+from barman.exceptions import BackupManifestException
 
 
 class BackupManifest:
@@ -46,13 +45,8 @@ class BackupManifest:
         """
 
         if self.file_manager.file_exist(self._get_manifest_file_path()):
-            msg = (
-                "File %s already exists. Skip file creation."
-                % self._get_manifest_file_path()
-            )
-            logging.info(msg)
-            output.info(msg)
-            return
+            msg = "File %s already exists." % self._get_manifest_file_path()
+            raise BackupManifestException(msg)
         self._create_files_metadata()
         str_manifest = self._get_manifest_str()
         # Create checksum from string without last '}' and ',' instead

--- a/barman/cli.py
+++ b/barman/cli.py
@@ -1524,7 +1524,10 @@ def generate_manifest(args):
     )
     backup_manifest.create_backup_manifest()
 
-    output.info("Backup %s is valid on server %s" % (args.backup_id, args.server_name))
+    output.info(
+        "Backup manifest for backup %s successfully generated for server %s"
+        % (args.backup_id, args.server_name)
+    )
     output.close_and_exit()
 
 

--- a/barman/exceptions.py
+++ b/barman/exceptions.py
@@ -398,3 +398,9 @@ class InvalidRetentionPolicy(BarmanException):
     """
     Exception raised when a retention policy cannot be parsed.
     """
+
+
+class BackupManifestException(BarmanException):
+    """
+    Exception raised when there is a problem with the backup manifest.
+    """

--- a/barman/fs.py
+++ b/barman/fs.py
@@ -52,6 +52,22 @@ class UnixLocalCommand(object):
         """
         return self.internal_cmd.out, self.internal_cmd.err
 
+    def move(self, source_path, dest_path):
+        """
+        Move a file from source_path to dest_path.
+
+        :param str source_path: full path to the source file.
+        :param str dest_path: full path to the destination file.
+        :returns bool: True if the move completed successfully,
+            False otherwise.
+        """
+        _logger.debug("Moving %s to %s" % (source_path, dest_path))
+        mv_ret = self.cmd("mv", args=[source_path, dest_path])
+        if mv_ret == 0:
+            return True
+        else:
+            raise FsOperationFailed("mv execution failed")
+
     def create_dir_if_not_exists(self, dir_path, mode=None):
         """
         This method recursively creates a directory if not exists

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -203,6 +203,13 @@ class RecoveryExecutor(object):
         else:
             backup_info.save(os.path.join(dest, ".barman-recover.info"))
 
+        # Rename the backup_manifest file by adding a backup ID suffix
+        if recovery_info["cmd"].exists(os.path.join(dest, "backup_manifest")):
+            recovery_info["cmd"].move(
+                os.path.join(dest, "backup_manifest"),
+                os.path.join(dest, "backup_manifest.%s" % backup_info.backup_id),
+            )
+
         # Standby mode is not available for PostgreSQL older than 9.0
         if backup_info.version < 90000 and standby_mode:
             raise RecoveryStandbyModeException(

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -1332,6 +1332,13 @@ class TarballRecoveryExecutor(RecoveryExecutor):
             item_class=controller.PGDATA_CLASS,
             bwlimit=self.config.get_bwlimit(),
         )
+        controller.add_file(
+            label="pgdata",
+            src=os.path.join(backup_info.get_data_directory(), "backup_manifest"),
+            dst=os.path.join(dest_prefix + dest, "backup_manifest"),
+            item_class=controller.PGDATA_CLASS,
+            bwlimit=self.config.get_bwlimit(),
+        )
 
         # Execute the copy
         try:

--- a/tests/test_backup_manifest.py
+++ b/tests/test_backup_manifest.py
@@ -20,6 +20,7 @@ import pytest
 import os
 from mock import patch
 from barman.backup_manifest import FileIdentity, BackupManifest
+from barman.exceptions import BackupManifestException
 from barman.utils import SHA256
 
 
@@ -186,5 +187,6 @@ class TestBackupManifest:
     def test_manifest_already_exist(self, file_manager, checksum_algorithm):
         file_manager.file_exist.return_value = True
         backup_manifest = BackupManifest("/path", file_manager, checksum_algorithm)
-        backup_manifest.create_backup_manifest()
+        with pytest.raises(BackupManifestException):
+            backup_manifest.create_backup_manifest()
         file_manager.get_file_list.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,6 +33,7 @@ from barman.cli import (
     check_target_action,
     check_wal_archive,
     command,
+    generate_manifest,
     get_server,
     get_server_list,
     manage_server_command,
@@ -656,6 +657,30 @@ class TestCli(object):
         # value for the config/arg combination
         assert server.config.immediate_checkpoint is expected_value
         assert server.postgres.immediate_checkpoint is expected_value
+
+    @patch("barman.cli.BackupManifest")
+    @patch("barman.cli.parse_backup_id")
+    @patch("barman.cli.get_server")
+    def test_generate_manifest(
+        self, _mock_get_server, _mock_parse_backup_id, _mock_backup_manifest, capsys
+    ):
+        """Verify expected log message is received on success."""
+        # GIVEN a backup for a server
+        args = Mock()
+        args.server_name = "test_server"
+        args.backup_id = "test_backup_id"
+
+        # WHEN a backup manifest is successfully created
+        with pytest.raises(SystemExit):
+            generate_manifest(args)
+
+        # THEN the expected message is in the logs
+        out, _err = capsys.readouterr()
+        assert (
+            "Backup manifest for backup %s successfully generated for server %s"
+            % (args.backup_id, args.server_name)
+            in out
+        )
 
 
 class TestKeepCli(object):

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -64,6 +64,22 @@ class TestUnixLocalCommand(object):
         assert err == "err"
 
     @patch("barman.fs.Command")
+    def test_move(self, command_mock):
+        # GIVEN a command which always succeeds
+        command = command_mock.return_value
+        command.return_value = 0
+        ulc = UnixLocalCommand()
+        # AND mock source and destination paths
+        src_path = "/path/to/src"
+        dst_path = "/path/to/dst"
+
+        # WHEN move is called
+        ulc.move(src_path, dst_path)
+
+        # THEN the `mv` command is called with the expected arguments
+        command.assert_called_once_with("mv '%s' '%s'" % (src_path, dst_path))
+
+    @patch("barman.fs.Command")
     def test_dir_if_not_exists(self, command_mock):
         command_instance = command_mock.return_value
 

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -1404,6 +1404,13 @@ class TestTarballRecoveryExecutor(object):
                 item_class=copy_controller_mock.return_value.PGDATA_CLASS,
                 label="pgdata",
             ),
+            mock.call().add_file(
+                bwlimit=10,
+                src="%s/main/base/%s/data/backup_manifest" % (barman_home, backup_id),
+                dst="%s/backup_manifest" % dest,
+                item_class=copy_controller_mock.return_value.PGDATA_CLASS,
+                label="pgdata",
+            ),
             mock.call().copy(),
         ]
 

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -1226,6 +1226,51 @@ class TestRecoveryExecutor(object):
             with closing(executor):
                 executor.recover(backup_info, destination, standby_mode=True)
 
+    @pytest.mark.parametrize("manifest_exists", (False, True))
+    @mock.patch("barman.recovery_executor.fs.unix_command_factory")
+    def test_recover_rename_manifest(
+        self, command_factory_mock, manifest_exists, tmpdir
+    ):
+        # GIVEN a backup_manifest file which exists according to manifest_exists
+        command = command_factory_mock.return_value
+
+        def mock_exists(filename):
+            if filename.endswith("backup_manifest"):
+                return manifest_exists
+            else:
+                return MagicMock()
+
+        command.exists.side_effect = mock_exists
+
+        # AND a mock recovery environment
+        backup_info = testing_helpers.build_test_backup_info()
+        backup_manager = testing_helpers.build_backup_manager()
+        executor = RecoveryExecutor(backup_manager)
+        backup_info.version = 90300
+        destination = tmpdir.mkdir("destination").strpath
+
+        executor._prepare_tablespaces = MagicMock()
+        executor._backup_copy = MagicMock()
+        executor._xlog_copy = MagicMock()
+        executor._generate_recovery_conf = MagicMock()
+
+        # WHEN recover is called
+        with closing(executor):
+            executor.recover(backup_info, destination, standby_mode=None)
+
+        if manifest_exists:
+            # THEN if the manifest exists it is renamed
+            assert (
+                (
+                    "%s/backup_manifest" % destination,
+                    "%s/backup_manifest.%s" % (destination, backup_info.backup_id),
+                ),
+                {},
+            ) in command.move.call_args_list
+        else:
+            # OR if it does not exist, no attempt is made to rename it
+            command.move.assert_not_called()
+
     @mock.patch("barman.recovery_executor.fs.unix_command_factory")
     @mock.patch("barman.recovery_executor.RsyncPgData")
     @mock.patch("barman.recovery_executor.output")


### PR DESCRIPTION
Closes #623.
Closes #626.

See https://github.com/EnterpriseDB/barman-testing/pull/60 for related integration tests.