### PR TITLE
Document python2 cloud library versions

### DIFF
--- a/doc/manual/55-barman-cli.en.md
+++ b/doc/manual/55-barman-cli.en.md
@@ -73,6 +73,21 @@ and can be installed alongside the PostgreSQL server:
 - `barman-cloud-restore`: script to be used to restore a backup directly
   taken with `barman-cloud-backup` from cloud storage;
 
+These commands require the appropriate library for the cloud provider you wish to
+use:
+
+* AWS S3: [boto3][boto3]
+* Azure Blob Storage: [azure-storage-blob][azure-storage-blob] and (optionally)
+  [azure-identity][azure-identity]
+* Google Cloud Storage: [google-cloud-storage][google-cloud-storage]
+
+**NOTE:** If you are using the Barman cloud utilities with Python 2 then you will
+need to ensure the following version requirements are met:
+
+* `boto3<1.18.0`
+* `azure-storage-blob<12.10.0` and `azure-identity<1.8.0`
+* `google-cloud-storage<2.0.0`
+
 For information on how to setup credentials for the aws-s3 cloud provider
 please refer to the ["Credentials" section in Boto 3 documentation][boto3creds].
 
@@ -82,11 +97,6 @@ The following environment variables are supported: `AZURE_STORAGE_CONNECTION_STR
 `AZURE_STORAGE_KEY` and `AZURE_STORAGE_SAS_TOKEN`. You can also use the
 `--credential` option to specify either `azure-cli` or `managed-identity` credentials
 in order to authenticate via Azure Active Directory.
-
-> **WARNING:** Cloud utilities require the appropriate library for the cloud
-> provider you wish to use - either: [boto3][boto3] or
-> [azure-storage-blob][azure-storage-blob] and (optionally)
-> [azure-identity][azure-identity]
 
 ## Installation
 

--- a/doc/manual/55-barman-cli.en.md
+++ b/doc/manual/55-barman-cli.en.md
@@ -81,8 +81,11 @@ use:
   [azure-identity][azure-identity]
 * Google Cloud Storage: [google-cloud-storage][google-cloud-storage]
 
-**NOTE:** If you are using the Barman cloud utilities with Python 2 then you will
-need to ensure the following version requirements are met:
+**NOTE:** The latest versions of these libraries do not support python 2 due to it
+being [end-of-lfe][python-2-sunset] since Januaray 2020. If you are using the
+Barman cloud utilities on a python 2 system it is recommended you upgrade to python 3.
+If you still want to use the Barman cloud utilities with python 2 then you will need
+to ensure the following version requirements are met for each library:
 
 * `boto3<1.18.0`
 * `azure-storage-blob<12.10.0` and `azure-identity<1.8.0`

--- a/doc/manual/99-references.en.md
+++ b/doc/manual/99-references.en.md
@@ -37,6 +37,7 @@
   [pg-backup-api]: https://github.com/EnterpriseDB/pg-backup-api
   [config-options]: https://docs.pgbarman.org/barman.5.html#options
   [barman-downloads]: https://pgbarman.org/downloads/
+  [python-2-sunset]: https://www.python.org/doc/sunset-python-2/
 
 
   [8]: https://en.wikipedia.org/wiki/Hard_link

--- a/doc/manual/99-references.en.md
+++ b/doc/manual/99-references.en.md
@@ -32,6 +32,7 @@
   [azure-identity]: https://docs.microsoft.com/en-us/python/api/azure-identity/?view=azure-python
   [azure-storage-blob]: https://docs.microsoft.com/en-us/python/api/azure-storage-blob/?view=azure-python
   [azure-storage-auth]: https://docs.microsoft.com/en-us/azure/storage/blobs/authorize-data-operations-cli#set-environment-variables-for-authorization-parameters
+  [google-cloud-storage]: https://cloud.google.com/storage/docs/reference/libraries
   [pg_basebackup-documentation]: https://www.postgresql.org/docs/current/app-pgbasebackup.html
   [pg-backup-api]: https://github.com/EnterpriseDB/pg-backup-api
   [config-options]: https://docs.pgbarman.org/barman.5.html#options


### PR DESCRIPTION
Updates the barman cloud docs so that they include version requirements
for cloud provider libraries which support python2.

Closes #638.