### PR TITLE
Fix broken assertions in compression tests

### DIFF
--- a/tests/test_compressor.py
+++ b/tests/test_compressor.py
@@ -867,7 +867,7 @@ class TestGZipCompression(object):
         else:
             gzip_compression.uncompress(src, dst, exclude=exclude, include_args=include)
             # THEN command.cmd was called
-            assert command.cmd.called_once()
+            command.cmd.assert_called_once()
             # AND the first argument was "tar"
             assert command.cmd.call_args_list[0][0][0] == "tar"
             # AND the basic arguments are present
@@ -998,7 +998,7 @@ class TestLZ4Compression(object):
         else:
             lz4_compression.uncompress(src, dst, exclude=exclude, include_args=include)
             # THEN command.cmd was called
-            assert command.cmd.called_once()
+            command.cmd.assert_called_once()
             # AND the first argument was "tar"
             assert command.cmd.call_args_list[0][0][0] == "tar"
             # AND the basic arguments are present
@@ -1139,7 +1139,7 @@ class TestZSTDCompression(object):
         else:
             zstd_compression.uncompress(src, dst, exclude=exclude, include_args=include)
             # THEN command.cmd was called
-            assert command.cmd.called_once()
+            command.cmd.assert_called_once()
             # AND the first argument was "tar"
             assert command.cmd.call_args_list[0][0][0] == "tar"
             # AND the basic arguments are present


### PR DESCRIPTION
Replaces `assert command.cmd.called_once()` with a call to the corresponding `assert_called_once` function. This fixes the assertion which was previously only passing due to the mock returning a truthy value.

Thanks to version 5.0.1 of the mock library for detecting this.