### PR TITLE
Document dependency on gzip, lz4 and zstd CLI programs

### DIFF
--- a/doc/barman.5
+++ b/doc/barman.5
@@ -99,8 +99,13 @@ Global/Server.
 .B backup_compression
 The compression to be used during the backup process.
 Only supported when \f[C]backup_method\ =\ postgres\f[].
-Can either be unset or \f[C]gzip\f[].
+Can either be unset or \f[C]gzip\f[],\f[C]lz4\f[] or \f[C]zstd\f[].
 If unset then no compression will be used during the backup.
+Use of this option requires that the CLI application for the specified
+compression algorithm is available on the Barman server (at backup time)
+and the PostgreSQL server (at recovery time).
+Note that the \f[C]lz4\f[] and \f[C]zstd\f[] algorithms require
+PostgreSQL 15 (beta) or later.
 Global/Server.
 .RS
 .RE

--- a/doc/barman.5.d/50-backup_compression.md
+++ b/doc/barman.5.d/50-backup_compression.md
@@ -1,4 +1,7 @@
 backup_compression
 :   The compression to be used during the backup process. Only supported when
     `backup_method = postgres`. Can either be unset or `gzip`,`lz4` or `zstd`. If unset then
-    no compression will be used during the backup. Global/Server.
+    no compression will be used during the backup. Use of this option requires that the
+    CLI application for the specified compression algorithm is available on the Barman
+    server (at backup time) and the PostgreSQL server (at recovery time). Note that
+    the `lz4` and `zstd` algorithms require PostgreSQL 15 (beta) or later. Global/Server.

--- a/doc/manual/50-feature-details.en.md
+++ b/doc/manual/50-feature-details.en.md
@@ -137,10 +137,24 @@ algorithm in Barman are: `gzip` `lz4` and `zstd`.
 ``` ini
 backup_compression = gzip|lz4|zstd
 ```
-> **Note:** `lz4` and `zstd` are only available with PostgreSQL version 15 or higher.
 
-> **Note:** `zstd` version must be 1.4.4 or higher.
+Barman requires the CLI utility for the selected compression algorithm
+to be available on both the Barman server *and* the PostgreSQL server.
+The CLI utility is used to extract the backup label from the compressed
+backup and to decompress the backup on the PostgreSQL server during
+recovery. These can be installed through system packages named `gzip`,
+`lz4` and `zstd` on Debian, Ubuntu, RedHat, CentOS and SLES systems.
 
+> **Note:** On Ubuntu 18.04 (bionic) the `lz4` utility is available in
+> the `liblz4-tool` pacakge.
+
+> **Note:** `zstd` version must be 1.4.4 or higher. The system packages
+> for `zstd` on Debian 10 (buster), Ubuntu 18.04 (bionic) and SLES 12
+> install an earlier version - `backup_compression = zstd` will not
+> work with these packages.
+
+> **Note:** `lz4` and `zstd` are only available with PostgreSQL version
+> 15 or higher.
 
 > **IMPORTANT:** If you are using `backup_compression` you must also
 > set `recovery_staging_path` so that `barman recover` is able to


### PR DESCRIPTION
Documents the requirement for the gzip, lz4 and zstd CLI programs when using `backup_compression = gzip|lz4|zstd`.