### PR TITLE
Revert to 20.04 runner for unit tests in GH workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
 
   unit-tests:
     name: "Python ${{ matrix.python-version }} ${{ matrix.tox-env }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]


### PR DESCRIPTION
The ubuntu-latest runner was recently updated to reference the ubuntu-22.04 runner. Because there are no python 2.7 or 3.6 packages available on 22.04 our unit tests cannot run against those versions using the 22.04 runner.

This isn't a bug in the 22.04 runner since these python versions are both EOL, however as long as Barman supports them we still need to run the tests on those pythons.

We therefore revert to the 20.04 runner until we either find a way to test using 2.7 and 3.6 on ubuntu-22.04 or we drop support for python 2.7 and 3.6.