### PR TITLE
Adjusting documentation of `barman backup` command

### DIFF
--- a/doc/barman.1.d/50-backup.md
+++ b/doc/barman.1.d/50-backup.md
@@ -1,7 +1,9 @@
 backup *SERVER_NAME*
 :   Perform a backup of `SERVER_NAME` using parameters specified in the
     configuration file. Specify `all` as `SERVER_NAME` to perform a backup
-    of all the configured servers.
+    of all the configured servers. You can also specify `SERVER_NAME` multiple
+    times to perform a backup of the specified servers -- e.g. `barman backup
+    SERVER_1_NAME SERVER_2_NAME`.
 
     --immediate-checkpoint
     :   forces the initial checkpoint to be done as quickly as possible.

--- a/doc/manual/42-server-commands.en.md
+++ b/doc/manual/42-server-commands.en.md
@@ -20,8 +20,8 @@ files received from the streaming connection or from the
 
 ## `backup`
 
-The `backup` command takes a full backup (_base backup_) of a given
-server. It has several options that let you override the corresponding
+The `backup` command takes a full backup (_base backup_) of the given
+servers. It has several options that let you override the corresponding
 configuration parameter for the new backup. For more information,
 consult the manual page.
 
@@ -34,6 +34,10 @@ barman backup <server_name>
 > **TIP:**
 > You can use `barman backup all` to sequentially backup all your
 > configured servers.
+
+> **TIP:**
+> You can use `barman backup <server_1_name> <server_2_name>` to sequentially
+> backup both `<server_1_name>` and `<server_2_name>` servers.
 
 Barman 2.10 introduces the `-w`/`--wait` option for the `backup` command.
 When set, Barman temporarily saves the state of the backup to


### PR DESCRIPTION
The documentation of `barman backup` command both in `man` and
in the website mention that `barman backup` command can be used
to take backups from a given server or from them all sequentially
by using `all` as server name.

While taking a look at the code of barman we can see that the
server name option is filled with `nargs='+'`, which means a call
like the following:

```
barman backup server-1 server-2
```

Would sequentially backup `server-1` and `server-2`.

This commit amends the docs for `man` and for the website to
reflect that behavior.

Signed-off-by: Israel Barth <israel.barth@laptop428-ma-us.local>