### PR TITLE
Allow receive-wal options against inactive servers

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -1420,7 +1420,10 @@ def receive_wal(args):
     The process uses the streaming protocol to receive WAL files
     from the PostgreSQL server.
     """
-    server = get_server(args)
+    should_skip_inactive = not (
+        args.create_slot or args.drop_slot or args.stop or args.reset
+    )
+    server = get_server(args, skip_inactive=should_skip_inactive)
     if args.stop and args.reset:
         output.error("--stop and --reset options are not compatible")
     # If the caller requested to shutdown the receive-wal process deliver the
@@ -1770,7 +1773,12 @@ def get_server(
     # Apply standard validation control and skips
     # the server if inactive or disabled, displaying standard
     # error messages. If on_error_stop (default) exits
-    if not manage_server_command(server, name, inactive_is_error) and on_error_stop:
+    if (
+        not manage_server_command(
+            server, name, inactive_is_error, skip_inactive=skip_inactive
+        )
+        and on_error_stop
+    ):
         output.close_and_exit()
         # The following return statement will never be reached
         # but it is here for clarity


### PR DESCRIPTION
Allows the receive-wal options --create-slot, --drop-slot, --reset and
--stop to be used against inactive servers. If `barman receive-wal` is
called with no options in order to start WAL streaming then inactive
servers will continue to be skipped.

The rationale for this is that certain DBA procedures can require that
WAL streaming is temporarily disabled and re-enabled at a later date.
Without this patch the server must be active in order to stop WAL
streaming, reset the stream or create/drop the replication slot. While
the server is active the `barman cron` job will restart WAL streaming
if it runs. Such procedures are therefore inherently racy unless the
`barman cron` job is disabled.

By allowing the receive-wal options to run against inactive servers,
users are now able to mark the server as `active = false` in the Barman
configuration and then carry out the necessary `receive-wal` actions
without needing to worry about `barman cron` restarting WAL streaming.

Closes #574.