### PR TITLE
Use a new connection to primary when switching WALs

### DIFF
--- a/barman/server.py
+++ b/barman/server.py
@@ -290,14 +290,9 @@ class Server(RemoteStatusMixin):
                 )
             # If primary_conninfo is set then we're connecting to a standby
             if config.primary_conninfo is not None:
-                # The standby needs a connection to the primary so that it can
-                # perform WAL switches itself when calling pg_backup_stop.
-                primary = PostgreSQLConnection(
-                    config.primary_conninfo,
-                )
                 self.postgres = StandbyPostgreSQLConnection(
                     config.conninfo,
-                    primary,
+                    config.primary_conninfo,
                     config.immediate_checkpoint,
                     config.slot_name,
                 )


### PR DESCRIPTION
Creates a new PostgreSQL connection to the primary in the child process which switches WALs on the primary during the call to pg_backup_stop on the standby.

This replaces the old buggy behaviour of reusing the connection from the parent process which is specifically not supported by psycopg2 or the underlying libpq library. This would lead to undefined behaviour including the closure of connections with the message `SSL error: decryption failed or bad record mac`.

We also close the connection once the child process is finished with it which avoids additional `could not receive data from client: Connection reset by peer` messages on the primary due to dangling connections.

Closes #686.
May also close #685.