### PR TITLE
Catch ValueError when parsing backup ID

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -1959,7 +1959,11 @@ def parse_backup_id(server, args):
     elif is_backup_id(args.backup_id):
         backup_id = args.backup_id
     else:
-        backup_id = server.get_backup_id_from_name(args.backup_id)
+        try:
+            backup_id = server.get_backup_id_from_name(args.backup_id)
+        except ValueError as exc:
+            output.error(str(exc))
+            output.close_and_exit()
     backup_info = server.get_backup(backup_id)
     if backup_info is None:
         output.error(


### PR DESCRIPTION
Catches any ValueError exceptions which occur when converting the backup ID to a name and logs the result before exiting cleanly.

Previously we were just letting the exception travel to the top which meant stack traces were dumped in the logs for no good reason. This would also break the integration tests which will fail if any exceptions or tracebacks are logged during the tests.

Relates to #690.