### PR TITLE
Log command output at DEBUG for all commands except pg_basebackup

### DIFF
--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -615,6 +615,7 @@ class PostgresBackupExecutor(BackupExecutor):
             retry_handler=partial(self._retry_handler, dest_dirs),
             compression=self.backup_compression,
             err_handler=self._err_handler,
+            out_handler=PgBaseBackup.make_logging_handler(logging.INFO),
         )
 
         # Do the actual copy

--- a/barman/command_wrappers.py
+++ b/barman/command_wrappers.py
@@ -219,7 +219,7 @@ class Command(object):
         if out_handler:
             self.out_handler = out_handler
         else:
-            self.out_handler = self.make_logging_handler(logging.INFO)
+            self.out_handler = self.make_logging_handler(logging.DEBUG)
         # If an error handler has been provided use it, otherwise log the
         # stderr as WARNING
         if err_handler:

--- a/tests/test_command_wrappers.py
+++ b/tests/test_command_wrappers.py
@@ -516,7 +516,7 @@ class TestCommand(object):
         assert cmd.ret == ret
         assert cmd.out is None
         assert cmd.err is None
-        assert ("Command", INFO, out) in caplog.record_tuples
+        assert ("Command", DEBUG, out) in caplog.record_tuples
         assert ("Command", WARNING, err) in caplog.record_tuples
 
     def test_execute_invocation_multiline(self, popen, pipe_processor_loop, caplog):
@@ -554,9 +554,9 @@ class TestCommand(object):
         assert cmd.out is None
         assert cmd.err is None
         for line in out.splitlines():
-            assert ("Command", INFO, line) in caplog.record_tuples
-        assert ("Command", INFO, "") not in caplog.record_tuples
-        assert ("Command", INFO, None) not in caplog.record_tuples
+            assert ("Command", DEBUG, line) in caplog.record_tuples
+        assert ("Command", DEBUG, "") not in caplog.record_tuples
+        assert ("Command", DEBUG, None) not in caplog.record_tuples
         for line in err.splitlines():
             assert ("Command", WARNING, line) in caplog.record_tuples
         assert ("Command", WARNING, "") not in caplog.record_tuples
@@ -595,7 +595,7 @@ class TestCommand(object):
         assert cmd.ret == ret
         assert cmd.out is None
         assert cmd.err is None
-        assert ("Command", INFO, out) in caplog.record_tuples
+        assert ("Command", DEBUG, out) in caplog.record_tuples
         assert ("Command", WARNING, err) in caplog.record_tuples
 
     def test_handlers_multiline(self, popen, pipe_processor_loop, caplog):
@@ -1223,7 +1223,7 @@ class TestPgBaseBackup(object):
         assert cmd.ret == ret
         assert cmd.out is None
         assert cmd.err is None
-        assert ("PgBaseBackup", INFO, out) in caplog.record_tuples
+        assert ("PgBaseBackup", DEBUG, out) in caplog.record_tuples
         assert ("PgBaseBackup", WARNING, err) in caplog.record_tuples
 
     @pytest.mark.parametrize(
@@ -1545,7 +1545,7 @@ class TestReceiveXlog(object):
         assert cmd.ret == ret
         assert cmd.out is None
         assert cmd.err is None
-        assert ("PgReceiveXlog", INFO, out) in caplog.record_tuples
+        assert ("PgReceiveXlog", DEBUG, out) in caplog.record_tuples
         assert ("PgReceiveXlog", WARNING, err) in caplog.record_tuples
 
     @mock.patch("barman.utils.which")

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1073,6 +1073,7 @@ class TestPostgresBackupExecutor(object):
         assert err == ""
         # check that the bwlimit option have been ignored
         assert pg_basebackup_mock.mock_calls == [
+            mock.call.make_logging_handler(logging.INFO),
             mock.call(
                 connection=mock.ANY,
                 version="9.2",
@@ -1088,6 +1089,7 @@ class TestPostgresBackupExecutor(object):
                 path=mock.ANY,
                 compression=None,
                 err_handler=mock.ANY,
+                out_handler=mock.ANY,
             ),
             mock.call()(),
         ]
@@ -1109,6 +1111,7 @@ class TestPostgresBackupExecutor(object):
         assert err == ""
         # check that the bwlimit option have been passed to the test call
         assert pg_basebackup_mock.mock_calls == [
+            mock.call.make_logging_handler(logging.INFO),
             mock.call(
                 connection=mock.ANY,
                 version="9.5",
@@ -1124,6 +1127,7 @@ class TestPostgresBackupExecutor(object):
                 path=mock.ANY,
                 compression=None,
                 err_handler=mock.ANY,
+                out_handler=mock.ANY,
             ),
             mock.call()(),
         ]
@@ -1144,6 +1148,7 @@ class TestPostgresBackupExecutor(object):
         )
         # check that the bwlimit option have been passed to the test call
         assert pg_basebackup_mock.mock_calls == [
+            mock.call.make_logging_handler(logging.INFO),
             mock.call(
                 connection=mock.ANY,
                 version="9.5",
@@ -1159,6 +1164,7 @@ class TestPostgresBackupExecutor(object):
                 path=mock.ANY,
                 compression=None,
                 err_handler=mock.ANY,
+                out_handler=mock.ANY,
             ),
             mock.call()(),
         ]
@@ -1174,6 +1180,7 @@ class TestPostgresBackupExecutor(object):
         assert err == ""
         # check that the bwlimit option have been passed to the test call
         assert pg_basebackup_mock.mock_calls == [
+            mock.call.make_logging_handler(logging.INFO),
             mock.call(
                 connection=mock.ANY,
                 version="9.5",
@@ -1189,6 +1196,7 @@ class TestPostgresBackupExecutor(object):
                 path=mock.ANY,
                 compression=None,
                 err_handler=mock.ANY,
+                out_handler=mock.ANY,
             ),
             mock.call()(),
         ]


### PR DESCRIPTION
Changes the log level of the default out_handler in `barman.command_wrappers.Command` from INFO to DEBUG. This means that stdout from commands invoked by Barman is now logged at DEBUG level except for pg_basebackup which is now given a custom logging handler at the INFO level.

The rationale for this change is as follows:

1. The default output handlers had been dormant for some time due to the `Command._get_output_once` function overriding any existing out_handler or err_handler with `out.append` or `err.append` respectively.
2. This meant that command output was only ever logged when the command had completed and was not logged at all while the command was in progress.
3. This issue was fixed so that the default logging out_handler and err_handler functions were used, allowing command output to be logged during the execution of the command. The specific commit here is 8808725e569c4b0ccf435134a801b94f704ef031 which fixed issue #493.
4. By fixing this issue we enabled logging of every command executed by Barman at INFO level. For many commands such as `barman sync-info` this leads to a significnat amount of extra log noise.
5. We therefore need to allow pg_basebackup commands to log their output at INFO level while also moving the output of all other commands to DEBUG level.

Closes #682.