### PR TITLE
Add trailing newline to rsync --files-from input

### DIFF
--- a/barman/command_wrappers.py
+++ b/barman/command_wrappers.py
@@ -679,7 +679,9 @@ class Rsync(Command):
         """
         if "stdin" in kwargs:
             raise TypeError("from_file_list() doesn't support 'stdin' keyword argument")
-        input_string = ("\n".join(filelist)).encode("UTF-8")
+        # The input string for the rsync --files-from argument must have a
+        # trailing newline for compatibility with certain versions of rsync.
+        input_string = ("\n".join(filelist) + "\n").encode("UTF-8")
         _logger.debug("from_file_list: %r", filelist)
         kwargs["stdin"] = input_string
         self.get_output("--files-from=-", src, dst, *args, **kwargs)

--- a/tests/test_command_wrappers.py
+++ b/tests/test_command_wrappers.py
@@ -947,7 +947,7 @@ class TestRsync(object):
             preexec_fn=mock.ANY,
             close_fds=True,
         )
-        pipe.stdin.write.assert_called_with("a\nb\nc".encode("UTF-8"))
+        pipe.stdin.write.assert_called_with("a\nb\nc\n".encode("UTF-8"))
         pipe.stdin.close.assert_called_once_with()
         assert result == ret
         assert cmd.ret == ret


### PR DESCRIPTION
Adds a trailing newline to the input to stdin for the rsync
`--files-from` command.

This is a mitigation for Rsync 3.2.5 and certain versions shipped by OS
maintainers which contain a fix for CVE-2022-29154. This fix broke
`--files-from` in cases where there was no trailing newline.

Closes #659.