### PR TITLE
Configurable recovery options filename

### DIFF
--- a/barman/backup.py
+++ b/barman/backup.py
@@ -746,7 +746,8 @@ class BackupManager(RemoteStatusMixin, KeepManagerMixin):
         :kwparam str|None target_action: default None. The recovery target
             action
         :kwparam bool|None standby_mode: the standby mode if needed
-        :kwparam str|None recovery_conf_filename: filename for storing recovery configurations
+        :kwparam str|None recovery_conf_filename: filename for storing recovery
+            configurations
         """
 
         # Archive every WAL files in the incoming directory of the server

--- a/barman/backup.py
+++ b/barman/backup.py
@@ -746,6 +746,7 @@ class BackupManager(RemoteStatusMixin, KeepManagerMixin):
         :kwparam str|None target_action: default None. The recovery target
             action
         :kwparam bool|None standby_mode: the standby mode if needed
+        :kwparam str|None recovery_conf_filename: filename for storing recovery configurations
         """
 
         # Archive every WAL files in the incoming directory of the server

--- a/barman/cli.py
+++ b/barman/cli.py
@@ -742,7 +742,11 @@ def rebuild_xlogdb(args):
         argument(
             "--recovery-conf-filename",
             dest="recovery_conf_filename",
-            help=("filename for storing recovery configurations."),
+            help=(
+                "Name of the file to which recovery configuration will be added "
+                "(default: postgresql.auto.conf for PostgreSQL 12 and newer, "
+                "recovery.conf for earlier versions)."
+            ),
         ),
         argument(
             "--snapshot-recovery-instance",
@@ -947,7 +951,7 @@ def recover(args):
                 remote_command=args.remote_ssh_command,
                 target_action=getattr(args, "target_action", None),
                 standby_mode=getattr(args, "standby_mode", None),
-                recovery_conf_filename=getattr(args, "recovery_conf_filename", None),
+                recovery_conf_filename=args.recovery_conf_filename,
                 **snapshot_kwargs
             )
         except RecoveryException as exc:

--- a/barman/cli.py
+++ b/barman/cli.py
@@ -740,6 +740,11 @@ def rebuild_xlogdb(args):
             ),
         ),
         argument(
+            "--recovery-conf-filename",
+            dest="recovery_conf_filename",
+            help=("filename for storing recovery configurations."),
+        ),
+        argument(
             "--snapshot-recovery-instance",
             help="Instance where the disks recovered from the snapshots are attached",
         ),
@@ -942,6 +947,7 @@ def recover(args):
                 remote_command=args.remote_ssh_command,
                 target_action=getattr(args, "target_action", None),
                 standby_mode=getattr(args, "standby_mode", None),
+                recovery_conf_filename=getattr(args, "recovery_conf_filename", None),
                 **snapshot_kwargs
             )
         except RecoveryException as exc:

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -125,12 +125,15 @@ class RecoveryExecutor(object):
         :param bool exclusive: whether the recovery is exclusive or not
         :param str|None target_action: The recovery target action
         :param bool|None standby_mode: standby mode
-        :param str|None recovery_conf_filename: filename for storing recovery configurations
+        :param str|None recovery_conf_filename: filename for storing recovery
+            configurations
         """
 
         # Run the cron to be sure the wal catalog is up to date
         # Prepare a map that contains all the objects required for a recovery
-        recovery_info = self._setup(backup_info, remote_command, dest, recovery_conf_filename)
+        recovery_info = self._setup(
+            backup_info, remote_command, dest, recovery_conf_filename
+        )
         output.info(
             "Starting %s restore for server %s using backup %s",
             recovery_info["recovery_dest"],

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -1662,6 +1662,7 @@ class SnapshotRecoveryExecutor(RemoteConfigRecoveryExecutor):
         exclusive=False,
         target_action=None,
         standby_mode=None,
+        recovery_conf_filename=None,
         recovery_instance=None,
         recovery_zone=None,
     ):
@@ -1687,6 +1688,8 @@ class SnapshotRecoveryExecutor(RemoteConfigRecoveryExecutor):
         :param bool exclusive: whether the recovery is exclusive or not
         :param str|None target_action: The recovery target action
         :param bool|None standby_mode: standby mode
+        :param str|None recovery_conf_filename: filename for storing recovery
+            configurations
         :param str|None recovery_instance: The name of the recovery node as it is
             known by the cloud provider
         :param str|None recovery_zone: The zone in which the recovery node is located
@@ -1715,6 +1718,7 @@ class SnapshotRecoveryExecutor(RemoteConfigRecoveryExecutor):
             exclusive=exclusive,
             target_action=target_action,
             standby_mode=standby_mode,
+            recovery_conf_filename=recovery_conf_filename,
         )
 
     def _start_backup_copy_message(self):

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -1255,8 +1255,12 @@ class RecoveryExecutor(object):
         if remote_command:
             # If this is a remote recovery, rsync the modified files from the
             # temporary local directory to the remote destination directory.
+            # The list of files is built from `temporary_configuration_files` instead
+            # of `configuration_files` because `configuration_files` is not guaranteed
+            # to include the recovery configuration file.
             file_list = []
-            for conf_file in recovery_info["configuration_files"]:
+            for conf_path in recovery_info["temporary_configuration_files"]:
+                conf_file = os.path.basename(conf_path)
                 file_list.append("%s" % conf_file)
                 file_list.append("%s.origin" % conf_file)
 

--- a/barman/server.py
+++ b/barman/server.py
@@ -1876,7 +1876,8 @@ class Server(RemoteStatusMixin):
         :kwparam bool exclusive: whether the recovery is exclusive or not
         :kwparam str|None target_action: the recovery target action
         :kwparam bool|None standby_mode: the standby mode
-        :kwparam str|None recovery_conf_filename: filename for storing recovery configurations
+        :kwparam str|None recovery_conf_filename: filename for storing recovery
+            configurations
         """
         return self.backup_manager.recover(
             backup_info, dest, tablespaces, remote_command, **kwargs

--- a/barman/server.py
+++ b/barman/server.py
@@ -1876,6 +1876,7 @@ class Server(RemoteStatusMixin):
         :kwparam bool exclusive: whether the recovery is exclusive or not
         :kwparam str|None target_action: the recovery target action
         :kwparam bool|None standby_mode: the standby mode
+        :kwparam str|None recovery_conf_filename: filename for storing recovery configurations
         """
         return self.backup_manager.recover(
             backup_info, dest, tablespaces, remote_command, **kwargs

--- a/doc/barman.1
+++ b/doc/barman.1
@@ -570,6 +570,21 @@ and has no effect otherwise.
 .RS
 .RE
 .TP
+.B \-\-recovery\-conf\-filename \f[I]RECOVERY_CONF_FILENAME\f[]
+The name of the file where Barman should write the PostgreSQL recovery
+options.
+This defaults to postgresql.auto.conf (or recovery.conf for PostgreSQL
+versions earlier than 12) however if \-\-recovery\-conf\-filename is
+used then recovery options will be written to RECOVERY_CONF_FILENAME
+instead.
+The default value is correct for a typical PostgreSQL installation
+however if PostgreSQL is being managed by tooling which modifies the
+configuration mechanism (for example postgresql.auto.conf could be
+symlinked to /dev/null) then this option can be used to write the
+recovery options to an alternative location.
+.RS
+.RE
+.TP
 .B \-\-snapshot\-recovery\-instance \f[I]INSTANCE_NAME\f[]
 Name of the instance where the disks recovered from the snapshots are
 attached.

--- a/doc/barman.1.d/50-recover.md
+++ b/doc/barman.1.d/50-recover.md
@@ -96,6 +96,17 @@ recover *\[OPTIONS\]* *SERVER_NAME* *BACKUP_ID* *DESTINATION_DIRECTORY*
         This option is *required* when recovering from compressed backups and
         has no effect otherwise.
 
+    --recovery-conf-filename *RECOVERY_CONF_FILENAME*
+    :   The name of the file where Barman should write the PostgreSQL recovery
+        options. This defaults to postgresql.auto.conf (or recovery.conf for
+        PostgreSQL versions earlier than 12) however if --recovery-conf-filename
+        is used then recovery options will be written to RECOVERY_CONF_FILENAME
+        instead. The default value is correct for a typical PostgreSQL
+        installation however if PostgreSQL is being managed by tooling which
+        modifies the configuration mechanism (for example postgresql.auto.conf
+        could be symlinked to /dev/null) then this option can be used to write
+        the recovery options to an alternative location.
+
     --snapshot-recovery-instance *INSTANCE_NAME*
     :   Name of the instance where the disks recovered from the snapshots are
         attached. This option is required when recovering backups made with

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -1783,6 +1783,7 @@ class TestSnapshotRecoveryExecutor(object):
             exclusive=False,
             target_action=None,
             standby_mode=None,
+            recovery_conf_filename=None,
         )
 
     @pytest.mark.parametrize(

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -65,7 +65,11 @@ class TestRecoveryExecutor(object):
         backup_manager = testing_helpers.build_backup_manager()
         assert RecoveryExecutor(backup_manager)
 
-    def test_analyse_temporary_config_files(self, tmpdir):
+    @pytest.mark.parametrize(
+        "recovery_configuration_file",
+        ("postgresql.auto.conf", "custom.recovery.conf"),
+    )
+    def test_analyse_temporary_config_files(self, recovery_configuration_file, tmpdir):
         """
         Test the method that identifies dangerous options into
         the configuration files
@@ -73,28 +77,31 @@ class TestRecoveryExecutor(object):
         # Build directory/files structure for testing
         tempdir = tmpdir.mkdir("tempdir")
         recovery_info = {
+            "auto_conf_append_lines": ["standby_mode = 'on'"],
             "configuration_files": ["postgresql.conf", "postgresql.auto.conf"],
             "tempdir": tempdir.strpath,
             "temporary_configuration_files": [],
             "results": {
                 "changes": [],
                 "warnings": [],
-                "recovery_configuration_file": "postgresql.auto.conf",
+                "recovery_configuration_file": recovery_configuration_file,
             },
         }
         postgresql_conf = tempdir.join("postgresql.conf")
-        postgresql_auto = tempdir.join("postgresql.auto.conf")
+        recovery_config_file = tempdir.join(recovery_configuration_file)
         postgresql_conf.write(
             "archive_command = something\n"
             "data_directory = something\n"
             "include = something\n"
             'include "without braces"'
         )
-        postgresql_auto.write(
+        recovery_config_file.write(
             "archive_command = something\n" "data_directory = something"
         )
         recovery_info["temporary_configuration_files"].append(postgresql_conf.strpath)
-        recovery_info["temporary_configuration_files"].append(postgresql_auto.strpath)
+        recovery_info["temporary_configuration_files"].append(
+            recovery_config_file.strpath
+        )
         # Build a RecoveryExecutor object (using a mock as server and backup
         # manager.
         backup_manager = testing_helpers.build_backup_manager()
@@ -110,12 +117,18 @@ class TestRecoveryExecutor(object):
         executor._analyse_temporary_config_files(recovery_info)
         assert len(recovery_info["results"]["changes"]) == 2
         assert len(recovery_info["results"]["warnings"]) == 4
+        # Verify auto options were appended
+        recovery_config_file_contents = recovery_config_file.read()
+        assert all(
+            append_line in recovery_config_file_contents
+            for append_line in recovery_info["auto_conf_append_lines"]
+        )
 
         # Test corner case with empty auto file
         recovery_info["results"]["changes"] = []
         recovery_info["results"]["warnings"] = []
         recovery_info["auto_conf_append_lines"] = ["l1", "l2"]
-        postgresql_auto.write("")
+        recovery_config_file.write("")
         executor._analyse_temporary_config_files(recovery_info)
         assert len(recovery_info["results"]["changes"]) == 1
         assert len(recovery_info["results"]["warnings"]) == 3
@@ -169,6 +182,93 @@ class TestRecoveryExecutor(object):
             and "pg_ident.conf" in recovery_info["results"]["missing_files"]
         )
 
+    @pytest.mark.parametrize(
+        (
+            "remote_command",
+            "recovery_dir_key",
+            "recovery_configuration_file",
+        ),
+        [
+            (None, "destination_path", "postgresql.auto.conf"),
+            ("mock_remote_command", "tempdir", "postgresql.auto.conf"),
+            (None, "destination_path", "custom.recovery.conf"),
+            ("mock_remote_command", "tempdir", "custom.recovery.conf"),
+        ],
+    )
+    @mock.patch("barman.recovery_executor.open")
+    @mock.patch("barman.recovery_executor.RecoveryExecutor._copy_conf_files_to_tempdir")
+    @mock.patch("barman.recovery_executor.RecoveryExecutor._conf_files_exist")
+    def test_map_temporary_config_files_recovery_configuration_file(
+        self,
+        mock_conf_files_exist,
+        mock_copy_conf_files_to_tempdir,
+        mock_open,
+        remote_command,
+        recovery_dir_key,
+        recovery_configuration_file,
+        tmpdir,
+    ):
+        """
+        Test the method that prepares configuration files for the final steps of a
+        recovery handles the recovery_configuration_file correctly.
+        """
+        # GIVEN a backup from PostgreSQL 12 (or above)
+        backup_info = testing_helpers.build_test_backup_info()
+        backup_info.version = 120000
+        # AND a recovery executor
+        backup_manager = testing_helpers.build_backup_manager()
+        executor = RecoveryExecutor(backup_manager)
+        # AND recovery_info specifies a recovery_configuration_file
+        destination_path = tmpdir.mkdir("destination_path")
+        tempdir = tmpdir.mkdir("tempdir")
+        recovery_info = {
+            "configuration_files": ["postgresql.conf", "postgresql.auto.conf"],
+            "destination_path": destination_path.strpath,
+            "tempdir": tempdir.strpath,
+            "temporary_configuration_files": [],
+            "results": {
+                "missing_files": [],
+                "recovery_configuration_file": recovery_configuration_file,
+            },
+        }
+        # AND postgresql.conf and postgresql.auto.conf exist
+        mock_conf_files_exist.return_value = {
+            "postgresql.conf": True,
+            "postgresql.auto.conf": True,
+        }
+        mock_copy_conf_files_to_tempdir.return_value = [
+            os.path.join(recovery_info[recovery_dir_key], filename)
+            for filename in recovery_info["configuration_files"]
+        ]
+
+        # WHEN _map_temporary_config_files is called
+        executor._map_temporary_config_files(recovery_info, backup_info, remote_command)
+
+        # THEN the configuration files were added to expected_temporary_files
+        assert recovery_info["temporary_configuration_files"][:2] == [
+            os.path.join(recovery_info[recovery_dir_key], filename)
+            for filename in recovery_info["configuration_files"]
+        ]
+        if recovery_configuration_file not in recovery_info["configuration_files"]:
+            # THEN the file was created if it was not already in
+            # configuration_files
+            conf_file_path = os.path.join(
+                recovery_info[recovery_dir_key], recovery_configuration_file
+            )
+            mock_open.assert_called_once_with(conf_file_path, "ab")
+            # AND the path was appended to temporary_configuration_files
+            assert recovery_info["temporary_configuration_files"][-1] == os.path.join(
+                recovery_info[recovery_dir_key], recovery_configuration_file
+            )
+        else:
+            # OR if the file was already in configuration_files
+            # THEN it was not created
+            mock_open.assert_not_called()
+            # AND no additional temporary files were created
+            assert len(recovery_info["temporary_configuration_files"]) == len(
+                recovery_info["configuration_files"]
+            )
+
     @mock.patch("barman.recovery_executor.RsyncPgData")
     def test_setup(self, rsync_mock):
         """
@@ -209,6 +309,59 @@ class TestRecoveryExecutor(object):
         ret = executor._setup(backup_info, None, recovery_dir, None)
         executor.close()
         assert ret["wal_dest"].endswith("/pg_wal")
+
+    @pytest.mark.parametrize(
+        (
+            "postgres_version",
+            "recovery_conf_filename",
+            "expected_recovery_configuration_file",
+            "expected_in_configuration_files",
+        ),
+        [
+            (110000, None, "recovery.conf", False),
+            (110000, "custom.recovery.conf", "custom.recovery.conf", False),
+            (120000, None, "postgresql.auto.conf", True),
+            (120000, "custom.recovery.conf", "custom.recovery.conf", False),
+        ],
+    )
+    @mock.patch("barman.recovery_executor.RsyncPgData")
+    def test_setup_recovery_configuration_file(
+        self,
+        _rsync_mock,
+        postgres_version,
+        recovery_conf_filename,
+        expected_recovery_configuration_file,
+        expected_in_configuration_files,
+    ):
+        """
+        Test the handling of recovery configuration files during _setup.
+        """
+        # GIVEN a backup from a PostgreSQL server with the specified version
+        backup_info = testing_helpers.build_test_backup_info()
+        backup_info.version = postgres_version
+        # AND a recovery executor
+        backup_manager = testing_helpers.build_backup_manager()
+        executor = RecoveryExecutor(backup_manager)
+
+        # WHEN _setup is called on the recovery executor
+        recovery_info = executor._setup(
+            backup_info, None, "/path/to/recovery/dir", recovery_conf_filename
+        )
+        executor.close()
+
+        # THEN the expected recovery configuration file is set
+        assert (
+            recovery_info["results"]["recovery_configuration_file"]
+            == expected_recovery_configuration_file
+        )
+        # AND the presence of the recovery conf file in configuration_files matches
+        # expectations
+        assert (
+            expected_recovery_configuration_file in recovery_info["configuration_files"]
+        ) == expected_in_configuration_files
+        # AND regardless of the recovery configuration file, postgresql.auto.conf is in
+        # configuration_files
+        assert "postgresql.auto.conf" in recovery_info["configuration_files"]
 
     def test_set_pitr_targets(self, tmpdir):
         """

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -76,7 +76,7 @@ class TestRecoveryExecutor(object):
             "configuration_files": ["postgresql.conf", "postgresql.auto.conf"],
             "tempdir": tempdir.strpath,
             "temporary_configuration_files": [],
-            "results": {"changes": [], "warnings": []},
+            "results": {"changes": [], "warnings": [], "recovery_configuration_file": "postgresql.auto.conf"},
         }
         postgresql_conf = tempdir.join("postgresql.conf")
         postgresql_auto = tempdir.join("postgresql.auto.conf")
@@ -177,31 +177,31 @@ class TestRecoveryExecutor(object):
 
         # setup should create a temporary directory
         # and teardown should delete it
-        ret = executor._setup(backup_info, None, "/tmp")
+        ret = executor._setup(backup_info, None, "/tmp", None)
         assert os.path.exists(ret["tempdir"])
         executor.close()
         assert not os.path.exists(ret["tempdir"])
         assert ret["wal_dest"].endswith("/pg_xlog")
 
         # no postgresql.auto.conf on version 9.3
-        ret = executor._setup(backup_info, None, "/tmp")
+        ret = executor._setup(backup_info, None, "/tmp", None)
         executor.close()
         assert "postgresql.auto.conf" not in ret["configuration_files"]
 
         # Check the present for postgresql.auto.conf on version 9.4
         backup_info.version = 90400
-        ret = executor._setup(backup_info, None, "/tmp")
+        ret = executor._setup(backup_info, None, "/tmp", None)
         executor.close()
         assert "postgresql.auto.conf" in ret["configuration_files"]
 
         # Receive a error if the remote command is invalid
         with pytest.raises(SystemExit):
             executor.server.path = None
-            executor._setup(backup_info, "invalid", "/tmp")
+            executor._setup(backup_info, "invalid", "/tmp", None)
 
         # Test for PostgreSQL 10
         backup_info.version = 100000
-        ret = executor._setup(backup_info, None, "/tmp")
+        ret = executor._setup(backup_info, None, "/tmp", None)
         executor.close()
         assert ret["wal_dest"].endswith("/pg_wal")
 


### PR DESCRIPTION
This is https://github.com/EnterpriseDB/barman/pull/707 with additional commits based on further thinking about the right way to handle the recovery options when a different destination file is requested.

---

I have squashed the original commits from #707 into a single commit ([Allow file for recovery config settings to be specified](https://github.com/EnterpriseDB/barman/pull/718/commits/ccb6b794eb1829aa10c8f3f5f8c444471990fd0d)) and also squashed the minor changes I added into [Minor changes to --recovery-conf-filename commit](https://github.com/EnterpriseDB/barman/pull/718/commits/bae473a89c273517e422725e267aa870b399120a). The rest of the commits reflect additional changes which I think can remain separate on merge/rebase.