### PR TITLE
Handle long running wal deletion requests

### DIFF
--- a/barman/clients/cloud_backup_delete.py
+++ b/barman/clients/cloud_backup_delete.py
@@ -323,6 +323,15 @@ def parse_arguments(args=None):
         action="store_true",
         help="Find the objects which need to be deleted but do not delete them",
     )
+    parser.add_argument(
+        "--batch-size",
+        dest="delete_batch_size",
+        type=int,
+        help="The maximum number of objects to be deleted in a single request to the "
+        "cloud provider. If unset then the maximum allowed batch size for the "
+        "specified cloud provider will be used (1000 for aws-s3, 256 for "
+        "azure-blob-storage and 100 for google-cloud-storage).",
+    )
     return parser.parse_args(args=args)
 
 

--- a/barman/clients/cloud_cli.py
+++ b/barman/clients/cloud_cli.py
@@ -167,6 +167,12 @@ def create_argument_parser(description, source_or_destination=UrlArgumentType.so
         "--profile",
         help="profile name (e.g. INI section in AWS credentials file)",
     )
+    s3_arguments.add_argument(
+        "--read-timeout",
+        type=int,
+        help="the time in seconds until a timeout is raised when waiting to "
+        "read from a connection (defaults to 60 seconds)",
+    )
     azure_arguments = parser.add_argument_group(
         "Extra options for the azure-blob-storage cloud provider"
     )

--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -115,7 +115,9 @@ def get_cloud_interface(config):
     cloud_interface_kwargs = {
         "url": config.source_url if "source_url" in config else config.destination_url
     }
-    _update_kwargs(cloud_interface_kwargs, config, ("jobs", "tags"))
+    _update_kwargs(
+        cloud_interface_kwargs, config, ("jobs", "tags", "delete_batch_size")
+    )
 
     if config.cloud_provider == "aws-s3":
         return _make_s3_cloud_interface(config, cloud_interface_kwargs)

--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -49,6 +49,7 @@ def _make_s3_cloud_interface(config, cloud_interface_kwargs):
         {
             "profile_name": config.profile,
             "endpoint_url": config.endpoint_url,
+            "read_timeout": config.read_timeout,
         }
     )
     if "encryption" in config:

--- a/barman/cloud_providers/aws_s3.py
+++ b/barman/cloud_providers/aws_s3.py
@@ -95,6 +95,7 @@ class S3CloudInterface(CloudInterface):
         profile_name=None,
         endpoint_url=None,
         tags=None,
+        delete_batch_size=None,
     ):
         """
         Create a new S3 interface given the S3 destination url and the profile
@@ -107,11 +108,14 @@ class S3CloudInterface(CloudInterface):
         :param str profile_name: Amazon auth profile identifier
         :param str endpoint_url: override default endpoint detection strategy
           with this one
+        :param int|None delete_batch_size: the maximum number of objects to be
+          deleted in a single request
         """
         super(S3CloudInterface, self).__init__(
             url=url,
             jobs=jobs,
             tags=tags,
+            delete_batch_size=delete_batch_size,
         )
         self.profile_name = profile_name
         self.encryption = encryption

--- a/barman/cloud_providers/azure_blob_storage.py
+++ b/barman/cloud_providers/azure_blob_storage.py
@@ -106,6 +106,8 @@ class AzureCloudInterface(CloudInterface):
     # MAX_ARCHIVE_SIZE - so we set a maximum of 1TB per file
     MAX_ARCHIVE_SIZE = 1 << 40
 
+    MAX_DELETE_BATCH_SIZE = 256
+
     # The size of each chunk in a single object upload when the size of the
     # object exceeds max_single_put_size. We default to 2MB in order to
     # allow the default max_concurrency of 8 to be achieved when uploading
@@ -451,12 +453,14 @@ class AzureCloudInterface(CloudInterface):
         blob_client.commit_block_list([], **self._extra_upload_args)
         blob_client.delete_blob()
 
-    def delete_objects(self, paths):
+    def _delete_objects_batch(self, paths):
         """
         Delete the objects at the specified paths
 
         :param List[str] paths:
         """
+        super(AzureCloudInterface, self)._delete_objects_batch(paths)
+
         try:
             # If paths is empty because the files have already been deleted then
             # delete_blobs will return successfully so we just call it with whatever
@@ -490,7 +494,4 @@ class AzureCloudInterface(CloudInterface):
                 )
 
         if errors:
-            raise CloudProviderError(
-                "Error from cloud provider while deleting objects - "
-                "please check the Barman logs"
-            )
+            raise CloudProviderError()

--- a/barman/cloud_providers/azure_blob_storage.py
+++ b/barman/cloud_providers/azure_blob_storage.py
@@ -135,6 +135,7 @@ class AzureCloudInterface(CloudInterface):
         encryption_scope=None,
         credential=None,
         tags=None,
+        delete_batch_size=None,
         max_block_size=DEFAULT_MAX_BLOCK_SIZE,
         max_concurrency=DEFAULT_MAX_CONCURRENCY,
         max_single_put_size=DEFAULT_MAX_SINGLE_PUT_SIZE,
@@ -145,11 +146,14 @@ class AzureCloudInterface(CloudInterface):
         :param str url: Full URL of the cloud destination/source
         :param int jobs: How many sub-processes to use for asynchronous
           uploading, defaults to 2.
+        :param int|None delete_batch_size: the maximum number of objects to be
+          deleted in a single request
         """
         super(AzureCloudInterface, self).__init__(
             url=url,
             jobs=jobs,
             tags=tags,
+            delete_batch_size=delete_batch_size,
         )
         self.encryption_scope = encryption_scope
         self.credential = credential

--- a/barman/cloud_providers/google_cloud_storage.py
+++ b/barman/cloud_providers/google_cloud_storage.py
@@ -67,7 +67,7 @@ class GoogleCloudInterface(CloudInterface):
 
     MAX_DELETE_BATCH_SIZE = 100
 
-    def __init__(self, url, jobs=1, tags=None):
+    def __init__(self, url, jobs=1, tags=None, delete_batch_size=None):
         """
         Create a new Google cloud Storage interface given the supplied account url
 
@@ -76,12 +76,15 @@ class GoogleCloudInterface(CloudInterface):
           uploading, defaults to 1.
         :param List[tuple] tags: List of tags as k,v tuples to be added to all
           uploaded objects
+        :param int|None delete_batch_size: the maximum number of objects to be
+          deleted in a single request
         """
         self.bucket_name, self.path = self._parse_url(url)
         super(GoogleCloudInterface, self).__init__(
             url=url,
             jobs=jobs,
             tags=tags,
+            delete_batch_size=delete_batch_size,
         )
         self.bucket_exists = None
         self._reinit_session()

--- a/barman/utils.py
+++ b/barman/utils.py
@@ -270,6 +270,19 @@ def timestamp(datetime_value):
         )
 
 
+def range_fun(*args, **kwargs):
+    """
+    Compatibility method required while we still support Python 2.7.
+
+    This can be removed when Python 2.7 support is dropped and calling code can
+    reference `range` directly.
+    """
+    try:
+        return xrange(*args, **kwargs)
+    except NameError:
+        return range(*args, **kwargs)
+
+
 def which(executable, path=None):
     """
     This method is useful to find if a executable is present into the

--- a/doc/barman-cloud-backup-delete.1
+++ b/doc/barman-cloud-backup-delete.1
@@ -126,6 +126,12 @@ endpoint.
 .RS
 .RE
 .TP
+.B \[en]read\-timeout \f[I]TIMEOUT\f[]
+the time in seconds until a timeout is raised when waiting to read from
+a connection to AWS S3 (defaults to 60 seconds)
+.RS
+.RE
+.TP
 .B \[en]credential {azure\-cli,managed\-identity}
 optionally specify the type of credential to use when authenticating
 with Azure Blob Storage.

--- a/doc/barman-cloud-backup-delete.1
+++ b/doc/barman-cloud-backup-delete.1
@@ -101,6 +101,15 @@ about the objects which would be deleted to stdout
 .RS
 .RE
 .TP
+.B \[en]batch\-size \f[I]SIZE\f[]
+The maximum number of objects to be deleted in a single request to the
+cloud provider.
+If unset then the maximum allowed batch size for the specified cloud
+provider will be used (1000 for aws\-s3, 256 for azure\-blob\-storage
+and 100 for google\-cloud\-storage).
+.RS
+.RE
+.TP
 .B \[en]cloud\-provider {aws\-s3,azure\-blob\-storage,google\-cloud\-storage}
 the cloud provider to which the backup should be uploaded
 .RS

--- a/doc/barman-cloud-backup-delete.1.md
+++ b/doc/barman-cloud-backup-delete.1.md
@@ -80,6 +80,12 @@ SERVER_NAME
 :    run without actually deleting any objects while printing information
      about the objects which would be deleted to stdout
 
+--batch-size *SIZE*
+:    The maximum number of objects to be deleted in a single request to the cloud
+     provider. If unset then the maximum allowed batch size for the specified cloud
+     provider will be used (1000 for aws-s3, 256 for azure-blob-storage and 100 for
+     google-cloud-storage).
+
 --cloud-provider {aws-s3,azure-blob-storage,google-cloud-storage}
 :    the cloud provider to which the backup should be uploaded
 

--- a/doc/barman-cloud-backup-delete.1.md
+++ b/doc/barman-cloud-backup-delete.1.md
@@ -95,6 +95,10 @@ SERVER_NAME
 --endpoint-url
 :    override the default S3 URL construction mechanism by specifying an endpoint.
 
+--read-timeout *TIMEOUT*
+:    the time in seconds until a timeout is raised when waiting to read from a
+     connection to AWS S3 (defaults to 60 seconds)
+
 --credential {azure-cli,managed-identity}
 :    optionally specify the type of credential to use when authenticating with
      Azure Blob Storage. If omitted then the credential will be obtained from the

--- a/doc/barman-cloud-backup-keep.1
+++ b/doc/barman-cloud-backup-keep.1
@@ -110,6 +110,12 @@ endpoint.
 .RS
 .RE
 .TP
+.B \[en]read\-timeout \f[I]TIMEOUT\f[]
+the time in seconds until a timeout is raised when waiting to read from
+a connection to AWS S3 (defaults to 60 seconds)
+.RS
+.RE
+.TP
 .B \[en]credential {azure\-cli,managed\-identity}
 optionally specify the type of credential to use when authenticating
 with Azure Blob Storage.

--- a/doc/barman-cloud-backup-keep.1.md
+++ b/doc/barman-cloud-backup-keep.1.md
@@ -82,6 +82,10 @@ BACKUP_ID
 --endpoint-url
 :    override the default S3 URL construction mechanism by specifying an endpoint.
 
+--read-timeout *TIMEOUT*
+:    the time in seconds until a timeout is raised when waiting to read from a
+     connection to AWS S3 (defaults to 60 seconds)
+
 --credential {azure-cli,managed-identity}
 :    optionally specify the type of credential to use when authenticating with
      Azure Blob Storage. If omitted then the credential will be obtained from the

--- a/doc/barman-cloud-backup-list.1
+++ b/doc/barman-cloud-backup-list.1
@@ -79,6 +79,12 @@ endpoint.
 .RS
 .RE
 .TP
+.B \[en]read\-timeout \f[I]TIMEOUT\f[]
+the time in seconds until a timeout is raised when waiting to read from
+a connection to AWS S3 (defaults to 60 seconds)
+.RS
+.RE
+.TP
 .B \[en]credential {azure\-cli,managed\-identity}
 optionally specify the type of credential to use when authenticating
 with Azure Blob Storage.

--- a/doc/barman-cloud-backup-list.1.md
+++ b/doc/barman-cloud-backup-list.1.md
@@ -61,6 +61,10 @@ SERVER_NAME
 --endpoint-url
 :    override the default S3 URL construction mechanism by specifying an endpoint.
 
+--read-timeout *TIMEOUT*
+:    the time in seconds until a timeout is raised when waiting to read from a
+     connection to AWS S3 (defaults to 60 seconds)
+
 --credential {azure-cli,managed-identity}
 :    optionally specify the type of credential to use when authenticating with
      Azure Blob Storage. If omitted then the credential will be obtained from the

--- a/doc/barman-cloud-backup.1
+++ b/doc/barman-cloud-backup.1
@@ -147,6 +147,12 @@ endpoint
 .RS
 .RE
 .TP
+.B \[en]read\-timeout \f[I]TIMEOUT\f[]
+the time in seconds until a timeout is raised when waiting to read from
+a connection to AWS S3 (defaults to 60 seconds)
+.RS
+.RE
+.TP
 .B \-e, \[en]encryption
 the encryption algorithm used when storing the uploaded data in S3
 Allowed values: `AES256'|`aws:kms'

--- a/doc/barman-cloud-backup.1.md
+++ b/doc/barman-cloud-backup.1.md
@@ -104,6 +104,10 @@ SERVER_NAME
 --endpoint-url
 :    override the default S3 URL construction mechanism by specifying an endpoint
 
+--read-timeout *TIMEOUT*
+:    the time in seconds until a timeout is raised when waiting to read from a
+     connection to AWS S3 (defaults to 60 seconds)
+
 -e, --encryption
 :    the encryption algorithm used when storing the uploaded data in S3
      Allowed values: 'AES256'|'aws:kms'

--- a/doc/barman-cloud-check-wal-archive.1
+++ b/doc/barman-cloud-check-wal-archive.1
@@ -87,6 +87,12 @@ endpoint.
 .RS
 .RE
 .TP
+.B \[en]read\-timeout \f[I]TIMEOUT\f[]
+the time in seconds until a timeout is raised when waiting to read from
+a connection to AWS S3 (defaults to 60 seconds)
+.RS
+.RE
+.TP
 .B \[en]credential {azure\-cli,managed\-identity}
 optionally specify the type of credential to use when authenticating
 with Azure Blob Storage.

--- a/doc/barman-cloud-check-wal-archive.1.md
+++ b/doc/barman-cloud-check-wal-archive.1.md
@@ -66,6 +66,10 @@ SERVER_NAME
 --endpoint-url
 :    override the default S3 URL construction mechanism by specifying an endpoint.
 
+--read-timeout *TIMEOUT*
+:    the time in seconds until a timeout is raised when waiting to read from a
+     connection to AWS S3 (defaults to 60 seconds)
+
 --credential {azure-cli,managed-identity}
 :    optionally specify the type of credential to use when authenticating with
      Azure Blob Storage. If omitted then the credential will be obtained from the

--- a/doc/barman-cloud-restore.1
+++ b/doc/barman-cloud-restore.1
@@ -90,6 +90,12 @@ endpoint.
 .RS
 .RE
 .TP
+.B \[en]read\-timeout \f[I]TIMEOUT\f[]
+the time in seconds until a timeout is raised when waiting to read from
+a connection to AWS S3 (defaults to 60 seconds)
+.RS
+.RE
+.TP
 .B \[en]credential {azure\-cli,managed\-identity}
 optionally specify the type of credential to use when authenticating
 with Azure Blob Storage.

--- a/doc/barman-cloud-restore.1.md
+++ b/doc/barman-cloud-restore.1.md
@@ -68,6 +68,10 @@ original location (you may repeat the option for multiple tablespaces)
 --endpoint-url
 :    override the default S3 URL construction mechanism by specifying an endpoint.
 
+--read-timeout *TIMEOUT*
+:    the time in seconds until a timeout is raised when waiting to read from a
+     connection to AWS S3 (defaults to 60 seconds)
+
 --credential {azure-cli,managed-identity}
 :    optionally specify the type of credential to use when authenticating with
      Azure Blob Storage. If omitted then the credential will be obtained from the

--- a/doc/barman-cloud-wal-archive.1
+++ b/doc/barman-cloud-wal-archive.1
@@ -135,6 +135,12 @@ service which is to be used to encrypt the data in Azure
 .RS
 .RE
 .TP
+.B \[en]read\-timeout \f[I]TIMEOUT\f[]
+the time in seconds until a timeout is raised when waiting to read from
+a connection to AWS S3 (defaults to 60 seconds)
+.RS
+.RE
+.TP
 .B \[en]credential {azure\-cli,managed\-identity}
 optionally specify the type of credential to use when authenticating
 with Azure Blob Storage.

--- a/doc/barman-cloud-wal-archive.1.md
+++ b/doc/barman-cloud-wal-archive.1.md
@@ -99,6 +99,10 @@ WAL_PATH
 :    the name of an encryption scope defined in the Azure Blob Storage
      service which is to be used to encrypt the data in Azure
 
+--read-timeout *TIMEOUT*
+:    the time in seconds until a timeout is raised when waiting to read from a
+     connection to AWS S3 (defaults to 60 seconds)
+
 --credential {azure-cli,managed-identity}
 :    optionally specify the type of credential to use when authenticating with
      Azure Blob Storage. If omitted then the credential will be obtained from the

--- a/doc/barman-cloud-wal-restore.1
+++ b/doc/barman-cloud-wal-restore.1
@@ -87,6 +87,12 @@ endpoint.
 .RS
 .RE
 .TP
+.B \[en]read\-timeout \f[I]TIMEOUT\f[]
+the time in seconds until a timeout is raised when waiting to read from
+a connection to AWS S3 (defaults to 60 seconds)
+.RS
+.RE
+.TP
 .B \[en]credential {azure\-cli,managed\-identity}
 optionally specify the type of credential to use when authenticating
 with Azure Blob Storage.

--- a/doc/barman-cloud-wal-restore.1.md
+++ b/doc/barman-cloud-wal-restore.1.md
@@ -64,6 +64,10 @@ WAL_PATH
 --endpoint-url
 :    override the default S3 URL construction mechanism by specifying an endpoint.
 
+--read-timeout *TIMEOUT*
+:    the time in seconds until a timeout is raised when waiting to read from a
+     connection to AWS S3 (defaults to 60 seconds)
+
 --credential {azure-cli,managed-identity}
 :    optionally specify the type of credential to use when authenticating with
      Azure Blob Storage. If omitted then the credential will be obtained from the

--- a/tests/test_barman_cloud_wal_archive.py
+++ b/tests/test_barman_cloud_wal_archive.py
@@ -229,6 +229,7 @@ class TestMain(object):
             profile_name=None,
             endpoint_url=None,
             encryption=None,
+            read_timeout=None,
         )
 
         # Verify expected override tags are passed to upload_wal

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -843,7 +843,7 @@ class TestS3CloudInterface(object):
 
         assert str(exc.value) == (
             "Error from cloud provider while deleting objects - please "
-            "check the Barman logs"
+            "check the command output."
         )
 
         assert (
@@ -1536,9 +1536,9 @@ class TestAzureCloudInterface(object):
         mock_keys = []
         cloud_interface.delete_objects(mock_keys)
 
-        # The Azure SDK is happy to accept an empty list here so verify that we
-        # simply passed it on
-        container_client.delete_blobs.assert_called_once_with()
+        # All cloud interface implementations should short-circuit and avoid calling
+        # the cloud provider SDK when given an empty list.
+        container_client.delete_blobs.assert_not_called()
 
     def _create_mock_HttpResponse(self, status_code, url):
         """Helper function for partial failure tests."""
@@ -1571,7 +1571,7 @@ class TestAzureCloudInterface(object):
 
         assert str(exc.value) == (
             "Error from cloud provider while deleting objects - please "
-            "check the Barman logs"
+            "check the command output."
         )
 
         assert (
@@ -1613,7 +1613,7 @@ class TestAzureCloudInterface(object):
 
         assert str(exc.value) == (
             "Error from cloud provider while deleting objects - please "
-            "check the Barman logs"
+            "check the command output."
         )
 
         assert (
@@ -2094,7 +2094,7 @@ class TestGoogleCloudInterface(TestCase):
             "https://console.cloud.google.com/storage/browser/barman-test/path/to/object/"
         )
         mock_keys = ["path/to/object/1", "path/to/object/2"]
-        with pytest.raises(RuntimeError):
+        with pytest.raises(CloudProviderError):
             cloud_interface.delete_objects(mock_keys)
 
         logging_mock.error.assert_called_with(


### PR DESCRIPTION
Provides two new features to handle requests to delete large volumes of WAL:

1. `--batch-size` parameter which determines the maximum number of objects allowed in a single delete request (#678).
2. `--read-timeout` parameter (AWS only) which allows the boto3 `read_timeout` value to be configured to something other than its default of 60 seconds (#576).

---

Related integration tests can be found at EnterpriseDB/barman-testing#76.