### PR TITLE
Being able to change recovery config file path

### DIFF
--- a/barman/backup.py
+++ b/barman/backup.py
@@ -723,6 +723,7 @@ class BackupManager(RemoteStatusMixin, KeepManagerMixin):
         :kwparam str|None target_action: default None. The recovery target
             action
         :kwparam bool|None standby_mode: the standby mode if needed
+        :kwparam str|None recovery_conf_filename: filename for storing recovery configurations
         """
 
         # Archive every WAL files in the incoming directory of the server

--- a/barman/cli.py
+++ b/barman/cli.py
@@ -724,6 +724,13 @@ def rebuild_xlogdb(args):
                 "backup."
             ),
         ),
+        argument(
+            "--recovery-conf-filename",
+            dest="recovery_conf_filename",
+            help=(
+                    "filename for storing recovery configurations."
+            ),
+        ),
     ]
 )
 def recover(args):

--- a/barman/cli.py
+++ b/barman/cli.py
@@ -885,6 +885,7 @@ def recover(args):
                 remote_command=args.remote_ssh_command,
                 target_action=getattr(args, "target_action", None),
                 standby_mode=getattr(args, "standby_mode", None),
+                recovery_conf_filename=getattr(args, "recovery_conf_filename", None),
             )
         except RecoveryException as exc:
             output.error(force_str(exc))

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -375,7 +375,7 @@ class RecoveryExecutor(object):
             if backup_info.version < 120000:
                 results["recovery_configuration_file"] = "recovery.conf"
         else:
-            recovery_info["configuration_files"].append(recovery_conf_filename)
+            recovery_info["configuration_files"].append(recovery_conf_filename) if (recovery_conf_filename in recovery_info["configuration_files"]) else 0
             results["recovery_configuration_file"] = recovery_conf_filename
         # Handle remote recovery options
         if remote_command:

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -127,7 +127,7 @@ class RecoveryExecutor(object):
 
         # Run the cron to be sure the wal catalog is up to date
         # Prepare a map that contains all the objects required for a recovery
-        recovery_info = self._setup(backup_info, remote_command, dest)
+        recovery_info = self._setup(backup_info, remote_command, dest, recovery_conf_filename)
         output.info(
             "Starting %s restore for server %s using backup %s",
             recovery_info["recovery_dest"],

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -315,7 +315,7 @@ class RecoveryExecutor(object):
         output.info("Identify dangerous settings in destination directory.")
 
         self._map_temporary_config_files(recovery_info, backup_info, remote_command, recovery_conf_filename)
-        self._analyse_temporary_config_files(recovery_info)
+        self._analyse_temporary_config_files(recovery_info, recovery_conf_filename)
         self._copy_temporary_config_files(dest, remote_command, recovery_info)
 
         return recovery_info

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -1196,8 +1196,8 @@ class RecoveryExecutor(object):
 
             append_lines = None
             conf_file_suffix = "postgresql.auto.conf"
-            if recovery_info["results"]["recovery_configuration_file"]:
-                conf_file_suffix = recovery_info["results"]["recovery_configuration_file"]
+            if results["recovery_configuration_file"]:
+                conf_file_suffix = results["recovery_configuration_file"]
             if conf_file.endswith(conf_file_suffix):
                 append_lines = recovery_info.get("auto_conf_append_lines")
 

--- a/barman/server.py
+++ b/barman/server.py
@@ -1858,6 +1858,7 @@ class Server(RemoteStatusMixin):
         :kwparam bool exclusive: whether the recovery is exclusive or not
         :kwparam str|None target_action: the recovery target action
         :kwparam bool|None standby_mode: the standby mode
+        :kwparam str|None recovery_conf_filename: filename for storing recovery configurations
         """
         return self.backup_manager.recover(
             backup_info, dest, tablespaces, remote_command, **kwargs

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -90,14 +90,14 @@ class TestRecoveryExecutor(object):
         backup_manager = testing_helpers.build_backup_manager()
         executor = RecoveryExecutor(backup_manager)
         # Identify dangerous options into config files for remote recovery
-        executor._analyse_temporary_config_files(recovery_info)
+        executor._analyse_temporary_config_files(recovery_info, None)
         assert len(recovery_info["results"]["changes"]) == 2
         assert len(recovery_info["results"]["warnings"]) == 4
         # Clean for a local recovery test
         recovery_info["results"]["changes"] = []
         recovery_info["results"]["warnings"] = []
         # Identify dangerous options for local recovery
-        executor._analyse_temporary_config_files(recovery_info)
+        executor._analyse_temporary_config_files(recovery_info, None)
         assert len(recovery_info["results"]["changes"]) == 2
         assert len(recovery_info["results"]["warnings"]) == 4
 
@@ -106,7 +106,7 @@ class TestRecoveryExecutor(object):
         recovery_info["results"]["warnings"] = []
         recovery_info["auto_conf_append_lines"] = ["l1", "l2"]
         postgresql_auto.write("")
-        executor._analyse_temporary_config_files(recovery_info)
+        executor._analyse_temporary_config_files(recovery_info, None)
         assert len(recovery_info["results"]["changes"]) == 1
         assert len(recovery_info["results"]["warnings"]) == 3
 
@@ -140,7 +140,7 @@ class TestRecoveryExecutor(object):
         backup_manager = testing_helpers.build_backup_manager()
         executor = RecoveryExecutor(backup_manager)
         executor._map_temporary_config_files(
-            recovery_info, backup_info, "ssh@something"
+            recovery_info, backup_info, "ssh@something", None
         )
         # check that configuration files have been moved by the method
         assert tempdir.join("postgresql.conf").check()
@@ -171,31 +171,31 @@ class TestRecoveryExecutor(object):
 
         # setup should create a temporary directory
         # and teardown should delete it
-        ret = executor._setup(backup_info, None, "/tmp")
+        ret = executor._setup(backup_info, None, "/tmp", None)
         assert os.path.exists(ret["tempdir"])
         executor.close()
         assert not os.path.exists(ret["tempdir"])
         assert ret["wal_dest"].endswith("/pg_xlog")
 
         # no postgresql.auto.conf on version 9.3
-        ret = executor._setup(backup_info, None, "/tmp")
+        ret = executor._setup(backup_info, None, "/tmp", None)
         executor.close()
         assert "postgresql.auto.conf" not in ret["configuration_files"]
 
         # Check the present for postgresql.auto.conf on version 9.4
         backup_info.version = 90400
-        ret = executor._setup(backup_info, None, "/tmp")
+        ret = executor._setup(backup_info, None, "/tmp", None)
         executor.close()
         assert "postgresql.auto.conf" in ret["configuration_files"]
 
         # Receive a error if the remote command is invalid
         with pytest.raises(SystemExit):
             executor.server.path = None
-            executor._setup(backup_info, "invalid", "/tmp")
+            executor._setup(backup_info, "invalid", "/tmp", None)
 
         # Test for PostgreSQL 10
         backup_info.version = 100000
-        ret = executor._setup(backup_info, None, "/tmp")
+        ret = executor._setup(backup_info, None, "/tmp", None)
         executor.close()
         assert ret["wal_dest"].endswith("/pg_wal")
 

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -70,7 +70,7 @@ class TestRecoveryExecutor(object):
             "configuration_files": ["postgresql.conf", "postgresql.auto.conf"],
             "tempdir": tempdir.strpath,
             "temporary_configuration_files": [],
-            "results": {"changes": [], "warnings": []},
+            "results": {"changes": [], "warnings": [], "recovery_configuration_file": "postgresql.auto.conf"},
         }
         postgresql_conf = tempdir.join("postgresql.conf")
         postgresql_auto = tempdir.join("postgresql.auto.conf")

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -90,14 +90,14 @@ class TestRecoveryExecutor(object):
         backup_manager = testing_helpers.build_backup_manager()
         executor = RecoveryExecutor(backup_manager)
         # Identify dangerous options into config files for remote recovery
-        executor._analyse_temporary_config_files(recovery_info, None)
+        executor._analyse_temporary_config_files(recovery_info)
         assert len(recovery_info["results"]["changes"]) == 2
         assert len(recovery_info["results"]["warnings"]) == 4
         # Clean for a local recovery test
         recovery_info["results"]["changes"] = []
         recovery_info["results"]["warnings"] = []
         # Identify dangerous options for local recovery
-        executor._analyse_temporary_config_files(recovery_info, None)
+        executor._analyse_temporary_config_files(recovery_info)
         assert len(recovery_info["results"]["changes"]) == 2
         assert len(recovery_info["results"]["warnings"]) == 4
 
@@ -106,7 +106,7 @@ class TestRecoveryExecutor(object):
         recovery_info["results"]["warnings"] = []
         recovery_info["auto_conf_append_lines"] = ["l1", "l2"]
         postgresql_auto.write("")
-        executor._analyse_temporary_config_files(recovery_info, None)
+        executor._analyse_temporary_config_files(recovery_info)
         assert len(recovery_info["results"]["changes"]) == 1
         assert len(recovery_info["results"]["warnings"]) == 3
 
@@ -140,7 +140,7 @@ class TestRecoveryExecutor(object):
         backup_manager = testing_helpers.build_backup_manager()
         executor = RecoveryExecutor(backup_manager)
         executor._map_temporary_config_files(
-            recovery_info, backup_info, "ssh@something", None
+            recovery_info, backup_info, "ssh@something"
         )
         # check that configuration files have been moved by the method
         assert tempdir.join("postgresql.conf").check()


### PR DESCRIPTION
sometimes we don't want to store generated configs related to recovery into the default file (e.g. `postgresql.auto.conf`)
so I added `--recovery-conf-filename` option to specify the filename

for example in our environment we are using https://github.com/basalam/kaastolon which links  `postgresql.auto.conf` to `/dev/null` in order to avoid `SET` queries on postgresql

credits to @mojtabash78 (for testing and using it in our production)