### PR TITLE
Add support for GCP persistent disk snapshots

### DIFF
--- a/barman/backup.py
+++ b/barman/backup.py
@@ -753,7 +753,7 @@ class BackupManager(RemoteStatusMixin, KeepManagerMixin):
         # Delegate the recovery operation to a RecoveryExecutor object
 
         command = unix_command_factory(remote_command, self.server.path)
-        executor = recovery_executor_factory(self, command, backup_info.compression)
+        executor = recovery_executor_factory(self, command, backup_info)
         # Run the pre_recovery_script if present.
         script = HookScriptRunner(self, "recovery_script", "pre")
         script.env_from_recover(

--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -80,6 +80,7 @@ class BackupExecutor(with_metaclass(ABCMeta, RemoteStatusMixin)):
 
         :param barman.backup.BackupManager backup_manager: the BackupManager
             assigned to the executor
+        :param str mode: The mode used by the executor for the backup.
         """
         super(BackupExecutor, self).__init__()
         self.backup_manager = backup_manager
@@ -731,12 +732,18 @@ class PostgresBackupExecutor(BackupExecutor):
         )
 
 
-class FsBackupExecutor(with_metaclass(ABCMeta, BackupExecutor)):
+class ExternalBackupExecutor(with_metaclass(ABCMeta, BackupExecutor)):
     """
-    Abstract base class file system level backup executors that
-    can operate remotely via SSH or locally:
+    Abstract base class for non-postgres backup executors.
+
+    An external backup executor is any backup executor which uses the
+    PostgreSQL low-level backup API to coordinate the backup.
+
+    Such executors can operate remotely via SSH or locally:
+
     - remote mode (default), operates via SSH
     - local mode, operates as the same user that Barman runs with
+
     It is also a factory for exclusive/concurrent backup strategy objects.
 
     Raises a SshCommandException if 'ssh_command' is not set and
@@ -749,11 +756,12 @@ class FsBackupExecutor(with_metaclass(ABCMeta, BackupExecutor)):
 
         :param barman.backup.BackupManager backup_manager: the BackupManager
             assigned to the executor
+        :param str mode: The mode used by the executor for the backup.
         :param bool local_mode: if set to False (default), the class is able
             to operate on remote servers using SSH. Operates only locally
             if set to True.
         """
-        super(FsBackupExecutor, self).__init__(backup_manager, mode)
+        super(ExternalBackupExecutor, self).__init__(backup_manager, mode)
 
         # Set local/remote mode for copy
         self.local_mode = local_mode
@@ -828,7 +836,7 @@ class FsBackupExecutor(with_metaclass(ABCMeta, BackupExecutor)):
         through the generic interface of a BackupExecutor. This implementation
         is responsible for performing a backup through a remote connection
         to the PostgreSQL server via Ssh. The specific set of instructions
-        depends on both the specific class that derives from FsBackupExecutor
+        depends on both the specific class that derives from ExternalBackupExecutor
         and the selected strategy (e.g. exclusive backup through Rsync).
 
         :param barman.infofile.LocalBackupInfo backup_info: backup information
@@ -887,7 +895,7 @@ class FsBackupExecutor(with_metaclass(ABCMeta, BackupExecutor)):
 
     def _local_check(self, check_strategy):
         """
-        Specific checks for local mode of FsBackupExecutor (same user)
+        Specific checks for local mode of ExternalBackupExecutor (same user)
 
         :param CheckStrategy check_strategy: the strategy for the management
              of the results of the various checks
@@ -908,7 +916,7 @@ class FsBackupExecutor(with_metaclass(ABCMeta, BackupExecutor)):
 
     def _remote_check(self, check_strategy):
         """
-        Specific checks for remote mode of FsBackupExecutor, via SSH.
+        Specific checks for remote mode of ExternalBackupExecutor, via SSH.
 
         :param CheckStrategy check_strategy: the strategy for the management
              of the results of the various checks
@@ -964,7 +972,7 @@ class FsBackupExecutor(with_metaclass(ABCMeta, BackupExecutor)):
 
     def check(self, check_strategy):
         """
-        Perform additional checks for FsBackupExecutor, including
+        Perform additional checks for ExternalBackupExecutor, including
         Ssh connection (executing a 'true' command on the remote server)
         and specific checks for the given backup strategy.
 
@@ -988,7 +996,7 @@ class FsBackupExecutor(with_metaclass(ABCMeta, BackupExecutor)):
 
     def status(self):
         """
-        Set additional status info for FsBackupExecutor using remote
+        Set additional status info for ExternalBackupExecutor using remote
         commands via Ssh, as well as those defined by the given
         backup strategy.
         """
@@ -1043,19 +1051,6 @@ class FsBackupExecutor(with_metaclass(ABCMeta, BackupExecutor)):
         except (PostgresConnectionError, FsOperationFailed) as e:
             _logger.warning("Error retrieving PostgreSQL status: %s", e)
         return remote_status
-
-    def _start_backup_copy_message(self, backup_info):
-        number_of_workers = self.config.parallel_jobs
-        via = "rsync/SSH"
-        if self.local_mode:
-            via = "local rsync"
-        message = "Starting backup copy via %s for %s" % (
-            via,
-            backup_info.backup_id,
-        )
-        if number_of_workers > 1:
-            message += " (%s jobs)" % number_of_workers
-        output.info(message)
 
 
 class PassiveBackupExecutor(BackupExecutor):
@@ -1153,13 +1148,13 @@ class PassiveBackupExecutor(BackupExecutor):
         return "passive"
 
 
-class RsyncBackupExecutor(FsBackupExecutor):
+class RsyncBackupExecutor(ExternalBackupExecutor):
     """
     Concrete class for backup via Rsync+Ssh.
 
     It invokes PostgreSQL commands to start and stop the backup, depending
     on the defined strategy. Data files are copied using Rsync via Ssh.
-    It heavily relies on methods defined in the FsBackupExecutor class
+    It heavily relies on methods defined in the ExternalBackupExecutor class
     from which it derives.
     """
 
@@ -1387,6 +1382,24 @@ class RsyncBackupExecutor(FsBackupExecutor):
         if not self.local_mode:
             return ":%s" % path
         return path
+
+    def _start_backup_copy_message(self, backup_info):
+        """
+        Output message for backup start.
+
+        :param barman.infofile.LocalBackupInfo backup_info: backup information
+        """
+        number_of_workers = self.config.parallel_jobs
+        via = "rsync/SSH"
+        if self.local_mode:
+            via = "local rsync"
+        message = "Starting backup copy via %s for %s" % (
+            via,
+            backup_info.backup_id,
+        )
+        if number_of_workers > 1:
+            message += " (%s jobs)" % number_of_workers
+        output.info(message)
 
 
 class BackupStrategy(with_metaclass(ABCMeta, object)):
@@ -1723,7 +1736,7 @@ class ExclusiveBackupStrategy(BackupStrategy):
     """
     Concrete class for exclusive backup strategy.
 
-    This strategy is for FsBackupExecutor only and is responsible for
+    This strategy is for ExternalBackupExecutor only and is responsible for
     coordinating Barman with PostgreSQL on standard physical backup
     operations (known as 'exclusive' backup), such as invoking
     pg_start_backup() and pg_stop_backup() on the master server.
@@ -1944,7 +1957,7 @@ class LocalConcurrentBackupStrategy(ConcurrentBackupStrategy):
     """
     Concrete class for concurrent backup strategy writing data locally.
 
-    This strategy is for FsBackupExecutor only and is responsible for
+    This strategy is for ExternalBackupExecutor only and is responsible for
     coordinating Barman with PostgreSQL on concurrent physical backup
     operations through concurrent backup PostgreSQL api.
     """

--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -1899,7 +1899,11 @@ class ConcurrentBackupStrategy(BackupStrategy):
         _logger.debug("Stop of native concurrent backup")
         self._concurrent_stop_backup(backup_info)
 
-        # Write backup_label retrieved from postgres connection
+        # Update the current action in preparation for writing the backup label.
+        # NOTE: The actual writing of the backup label happens either in the
+        # specialization of this function in LocalConcurrentBackupStrategy
+        # or out-of-band in a CloudBackupUploader (when ConcurrentBackupStrategy
+        # is used directly when writing to an object store).
         self.current_action = "writing backup label"
 
         # Ask PostgreSQL to switch to another WAL file. This is needed

--- a/barman/cli.py
+++ b/barman/cli.py
@@ -739,6 +739,14 @@ def rebuild_xlogdb(args):
                 "backup."
             ),
         ),
+        argument(
+            "--snapshot-recovery-instance",
+            help="Instance where the disks recovered from the snapshots are attached",
+        ),
+        argument(
+            "--snapshot-recovery-zone",
+            help="Zone containing the instance and disks for the snapshot recovery",
+        ),
     ]
 )
 def recover(args):
@@ -877,6 +885,47 @@ def recover(args):
             output.close_and_exit()
         server.config.network_compression = args.network_compression
 
+    if backup_id.snapshots_info is not None:
+        missing_args = []
+        if not args.snapshot_recovery_instance:
+            missing_args.append("--snapshot-recovery-instance")
+        if not args.snapshot_recovery_zone:
+            missing_args.append("--snapshot-recovery-zone")
+        if len(missing_args) > 0:
+            output.error(
+                "Backup %s is a snapshot backup and the following required arguments "
+                "have not been provided: %s",
+                backup_id.backup_id,
+                ", ".join(missing_args),
+            )
+            output.close_and_exit()
+        if tablespaces != {}:
+            output.error(
+                "Backup %s is a snapshot backup therefore tablespace relocation rules "
+                "cannot be used.",
+                backup_id.backup_id,
+            )
+            output.close_and_exit()
+        snapshot_kwargs = {
+            "recovery_instance": args.snapshot_recovery_instance,
+            "recovery_zone": args.snapshot_recovery_zone,
+        }
+    else:
+        unexpected_args = []
+        if args.snapshot_recovery_instance:
+            unexpected_args.append("--snapshot-recovery-instance")
+        if args.snapshot_recovery_zone:
+            unexpected_args.append("--snapshot-recovery-zone")
+        if len(unexpected_args) > 0:
+            output.error(
+                "Backup %s is not a snapshot backup but the following snapshot "
+                "arguments have been used: %s",
+                backup_id.backup_id,
+                ", ".join(unexpected_args),
+            )
+            output.close_and_exit()
+        snapshot_kwargs = {}
+
     with closing(server):
         try:
             server.recover(
@@ -893,6 +942,7 @@ def recover(args):
                 remote_command=args.remote_ssh_command,
                 target_action=getattr(args, "target_action", None),
                 standby_mode=getattr(args, "standby_mode", None),
+                **snapshot_kwargs
             )
         except RecoveryException as exc:
             output.error(force_str(exc))

--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -33,7 +33,7 @@ from barman.clients.cloud_cli import (
 )
 from barman.cloud import (
     CloudBackupUploaderBarman,
-    CloudBackupUploaderPostgres,
+    CloudBackupUploader,
     configure_logging,
 )
 from barman.cloud_providers import get_cloud_interface
@@ -175,7 +175,7 @@ def main(args=None):
                     raise OperationErrorExit()
 
                 with closing(postgres):
-                    uploader = CloudBackupUploaderPostgres(
+                    uploader = CloudBackupUploader(
                         postgres=postgres,
                         backup_name=config.backup_name,
                         **uploader_kwargs

--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -30,15 +30,18 @@ from barman.clients.cloud_cli import (
     NetworkErrorExit,
     OperationErrorExit,
     UrlArgumentType,
+    get_missing_attrs,
 )
 from barman.cloud import (
+    CloudBackupSnapshot,
     CloudBackupUploaderBarman,
     CloudBackupUploader,
     configure_logging,
 )
-from barman.cloud_providers import get_cloud_interface
+from barman.cloud_providers import get_cloud_interface, get_snapshot_interface
 from barman.exceptions import (
     BarmanException,
+    ConfigurationException,
     PostgresConnectionError,
     UnrecoverableHookScriptError,
 )
@@ -102,6 +105,36 @@ def build_conninfo(config):
     return " ".join(conn_parts)
 
 
+def _validate_config(config):
+    """
+    Additional validation for config such as mutually inclusive options.
+
+    Raises a ConfigurationException if any options are missing or incompatible.
+
+    :param argparse.Namespace config: The backup options provided at the command line.
+    """
+    required_snapshot_variables = (
+        "snapshot_disks",
+        "snapshot_instance",
+        "snapshot_zone",
+    )
+    is_snapshot_backup = any(
+        [getattr(config, var) for var in required_snapshot_variables]
+    )
+    if is_snapshot_backup:
+        missing_options = get_missing_attrs(config, required_snapshot_variables)
+        if len(missing_options) > 0:
+            raise ConfigurationException(
+                "Incomplete options for snapshot backup - missing: %s"
+                % ", ".join(missing_options)
+            )
+
+        if getattr(config, "compression"):
+            raise ConfigurationException(
+                "Compression options cannot be used with snapshot backups"
+            )
+
+
 def main(args=None):
     """
     The main script entry point
@@ -113,6 +146,7 @@ def main(args=None):
     configure_logging(config)
     tempdir = tempfile.mkdtemp(prefix="barman-cloud-backup-")
     try:
+        _validate_config(config)
         # Create any temporary file in the `tempdir` subdirectory
         tempfile.tempdir = tempdir
 
@@ -175,12 +209,28 @@ def main(args=None):
                     raise OperationErrorExit()
 
                 with closing(postgres):
-                    uploader = CloudBackupUploader(
-                        postgres=postgres,
-                        backup_name=config.backup_name,
-                        **uploader_kwargs
-                    )
-                    uploader.backup()
+                    # Take snapshot backups if snapshot backups were specified
+                    if config.snapshot_instance:
+                        snapshot_interface = get_snapshot_interface(config)
+                        snapshot_backup = CloudBackupSnapshot(
+                            config.server_name,
+                            cloud_interface,
+                            snapshot_interface,
+                            postgres,
+                            config.snapshot_instance,
+                            config.snapshot_zone,
+                            config.snapshot_disks,
+                            config.backup_name,
+                        )
+                        snapshot_backup.backup()
+                    # Otherwise upload everything to the object store
+                    else:
+                        uploader = CloudBackupUploader(
+                            postgres=postgres,
+                            backup_name=config.backup_name,
+                            **uploader_kwargs
+                        )
+                        uploader.backup()
 
     except KeyboardInterrupt as exc:
         logging.error("Barman cloud backup was interrupted by the user")
@@ -287,6 +337,29 @@ def parse_arguments(args=None):
         default=None,
         type=check_backup_name,
         dest="backup_name",
+    )
+    parser.add_argument(
+        "--snapshot-instance",
+        help="Instance where the disks to be backed up as snapshots are attached",
+    )
+    parser.add_argument(
+        "--snapshot-disk",
+        help="Name of a disk from which snapshots should be taken",
+        metavar="NAME",
+        action="append",
+        default=[],
+        dest="snapshot_disks",
+    )
+    parser.add_argument(
+        "--snapshot-zone",
+        help="Zone of the disks from which snapshots should be taken",
+    )
+    gcs_arguments = parser.add_argument_group(
+        "Extra options for google-cloud-storage cloud provider"
+    )
+    gcs_arguments.add_argument(
+        "--snapshot-gcp-project",
+        help="GCP project under which disk snapshots should be stored",
     )
     add_tag_argument(
         parser,

--- a/barman/clients/cloud_backup_delete.py
+++ b/barman/clients/cloud_backup_delete.py
@@ -30,7 +30,10 @@ from barman.clients.cloud_cli import (
     OperationErrorExit,
 )
 from barman.cloud import CloudBackupCatalog, configure_logging
-from barman.cloud_providers import get_cloud_interface
+from barman.cloud_providers import (
+    get_cloud_interface,
+    get_snapshot_interface_from_backup_info,
+)
 from barman.exceptions import InvalidRetentionPolicy
 from barman.retention_policies import RetentionPolicyFactory
 from barman.utils import force_str
@@ -170,6 +173,16 @@ def _delete_backup(
     if not backup_info:
         logging.warning("Backup %s does not exist", backup_id)
         return
+    if backup_info.snapshots_info:
+        logging.debug(
+            "Will delete the following snapshots: %s",
+            ", ".join(
+                snapshot.identifier for snapshot in backup_info.snapshots_info.snapshots
+            ),
+        )
+        if not dry_run:
+            snapshot_interface = get_snapshot_interface_from_backup_info(backup_info)
+            snapshot_interface.delete_snapshot_backup(backup_info)
     objects_to_delete = _get_files_for_backup(catalog, backup_info)
     backup_info_path = os.path.join(
         catalog.prefix, backup_info.backup_id, "backup.info"

--- a/barman/clients/cloud_backup_show.py
+++ b/barman/clients/cloud_backup_show.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+# © Copyright EnterpriseDB UK Limited 2018-2022
+#
+# This file is part of Barman.
+#
+# Barman is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Barman is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Barman.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import print_function
+
+import json
+import logging
+from contextlib import closing
+
+from barman.clients.cloud_cli import (
+    create_argument_parser,
+    GeneralErrorExit,
+    NetworkErrorExit,
+    OperationErrorExit,
+)
+from barman.cloud import CloudBackupCatalog, configure_logging
+from barman.cloud_providers import get_cloud_interface
+from barman.output import ConsoleOutputWriter
+from barman.utils import force_str
+
+
+def main(args=None):
+    """
+    The main script entry point
+
+    :param list[str] args: the raw arguments list. When not provided
+        it defaults to sys.args[1:]
+    """
+    config = parse_arguments(args)
+    configure_logging(config)
+
+    try:
+        cloud_interface = get_cloud_interface(config)
+
+        with closing(cloud_interface):
+            catalog = CloudBackupCatalog(
+                cloud_interface=cloud_interface, server_name=config.server_name
+            )
+
+            if not cloud_interface.test_connectivity():
+                raise NetworkErrorExit()
+            # If test is requested, just exit after connectivity test
+            elif config.test:
+                raise SystemExit(0)
+
+            if not cloud_interface.bucket_exists:
+                logging.error("Bucket %s does not exist", cloud_interface.bucket_name)
+                raise OperationErrorExit()
+
+            backup_id = catalog.parse_backup_id(config.backup_id)
+            backup_info = catalog.get_backup_info(backup_id)
+
+            if not backup_info:
+                logging.error(
+                    "Backup %s for server %s does not exist",
+                    backup_id,
+                    config.server_name,
+                )
+                raise OperationErrorExit()
+
+            # Output
+            if config.format == "console":
+                ConsoleOutputWriter.render_show_backup(backup_info.to_dict(), print)
+            else:
+                # Match the `barman show-backup` top level structure
+                json_output = {backup_info.server_name: backup_info.to_json()}
+                print(json.dumps(json_output))
+
+    except Exception as exc:
+        logging.error("Barman cloud backup show exception: %s", force_str(exc))
+        logging.debug("Exception details:", exc_info=exc)
+        raise GeneralErrorExit()
+
+
+def parse_arguments(args=None):
+    """
+    Parse command line arguments
+
+    :param list[str] args: The raw arguments list
+    :return: The options parsed
+    """
+
+    parser, _, _ = create_argument_parser(
+        description="This script can be used to show metadata for backups "
+        "made with barman-cloud-backup command. "
+        "Currently AWS S3, Azure Blob Storage and Google Cloud Storage are supported.",
+    )
+    parser.add_argument("backup_id", help="the backup ID")
+
+    parser.add_argument(
+        "--format",
+        default="console",
+        help="Output format (console or json). Default console.",
+    )
+    return parser.parse_args(args=args)
+
+
+if __name__ == "__main__":
+    main()

--- a/barman/clients/cloud_cli.py
+++ b/barman/clients/cloud_cli.py
@@ -61,6 +61,22 @@ class UrlArgumentType(object):
     destination = "destination"
 
 
+def get_missing_attrs(config, attrs):
+    """
+    Returns list of each attr not found in config.
+
+    :param argparse.Namespace config: The backup options provided at the command line.
+    :param list[str] attrs: List of attribute names to be searched for in the config.
+    :rtype: list[str]
+    :return: List of all items in attrs which were not found as attributes of config.
+    """
+    missing_options = []
+    for attr in attrs:
+        if not getattr(config, attr):
+            missing_options.append(attr)
+    return missing_options
+
+
 def __parse_tag(tag):
     """Parse key,value tag with csv reader"""
     try:

--- a/barman/clients/cloud_restore.py
+++ b/barman/clients/cloud_restore.py
@@ -26,10 +26,42 @@ from barman.clients.cloud_cli import (
     GeneralErrorExit,
     NetworkErrorExit,
     OperationErrorExit,
+    get_missing_attrs,
 )
 from barman.cloud import CloudBackupCatalog, configure_logging
-from barman.cloud_providers import get_cloud_interface
+from barman.cloud_providers import (
+    get_cloud_interface,
+    get_snapshot_interface_from_backup_info,
+)
+from barman.exceptions import ConfigurationException
+from barman.fs import UnixLocalCommand
+from barman.recovery_executor import SnapshotRecoveryExecutor
 from barman.utils import force_str, with_metaclass
+
+
+def _validate_config(config, backup_info):
+    """
+    Additional validation for config such as mutually inclusive options.
+
+    Raises a ConfigurationException if any options are missing or incompatible.
+
+    :param argparse.Namespace config: The backup options provided at the command line.
+    :param BackupInfo backup_info: The backup info for the backup to restore
+    """
+    if backup_info.snapshots_info:
+        missing_options = get_missing_attrs(
+            config, ("snapshot_recovery_instance", "snapshot_recovery_zone")
+        )
+        if len(missing_options) > 0:
+            raise ConfigurationException(
+                "Incomplete options for snapshot restore - missing: %s"
+                % ", ".join(missing_options)
+            )
+        if config.tablespace != []:
+            raise ConfigurationException(
+                "Backup %s is a snapshot backup therefore tablespace relocation rules "
+                "cannot be used." % backup_info.backup_id,
+            )
 
 
 def main(args=None):
@@ -68,12 +100,23 @@ def main(args=None):
                 )
                 raise OperationErrorExit()
 
-            downloader = CloudBackupDownloaderObjectStore(cloud_interface, catalog)
-            downloader.download_backup(
-                backup_info,
-                config.recovery_dir,
-                tablespace_map(config.tablespace),
-            )
+            _validate_config(config, backup_info)
+
+            if backup_info.snapshots_info:
+                downloader = CloudBackupDownloaderSnapshot(cloud_interface, catalog)
+                downloader.download_backup(
+                    backup_info,
+                    config.recovery_dir,
+                    config.snapshot_recovery_instance,
+                    config.snapshot_recovery_zone,
+                )
+            else:
+                downloader = CloudBackupDownloaderObjectStore(cloud_interface, catalog)
+                downloader.download_backup(
+                    backup_info,
+                    config.recovery_dir,
+                    tablespace_map(config.tablespace),
+                )
 
     except KeyboardInterrupt as exc:
         logging.error("Barman cloud restore was interrupted by the user")
@@ -105,6 +148,14 @@ def parse_arguments(args=None):
         metavar="NAME:LOCATION",
         action="append",
         default=[],
+    )
+    parser.add_argument(
+        "--snapshot-recovery-instance",
+        help="Instance where the disks recovered from the snapshots are attached",
+    )
+    parser.add_argument(
+        "--snapshot-recovery-zone",
+        help="Zone containing the instance and disks for the snapshot recovery",
     )
     return parser.parse_args(args=args)
 
@@ -247,6 +298,41 @@ class CloudBackupDownloaderObjectStore(CloudBackupDownloader):
         wal_path = os.path.join(destination_dir, backup_info.wal_directory())
         if not os.path.exists(wal_path):
             os.mkdir(wal_path)
+
+
+class CloudBackupDownloaderSnapshot(CloudBackupDownloader):
+    """A minimal downloader for cloud backups which just retrieves the backup label."""
+
+    def download_backup(
+        self, backup_info, destination_dir, recovery_instance, recovery_zone
+    ):
+        """
+        Download a backup from cloud storage
+
+        :param BackupInfo backup_info: The backup info for the backup to restore
+        :param str destination_dir: Path to the destination directory
+        :param str recovery_instance: The name of the VM instance to which the disks
+            cloned from the backup snapshots are attached.
+        :param str recovery_zone: The zone in which the recovery disks and instance
+            reside.
+        """
+        snapshot_interface = get_snapshot_interface_from_backup_info(backup_info)
+        attached_snapshots = SnapshotRecoveryExecutor.get_attached_snapshots_for_backup(
+            snapshot_interface, backup_info, recovery_instance, recovery_zone
+        )
+        cmd = UnixLocalCommand()
+        SnapshotRecoveryExecutor.check_mount_points(
+            backup_info, attached_snapshots, cmd
+        )
+        SnapshotRecoveryExecutor.check_recovery_dir_exists(destination_dir, cmd)
+
+        # If the target directory does not exist then we will fail here because
+        # it tells us the snapshot has not been restored.
+        return self.cloud_interface.download_file(
+            "/".join((self.catalog.prefix, backup_info.backup_id, "backup_label")),
+            os.path.join(destination_dir, "backup_label"),
+            decompress=None,
+        )
 
 
 if __name__ == "__main__":

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -1972,6 +1972,23 @@ class CloudSnapshotInterface(with_metaclass(ABCMeta)):
         """
 
     @abstractmethod
+    def get_attached_snapshots(self, instance_name, zone):
+        """
+        Returns the snapshots which are sources for disks attached to instance.
+
+        Implementations must return each snapshot which is the source for a disk
+        attache to the instance along with the device path at which it is attached.
+
+        :param str instance_name: The name of the VM instance to which the disks
+            to be backed up are attached.
+        :param str zone: The zone in which the snapshot disks and instance reside.
+        :rtype: dict[str,str]
+        :return: A dict where the key is the snapshot name and the value is the
+            device path for the source disk for that snapshot on the specified
+            instance.
+        """
+
+    @abstractmethod
     def instance_exists(self, instance_name, zone):
         """
         Determine whether the named instance exists in the specified zone.

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -1900,3 +1900,289 @@ class CloudBackupCatalog(KeepManagerMixinCloud):
                     raise SystemExit(1)
 
         return backup_files
+
+
+class CloudSnapshotInterface(with_metaclass(ABCMeta)):
+    """Defines a common interface for handling cloud snapshots."""
+
+    @abstractmethod
+    def take_snapshot(self, backup_info, disk_zone, disk_name):
+        """
+        Take a snapshot of a disk in the cloud.
+
+        :param barman.infofile.LocalBackupInfo backup_info: Backup information.
+        :param str disk_zone: The zone in which the disk resides.
+        :param str disk_name: The name of the source disk for the snapshot.
+        :rtype: str
+        :return: The name used to reference the snapshot with the cloud provider.
+        """
+
+    @abstractmethod
+    def take_snapshot_backup(self, backup_info, instance_name, zone, disks):
+        """
+        Take a snapshot backup for the named instance.
+
+        Implementations of this method must do the following:
+
+            * Create a snapshot of the disk.
+            * Set the snapshots_info field of the backup_info to a SnapshotsInfo
+              implementation which contains the snapshot metadata required both
+              by Barman and any third party tooling which needs to recover the
+              snapshots.
+
+        :param barman.infofile.LocalBackupInfo backup_info: Backup information.
+        :param str instance_name: The name of the VM instance to which the disks
+            to be backed up are attached.
+        :param str zone: The zone in which the snapshot disks and instance reside.
+        :param list[str] disks: A list containing the names of the source disks.
+        """
+
+    @abstractmethod
+    def delete_snapshot(self, snapshot_identifier):
+        """
+        Delete the specified snapshot.
+
+        :param str snapshot_identifier: An identifier used to reference this snapshot
+            within the cloud provider API.
+        """
+
+    @abstractmethod
+    def delete_snapshot_backup(self, backup_info):
+        """
+        Delete all snapshots for the supplied backup.
+
+        :param barman.infofile.LocalBackupInfo backup_info: Backup information.
+        """
+
+    @abstractmethod
+    def get_attached_devices(self, instance_name, zone):
+        """
+        Returns the non-boot devices attached to instance_name in zone.
+
+        Implementations must return a dict where the key is the name of the attached
+        disk and the value is the full path to the device at which the disk is attached
+        on the instance.
+
+        :param str instance_name: The name of the VM instance to which the disks
+            to be backed up are attached.
+        :param str zone: The zone in which the snapshot disks and instance reside.
+        :rtype: dict[str,str]
+        :return: A dict where the key is the disk name and the value is the device
+            path for that disk on the specified instance.
+        """
+
+    @abstractmethod
+    def instance_exists(self, instance_name, zone):
+        """
+        Determine whether the named instance exists in the specified zone.
+
+        :param str instance_name: The name of the VM instance to which the disks
+            to be backed up are attached.
+        :param str zone: The zone in which the snapshot disks and instance reside.
+        :rtype: bool
+        :return: True if the named instance exists in zone, False otherwise.
+        """
+
+
+class SnapshotMetadata(object):
+    """
+    Represents metadata for a single snapshot.
+
+    This class holds the snapshot metadata common to all snapshot providers.
+    Currently this is the mount_options and the mount_point of the source disk for the
+    snapshot at the time of the backup.
+
+    The `identifier` and `device` properties are part of the public interface used
+    within Barman so that the calling code can access the snapshot identifier and
+    device path without having to worry about how these are composed from the snapshot
+    metadata for each cloud provider.
+
+    Specializations of this class must:
+
+        1. Add their provider-specific fields to `_provider_fields`.
+        2. Implement the `identifier` abstract property so that it returns a value which
+           can identify the snapshot via the cloud provider API. An example would be
+           the snapshot short name in GCP.
+        3. Implement the `device` abstract property so that it returns a full device
+           path to the location at which the source disk was attached to the compute
+           instance.
+    """
+
+    _provider_fields = ()
+
+    def __init__(self, mount_options=None, mount_point=None):
+        """
+        Constructor accepts properties generic to all snapshot providers.
+
+        :param str mount_options: The mount options used for the source disk at the
+            time of the backup.
+        :param str mount_point: The mount point of the source disk at the time of
+            the backup.
+        """
+        self.mount_options = mount_options
+        self.mount_point = mount_point
+
+    @classmethod
+    def from_dict(cls, info):
+        """
+        Create a new SnapshotMetadata object from the raw metadata dict.
+
+        This function will set the generic fields supported by SnapshotMetadata before
+        iterating through fields listed in `cls._provider_fields`. This means
+        subclasses do not need to override this method, they just need to add their
+        fields to their own `_provider_fields`.
+
+        :param dict[str,str] info: The raw snapshot metadata.
+        :rtype: SnapshotMetadata
+        """
+        snapshot_info = cls()
+        if "mount" in info:
+            for field in ("mount_options", "mount_point"):
+                try:
+                    setattr(snapshot_info, field, info["mount"][field])
+                except KeyError:
+                    pass
+        for field in cls._provider_fields:
+            try:
+                setattr(snapshot_info, field, info["provider"][field])
+            except KeyError:
+                pass
+        return snapshot_info
+
+    def to_dict(self):
+        """
+        Seralize this SnapshotMetadata object as a raw dict.
+
+        This function will create a dict with the generic fields supported by
+        SnapshotMetadata before iterating through fields listed in
+        `self._provider_fields` and adding them to a special `provider` field.
+        As long as they add their provider-specific fields to `_provider_fields`
+        then subclasses do not need to override this method.
+
+        :rtype: dict
+        :return: A dict containing the metadata for this snapshot.
+        """
+        info = {
+            "mount": {
+                "mount_options": self.mount_options,
+                "mount_point": self.mount_point,
+            },
+        }
+        if len(self._provider_fields) > 0:
+            info["provider"] = {}
+            for field in self._provider_fields:
+                info["provider"][field] = getattr(self, field)
+        return info
+
+    @abstractproperty
+    def identifier(self):
+        """
+        An identifier which can reference the snapshot via the cloud provider.
+
+        Subclasses must ensure this returns a string which can be used by Barman to
+        reference the snapshot when interacting with the cloud provider API.
+
+        :rtype: str
+        :return: A snapshot identifier.
+        """
+
+    @abstractproperty
+    def device(self):
+        """
+        The device path to the source disk on the compute instance at the time the
+        backup was taken.
+
+        Subclasses must ensure this returns a full path. Certain cloud platforms,
+        such as GCP, provide only a short name which must be forged into a full path.
+        Such forging should take place here.
+
+        :rtype: str
+        :return: The device path.
+        """
+
+
+class SnapshotsInfo(object):
+    """
+    Represents the snapshots_info field of backup metadata stored in BackupInfo.
+
+    This class holds the metadata for a snapshot backup which is common to all
+    snapshot providers. This is the list of SnapshotMetadata objects representing the
+    individual snapshots.
+
+    Specializations of this class must:
+
+        1. Add their provider-specific fields to `_provider_fields`.
+        2. Set their `_snapshot_metadata_cls` property to the required specialization of
+           SnapshotMetadata.
+        3. Set the provider property to the required value.
+    """
+
+    _provider_fields = ()
+    _snapshot_metadata_cls = SnapshotMetadata
+
+    def __init__(self, snapshots=None):
+        """
+        Constructor saves the list of snapshots if it is provided.
+
+        :param list[SnapshotMetadata] snapshots: A list of metadata objects for each
+            snapshot.
+        """
+        if snapshots is None:
+            snapshots = []
+        self.snapshots = snapshots
+        self.provider = None
+
+    @classmethod
+    def from_dict(cls, info):
+        """
+        Create a new SnapshotsInfo object from the raw metadata dict.
+
+        This function will iterate through fields listed in `cls._provider_fields`
+        and add them to the instantiated object. It will then create a new
+        SnapshotMetadata object (of the type specified in `cls._snapshot_metadata_cls`)
+        for each snapshot in the raw dict.
+
+        Subclasses do not need to override this method, they just need to add their
+        fields to their own `_provider_fields` and override `_snapshot_metadata_cls`.
+
+        :param dict info: The raw snapshots_info dict.
+        :rtype: SnapshotsInfo
+        :return: The SnapshotsInfo object representing the raw dict.
+        """
+        snapshots_info = cls()
+        for field in cls._provider_fields:
+            try:
+                setattr(snapshots_info, field, info["provider_info"][field])
+            except KeyError:
+                pass
+        snapshots_info.snapshots = [
+            cls._snapshot_metadata_cls.from_dict(snapshot_info)
+            for snapshot_info in info["snapshots"]
+        ]
+        return snapshots_info
+
+    def to_dict(self):
+        """
+        Seralize this SnapshotMetadata object as a raw dict.
+
+        This function will create a dict with the generic fields supported by
+        SnapshotMetadata before iterating through fields listed in
+        `self._provider_fields` and adding them to a special `provider_info` field.
+        The SnapshotMetadata objects in `self.snapshots` are serialized into the
+        dict via their own `to_dict` function.
+
+        As long as they add their provider-specific fields to `_provider_fields`
+        then subclasses do not need to override this method.
+
+        :rtype: dict
+        :return: A dict containing the metadata for this snapshot.
+        """
+        info = {"provider": self.provider}
+        if len(self._provider_fields) > 0:
+            info["provider_info"] = {}
+            for field in self._provider_fields:
+                info["provider_info"][field] = getattr(self, field)
+        info["snapshots"] = [
+            snapshot_info.to_dict() for snapshot_info in self.snapshots
+        ]
+        return info

--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -133,6 +133,32 @@ def get_cloud_interface(config):
         )
 
 
+def get_snapshot_interface(config):
+    """
+    Factory function that creates CloudSnapshotInterface for the cloud provider
+    specified in the supplied config.
+
+    :param argparse.Namespace config: The backup options provided at the command line.
+    :rtype: CloudSnapshotInterface
+    :returns: A CloudSnapshotInterface for the specified snapshot_provider.
+    """
+    if config.cloud_provider == "google-cloud-storage":
+        from barman.cloud_providers.google_cloud_storage import (
+            GcpCloudSnapshotInterface,
+        )
+
+        if config.snapshot_gcp_project is None:
+            raise ConfigurationException(
+                "--snapshot-gcp-project option must be set for snapshot backups "
+                "when cloud provider is google-cloud-storage"
+            )
+        return GcpCloudSnapshotInterface(config.snapshot_gcp_project)
+    else:
+        raise CloudProviderUnsupported(
+            "No snapshot provider for cloud provider: %s" % config.cloud_provider
+        )
+
+
 def get_snapshot_interface_from_server_config(server_config):
     """
     Factory function that creates CloudSnapshotInterface for the snapshot provider

--- a/barman/config.py
+++ b/barman/config.py
@@ -66,7 +66,7 @@ _SI_SUFFIX_RE = re.compile(r"""(\d+)\s*(k|Ki|M|Mi|G|Gi|T|Ti)?\s*$""")
 REUSE_BACKUP_VALUES = ("copy", "link", "off")
 
 # Possible copy methods for backups (must be all lowercase)
-BACKUP_METHOD_VALUES = ["rsync", "postgres", "local-rsync"]
+BACKUP_METHOD_VALUES = ["rsync", "postgres", "local-rsync", "snapshot"]
 
 CREATE_SLOT_VALUES = ["manual", "auto"]
 
@@ -384,6 +384,22 @@ def parse_slot_name(value):
     return value
 
 
+def parse_snapshot_disks(value):
+    """
+    Parse a comma separated list of names used to reference disks managed by a cloud
+    provider.
+
+    :param str value: Comma separated list of disk names
+    :return: List of disk names
+    """
+    disk_names = value.split(",")
+    # Verify each parsed disk is not an empty string
+    for disk_name in disk_names:
+        if disk_name == "":
+            raise ValueError(disk_names)
+    return disk_names
+
+
 def parse_create_slot(value):
     """
     Parse a string to a valid create_slot value.
@@ -474,6 +490,11 @@ class ServerConfig(object):
         "retention_policy_mode",
         "reuse_backup",
         "slot_name",
+        "snapshot_disks",
+        "snapshot_gcp_project",
+        "snapshot_instance",
+        "snapshot_provider",
+        "snapshot_zone",
         "ssh_command",
         "streaming_archiver",
         "streaming_archiver_batch_size",
@@ -543,6 +564,8 @@ class ServerConfig(object):
         "retention_policy_mode",
         "reuse_backup",
         "slot_name",
+        "snapshot_gcp_project",
+        "snapshot_provider",
         "streaming_archiver",
         "streaming_archiver_batch_size",
         "streaming_archiver_name",
@@ -614,6 +637,7 @@ class ServerConfig(object):
         "recovery_staging_path": parse_recovery_staging_path,
         "create_slot": parse_create_slot,
         "reuse_backup": parse_reuse_backup,
+        "snapshot_disks": parse_snapshot_disks,
         "streaming_archiver": parse_boolean,
         "streaming_archiver_batch_size": int,
         "slot_name": parse_slot_name,

--- a/barman/exceptions.py
+++ b/barman/exceptions.py
@@ -116,6 +116,12 @@ class BackupInfoBadInitialisation(BackupException):
     """
 
 
+class SnapshotBackupException(BackupException):
+    """
+    Exception for snapshot backups
+    """
+
+
 class SyncError(SyncException):
     """
     Synchronisation error

--- a/barman/exceptions.py
+++ b/barman/exceptions.py
@@ -364,6 +364,12 @@ class RecoveryException(BarmanException):
     """
 
 
+class RecoveryPreconditionException(RecoveryException):
+    """
+    Exception for a recovery precondition not being met
+    """
+
+
 class RecoveryTargetActionException(RecoveryException):
     """
     Exception for a wrong recovery target action

--- a/barman/exceptions.py
+++ b/barman/exceptions.py
@@ -116,6 +116,12 @@ class BackupInfoBadInitialisation(BackupException):
     """
 
 
+class BackupPreconditionException(BackupException):
+    """
+    Exception for a backup precondition not being met
+    """
+
+
 class SnapshotBackupException(BackupException):
     """
     Exception for snapshot backups

--- a/barman/fs.py
+++ b/barman/fs.py
@@ -343,6 +343,31 @@ class UnixLocalCommand(object):
         self.cmd("ls", args=ls_options)
         return self.internal_cmd.out
 
+    def findmnt(self, device):
+        """
+        Retrieve the mount point and mount options for the provided device.
+
+        :param str device: The device for which the mount point and options should
+            be found.
+        :rtype: List[str|None, str|None]
+        :return: The mount point and the mount options of the specified device or
+            [None, None] if the device could not be found by findmnt.
+        """
+        _logger.debug("finding mount point and options for device %s", device)
+        self.cmd("findmnt", args=("-o", "TARGET,OPTIONS", "-n", device))
+        output = self.internal_cmd.out
+        if output == "":
+            # No output means we successfully ran the command but couldn't find
+            # the mount point
+            return [None, None]
+        output_fields = output.split()
+        if len(output_fields) != 2:
+            raise FsOperationFailed(
+                "Unexpected findmnt output: %s" % self.internal_cmd.out
+            )
+        else:
+            return output_fields
+
 
 class UnixRemoteCommand(UnixLocalCommand):
     """

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -1235,7 +1235,70 @@ class RecoveryExecutor(object):
         self.temp_dirs = []
 
 
-class TarballRecoveryExecutor(RecoveryExecutor):
+class RemoteConfigRecoveryExecutor(RecoveryExecutor):
+    """
+    Recovery executor which retrieves config files from the recovery directory
+    instead of the backup directory. Useful when the config files are not available
+    in the backup directory (e.g. compressed backups).
+    """
+
+    def _conf_files_exist(self, conf_files, backup_info, recovery_info):
+        """
+        Determine whether the conf files in the supplied list exist in the backup
+        represented by backup_info.
+
+        :param list[str] conf_files: List of config files to be checked.
+        :param BackupInfo backup_info: Backup information for the backup being
+            recovered.
+        :param dict recovery_info: Dictionary of recovery information.
+        :rtype: dict[str,bool]
+        :return: A dict representing a map of conf_file:exists.
+        """
+        exists = {}
+        for conf_file in conf_files:
+            source_path = os.path.join(recovery_info["destination_path"], conf_file)
+            exists[conf_file] = recovery_info["cmd"].exists(source_path)
+        return exists
+
+    def _copy_conf_files_to_tempdir(
+        self, backup_info, recovery_info, remote_command=None
+    ):
+        """
+        Copy conf files from the backup location to a temporary directory so that
+        they can be checked and mangled.
+
+        :param BackupInfo backup_info: Backup information for the backup being
+            recovered.
+        :param dict recovery_info: Dictionary of recovery information.
+        :param str remote_command: The ssh command to be used when copying the files.
+        :rtype: list[str]
+        :return: A list of paths to the destination conf files.
+        """
+        conf_file_paths = []
+
+        rsync = RsyncPgData(
+            path=self.server.path,
+            ssh=remote_command,
+            bwlimit=self.config.bandwidth_limit,
+            network_compression=self.config.network_compression,
+        )
+
+        rsync.from_file_list(
+            recovery_info["configuration_files"],
+            ":" + recovery_info["destination_path"],
+            recovery_info["tempdir"],
+        )
+
+        conf_file_paths.extend(
+            [
+                os.path.join(recovery_info["tempdir"], conf_file)
+                for conf_file in recovery_info["configuration_files"]
+            ]
+        )
+        return conf_file_paths
+
+
+class TarballRecoveryExecutor(RemoteConfigRecoveryExecutor):
     """
     A specialised recovery method for compressed backups.
     Inheritence is not necessarily the best thing here since the two RecoveryExecutor
@@ -1382,51 +1445,6 @@ class TarballRecoveryExecutor(RecoveryExecutor):
             base_src_path, dest, exclude=["recovery.conf", "tablespace_map"]
         )
         _logger.debug("Uncompression output for base tarball: %s", cmd_output)
-
-    def _conf_files_exist(self, conf_files, backup_info, recovery_info):
-        """
-        Determine whether the conf files in the supplied list exist in the backup
-        represented by backup_info.
-
-        Returns a map of conf_file:exists.
-        """
-        exists = {}
-        for conf_file in conf_files:
-            source_path = os.path.join(recovery_info["destination_path"], conf_file)
-            exists[conf_file] = recovery_info["cmd"].exists(source_path)
-        return exists
-
-    def _copy_conf_files_to_tempdir(
-        self, backup_info, recovery_info, remote_command=None
-    ):
-        """
-        Copy conf files from the backup location to a temporary directory so that
-        they can be checked and mangled.
-
-        Returns a list of the paths to the temporary conf files.
-        """
-        conf_file_paths = []
-
-        rsync = RsyncPgData(
-            path=self.server.path,
-            ssh=remote_command,
-            bwlimit=self.config.bandwidth_limit,
-            network_compression=self.config.network_compression,
-        )
-
-        rsync.from_file_list(
-            recovery_info["configuration_files"],
-            ":" + recovery_info["destination_path"],
-            recovery_info["tempdir"],
-        )
-
-        conf_file_paths.extend(
-            [
-                os.path.join(recovery_info["tempdir"], conf_file)
-                for conf_file in recovery_info["configuration_files"]
-            ]
-        )
-        return conf_file_paths
 
 
 def recovery_executor_factory(backup_manager, command, compression=None):

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,13 @@ setup(
         "google": [
             "google-cloud-storage",
         ],
+        # The google-cloud-compute library does not support python 2.7 in any version
+        # so google snapshots extras are in their own section to avoid breaking GCS
+        # for anyone unfortunate enough to still be using python 2.7.
+        "google-snapshots": [
+            "grpcio",
+            "google-cloud-compute",
+        ],
     },
     platforms=["Linux", "Mac OS X"],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
             "barman-cloud-backup-delete=barman.clients.cloud_backup_delete:main",
             "barman-cloud-backup-keep=barman.clients.cloud_backup_keep:main",
             "barman-cloud-backup-list=barman.clients.cloud_backup_list:main",
+            "barman-cloud-backup-show=barman.clients.cloud_backup_show:main",
             "barman-cloud-check-wal-archive=barman.clients.cloud_check_wal_archive:main",
             "barman-wal-archive=barman.clients.walarchive:main",
             "barman-wal-restore=barman.clients.walrestore:main",

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -26,6 +26,7 @@ import dateutil.tz
 import mock
 import pytest
 from mock import Mock, patch
+from barman.backup import BackupManager
 
 import barman.utils
 from barman.annotations import KeepManager
@@ -40,6 +41,7 @@ from barman.retention_policies import RetentionPolicyFactory
 from testing_helpers import (
     build_backup_directories,
     build_backup_manager,
+    build_mocked_server,
     build_test_backup_info,
     caplog_reset,
     interpolate_wals,
@@ -1593,3 +1595,75 @@ class TestVerifyBackup:
         backup_manager.verify_backup(mock_backup_info)
 
         mock_pg_verify_backup_instance.get_output.assert_not_called()
+
+
+class TestSnapshotBackup(object):
+    """Test handling of snapshot backups by BackupManager."""
+
+    @patch("barman.backup.SnapshotBackupExecutor")
+    def test_snapshot_backup_method(self, mock_snapshot_executor):
+        """
+        Verify that a SnapshotBackupExecutor is created for backup_method "snapshot".
+        """
+        # GIVEN a server with backup_method = "snapshot"
+        server = build_mocked_server(
+            "test_server", main_conf={"backup_method": "snapshot"}
+        )
+        # WHEN a BackupManager is created for that server
+        manager = BackupManager(server=server)
+        # THEN its executor is a SnapshotBackupExecutor
+        assert manager.executor == mock_snapshot_executor.return_value
+
+    @patch("barman.backup.os")
+    @patch("barman.backup.shutil")
+    @patch("barman.backup.get_snapshot_interface_from_backup_info")
+    @patch("barman.backup.BackupManager.remove_wal_before_backup")
+    @patch("barman.backup.BackupManager.get_available_backups")
+    def test_snapshot_delete(
+        self,
+        mock_get_available_backups,
+        mock_remove_wal_before_backup,
+        mock_get_snapshot_interface,
+        mock_shutil,
+        mock_os,
+        caplog,
+    ):
+        """
+        Verify that the snapshots are deleted via the snapshot interface.
+        """
+        # GIVEN a backup manager
+        backup_manager = build_backup_manager()
+        backup_manager.server.config.name = "test_server"
+        backup_manager.server.config.minimum_redundancy = 0
+        # WITH a single snapshot backup
+        backup_info = build_test_backup_info(
+            backup_id="test_backup_id",
+            server=backup_manager.server,
+            snapshots_info=mock.Mock(snapshots=[mock.Mock(identifier="test_snapshot")]),
+            tablespaces=[("tbs1", 16385, "/tbs1")],
+        )
+        mock_get_available_backups.return_value = {backup_info.backup_id: backup_info}
+
+        # WHEN the backup is deleted
+        delete_result = backup_manager.delete_backup(backup_info)
+
+        # THEN the deletion is successful
+        assert delete_result is True
+        # AND the snapshots were deleted via the snapshot interface
+        mock_get_snapshot_interface.assert_called_once_with(backup_info)
+        mock_snapshot_interface = mock_get_snapshot_interface.return_value
+        mock_snapshot_interface.delete_snapshot_backup.assert_called_once_with(
+            backup_info
+        )
+        # AND rmtree was called twice in total
+        assert mock_shutil.rmtree.call_count == 2
+        # AND rmtree was called on the data directory
+        assert (
+            mock_shutil.rmtree.call_args_list[0][0][0]
+            == backup_info.get_data_directory()
+        )
+        # AND rmtree was called on the base directory
+        assert (
+            mock_shutil.rmtree.call_args_list[1][0][0]
+            == backup_info.get_basebackup_directory()
+        )

--- a/tests/test_barman_cloud_backup.py
+++ b/tests/test_barman_cloud_backup.py
@@ -38,7 +38,7 @@ class TestCloudBackup(object):
     )
     @mock.patch("barman.clients.cloud_backup.PostgreSQLConnection")
     @mock.patch("barman.clients.cloud_backup.get_cloud_interface")
-    @mock.patch("barman.clients.cloud_backup.CloudBackupUploaderPostgres")
+    @mock.patch("barman.clients.cloud_backup.CloudBackupUploader")
     def test_uses_postgres_backup_uploader(
         self,
         uploader_mock,
@@ -63,7 +63,7 @@ class TestCloudBackup(object):
 
     @mock.patch("barman.clients.cloud_backup.PostgreSQLConnection")
     @mock.patch("barman.clients.cloud_backup.get_cloud_interface")
-    @mock.patch("barman.clients.cloud_backup.CloudBackupUploaderPostgres")
+    @mock.patch("barman.clients.cloud_backup.CloudBackupUploader")
     def test_name_option_success(
         self,
         uploader_mock,
@@ -94,7 +94,7 @@ class TestCloudBackup(object):
     )
     @mock.patch("barman.clients.cloud_backup.PostgreSQLConnection")
     @mock.patch("barman.clients.cloud_backup.get_cloud_interface")
-    @mock.patch("barman.clients.cloud_backup.CloudBackupUploaderPostgres")
+    @mock.patch("barman.clients.cloud_backup.CloudBackupUploader")
     def test_name_option_validation_failure(
         self,
         uploader_mock,

--- a/tests/test_barman_cloud_backup_delete.py
+++ b/tests/test_barman_cloud_backup_delete.py
@@ -128,7 +128,7 @@ class TestCloudBackupDelete(object):
                 }
             )
             backup_metadata[backup_id]["files"] = mock_backup_files
-            backup_info = mock.MagicMock(name="backup_info")
+            backup_info = mock.MagicMock(name="backup_info", snapshots_info=None)
             backup_info.backup_id = backup_id
             if backup_name:
                 backup_info.backup_name = backup_name
@@ -305,6 +305,51 @@ class TestCloudBackupDelete(object):
         # that backup and the backup.info file for that backup
         self._verify_only_these_backups_deleted(
             get_cloud_interface_mock, backup_metadata, [backup_id]
+        )
+
+    @mock.patch("barman.clients.cloud_backup_delete.CloudBackupCatalog")
+    @mock.patch(
+        "barman.clients.cloud_backup_delete.get_snapshot_interface_from_backup_info"
+    )
+    @mock.patch("barman.clients.cloud_backup_delete.get_cloud_interface")
+    def test_delete_snapshot_backup(
+        self,
+        get_cloud_interface_mock,
+        get_snapshot_interface_mock,
+        cloud_backup_catalog_mock,
+    ):
+        """
+        Tests that snapshots are deleted if the backup has snapshots_info.
+        """
+        # GIVEN a backup catalog with one named backup and no WALs
+        backup_id = "20210723T095432"
+        backup_metadata = self._create_backup_metadata([(backup_id, "backup name")])
+        # AND a backup_info with multiple snapshots
+        backup_info = backup_metadata[backup_id]["info"]
+        snapshots = [
+            mock.Mock(identifier="snapshot0"),
+            mock.Mock(identifier="snapshot1"),
+            mock.Mock(identifier="snapshot2"),
+        ]
+        backup_info.snapshots_info = mock.Mock(snapshots=snapshots)
+
+        # AND a CloudBackupCatalog which returns the backup_info for only that backup
+        cloud_backup_catalog_mock.return_value = self._create_catalog(backup_metadata)
+
+        # WHEN barman-cloud-backup-delete runs
+        cloud_backup_delete.main(
+            ["cloud_storage_url", "test_server", "--backup-id", "20210723T095432"]
+        )
+
+        # THEN the cloud interface was only used to delete the files associated with
+        # that backup and the backup.info file for that backup
+        self._verify_only_these_backups_deleted(
+            get_cloud_interface_mock, backup_metadata, [backup_id]
+        )
+        # AND delete_snapshot_backup was called for the backup
+        mock_snapshots_interface = get_snapshot_interface_mock.return_value
+        mock_snapshots_interface.delete_snapshot_backup.assert_called_once_with(
+            backup_info
         )
 
     @pytest.mark.parametrize("backup_id_arg", ("20210723T095432", "backup name"))

--- a/tests/test_barman_cloud_backup_show.py
+++ b/tests/test_barman_cloud_backup_show.py
@@ -1,0 +1,301 @@
+# -*- coding: utf-8 -*-
+# © Copyright EnterpriseDB UK Limited 2013-2022
+#
+# Client Utilities for Barman, Backup and Recovery Manager for PostgreSQL
+#
+# Barman is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Barman is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Barman.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+import json
+import mock
+import pytest
+
+from barman.clients import cloud_backup_show
+from barman.clients.cloud_cli import OperationErrorExit
+from barman.cloud_providers.google_cloud_storage import (
+    GcpSnapshotMetadata,
+    GcpSnapshotsInfo,
+)
+from testing_helpers import build_test_backup_info
+
+
+class TestCloudBackupShow(object):
+    @pytest.fixture
+    def backup_id(self):
+        yield "20380119T031408"
+
+    @pytest.fixture
+    def cloud_backup_catalog(self, backup_id):
+        backup_info = build_test_backup_info(
+            backup_id="backup_id_1",
+            begin_time=datetime.datetime(2038, 1, 19, 3, 14, 8),
+            begin_wal="000000010000000000000002",
+            end_time=datetime.datetime(2038, 1, 19, 4, 14, 8),
+            end_wal="000000010000000000000004",
+            size=None,
+            snapshots_info=GcpSnapshotsInfo(
+                project="test_project",
+                snapshots=[
+                    GcpSnapshotMetadata(
+                        mount_point="/opt/disk0",
+                        mount_options="rw,noatime",
+                        device_name="dev0",
+                        snapshot_name="snapshot0",
+                        snapshot_project="test_project",
+                    ),
+                    GcpSnapshotMetadata(
+                        mount_point="/opt/disk1",
+                        mount_options="rw",
+                        device_name="dev1",
+                        snapshot_name="snapshot1",
+                        snapshot_project="test_project",
+                    ),
+                ],
+            ),
+            version=150000,
+        )
+        backup_info.mode = "concurrent"
+        cloud_backup_catalog = mock.Mock()
+        cloud_backup_catalog.get_backup_list.return_value = {backup_id: backup_info}
+        cloud_backup_catalog.get_backup_info.return_value = backup_info
+        yield cloud_backup_catalog
+
+    @mock.patch("barman.clients.cloud_backup_show.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_show.get_cloud_interface")
+    def test_cloud_backup_show(
+        self,
+        _mock_get_cloud_interface,
+        mock_cloud_backup_catalog,
+        cloud_backup_catalog,
+        backup_id,
+        capsys,
+    ):
+        """
+        Verify plain output of barman-cloud-backup-show for a backup.
+        """
+        # GIVEN a backup catalog with a single backup
+        mock_cloud_backup_catalog.return_value = cloud_backup_catalog
+        # WHEN barman_cloud_backup_show is called for that backup
+        cloud_backup_show.main(["cloud_storage_url", "test_server", backup_id])
+        # THEN the expected output is printed
+        out, _err = capsys.readouterr()
+        assert out == (
+            "Backup backup_id_1:\n"
+            "  Server Name            : main\n"
+            "  Status                 : DONE\n"
+            "  PostgreSQL Version     : 150000\n"
+            "  PGDATA directory       : /pgdata/location\n"
+            "\n"
+            "  Snapshot information:\n"
+            "    provider             : gcp\n"
+            "    project              : test_project\n"
+            "\n"
+            "    device_name          : dev0\n"
+            "    snapshot_name        : snapshot0\n"
+            "    snapshot_project     : test_project\n"
+            "    Mount point          : /opt/disk0\n"
+            "    Mount options        : rw,noatime\n"
+            "\n"
+            "    device_name          : dev1\n"
+            "    snapshot_name        : snapshot1\n"
+            "    snapshot_project     : test_project\n"
+            "    Mount point          : /opt/disk1\n"
+            "    Mount options        : rw\n"
+            "\n"
+            "  Tablespaces:\n"
+            "    tbs1                 : /fake/location (oid: 16387)\n"
+            "    tbs2                 : /another/location (oid: 16405)\n"
+            "\n"
+            "  Base backup information:\n"
+            "    Timeline             : 1\n"
+            "    Begin WAL            : 000000010000000000000002\n"
+            "    End WAL              : 000000010000000000000004\n"
+            "    Begin time           : 2038-01-19 03:14:08\n"
+            "    End time             : 2038-01-19 04:14:08\n"
+            "    Begin Offset         : 40\n"
+            "    End Offset           : 184\n"
+            "    Begin LSN            : 0/2000028\n"
+            "    End LSN              : 0/20000B8\n"
+            "\n"
+        )
+
+    @mock.patch("barman.clients.cloud_backup_show.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_show.get_cloud_interface")
+    def test_cloud_backup_show_json(
+        self,
+        _mock_get_cloud_interface,
+        mock_cloud_backup_catalog,
+        cloud_backup_catalog,
+        backup_id,
+        capsys,
+    ):
+        """
+        Verify json output of barman-cloud-backup-show for a backup.
+        """
+        # GIVEN a backup catalog with a single backup
+        mock_cloud_backup_catalog.return_value = cloud_backup_catalog
+        # WHEN barman_cloud_backup_show is called for that backup
+        cloud_backup_show.main(
+            ["cloud_storage_url", "test_server", backup_id, "--format", "json"]
+        )
+        # THEN the expected output is printed
+        out, _err = capsys.readouterr()
+        assert json.loads(out)["main"] == {
+            "backup_label": None,
+            "begin_offset": 40,
+            "begin_time": "Tue Jan 19 03:14:08 2038",
+            "begin_wal": "000000010000000000000002",
+            "begin_xlog": "0/2000028",
+            "compression": None,
+            "config_file": "/pgdata/location/postgresql.conf",
+            "copy_stats": None,
+            "deduplicated_size": None,
+            "end_offset": 184,
+            "end_time": "Tue Jan 19 04:14:08 2038",
+            "end_wal": "000000010000000000000004",
+            "end_xlog": "0/20000B8",
+            "error": None,
+            "hba_file": "/pgdata/location/pg_hba.conf",
+            "ident_file": "/pgdata/location/pg_ident.conf",
+            "included_files": None,
+            "mode": "concurrent",
+            "pgdata": "/pgdata/location",
+            "server_name": "main",
+            "size": None,
+            "snapshots_info": {
+                "provider": "gcp",
+                "provider_info": {
+                    "project": "test_project",
+                },
+                "snapshots": [
+                    {
+                        "mount": {
+                            "mount_options": "rw,noatime",
+                            "mount_point": "/opt/disk0",
+                        },
+                        "provider": {
+                            "device_name": "dev0",
+                            "snapshot_name": "snapshot0",
+                            "snapshot_project": "test_project",
+                        },
+                    },
+                    {
+                        "mount": {
+                            "mount_options": "rw",
+                            "mount_point": "/opt/disk1",
+                        },
+                        "provider": {
+                            "device_name": "dev1",
+                            "snapshot_name": "snapshot1",
+                            "snapshot_project": "test_project",
+                        },
+                    },
+                ],
+            },
+            "status": "DONE",
+            "systemid": None,
+            "tablespaces": [
+                ["tbs1", 16387, "/fake/location"],
+                ["tbs2", 16405, "/another/location"],
+            ],
+            "timeline": 1,
+            "version": 150000,
+            "xlog_segment_size": 16777216,
+            "backup_id": "backup_id_1",
+        }
+
+    @mock.patch("barman.clients.cloud_backup_show.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_backup_show.get_cloud_interface")
+    def test_cloud_backup_show_missing_backup(
+        self,
+        _mock_get_cloud_interface,
+        mock_cloud_backup_catalog,
+        backup_id,
+        caplog,
+    ):
+        """
+        Verify plain output of barman-cloud-backup-show for a backup.
+        """
+        # GIVEN a backup catalog with a single backup
+        cloud_backup_catalog = mock_cloud_backup_catalog.return_value
+        cloud_backup_catalog.get_backup_list.return_value = {}
+        cloud_backup_catalog.get_backup_info.return_value = None
+        cloud_backup_catalog.parse_backup_id.return_value = backup_id
+        # WHEN barman_cloud_backup_show is called for that backup
+        # THEN an OperationErrorExit is raised
+        with pytest.raises(OperationErrorExit):
+            cloud_backup_show.main(["cloud_storage_url", "test_server", backup_id])
+        # AND an error message was logged
+        assert (
+            "Backup {} for server test_server does not exist".format(backup_id)
+            in caplog.text
+        )
+
+    @pytest.mark.parametrize(
+        ("connectivity_test_result", "expected_exit_code"), ([False, 2], [True, 0])
+    )
+    @mock.patch("barman.clients.cloud_backup_show.get_cloud_interface")
+    def test_exits_on_connectivity_test(
+        self, get_cloud_interface_mock, connectivity_test_result, expected_exit_code
+    ):
+        """If the -t option is used we check connectivity and exit."""
+        # GIVEN a mock cloud interface
+        cloud_interface_mock = get_cloud_interface_mock.return_value
+        # AND the connectivity test returns the specified result
+        cloud_interface_mock.test_connectivity.return_value = connectivity_test_result
+
+        # WHEN cloud_backup_show is called with the `-t` option
+        with pytest.raises(SystemExit) as exc:
+            cloud_backup_show.main(
+                ["cloud_storage_url", "test_server", "backup_id", "-t"]
+            )
+
+        # THEN the expected error code is returned
+        assert exc.value.code == expected_exit_code
+        # AND the connectivity test was called
+        cloud_interface_mock.test_connectivity.assert_called_once()
+
+    @mock.patch("barman.clients.cloud_backup_show.get_cloud_interface")
+    def test_fails_if_bucket_not_found(self, get_cloud_interface_mock, caplog):
+        """If the bucket does not exist we exit with status 1."""
+        # GIVEN a mock cloud interface
+        cloud_interface_mock = get_cloud_interface_mock.return_value
+        # AND a bucket which does not exist
+        bucket_name = "missing_bucket"
+        cloud_interface_mock.bucket_name = bucket_name
+        cloud_interface_mock.bucket_exists = False
+
+        # WHEN cloud_backup_show is called against the missing bucket
+        with pytest.raises(SystemExit) as exc:
+            cloud_backup_show.main([bucket_name, "test_server", "backup_id"])
+
+        # THEN an exit code of 1 is returned
+        assert exc.value.code == 1
+        # AND the expected message is logged
+        assert "Bucket {} does not exist".format(bucket_name) in caplog.text
+
+    @mock.patch("barman.clients.cloud_backup_show.get_cloud_interface")
+    def test_fails_on_any_exception(self, get_cloud_interface_mock, caplog):
+        """If any non-specific exception occurs then we exit with status 4."""
+        # GIVEN a general exception when getting the cloud interface
+        get_cloud_interface_mock.side_effect = Exception("an error happened")
+
+        # WHEN cloud_backup_show is called with any valid args
+        with pytest.raises(SystemExit) as exc:
+            cloud_backup_show.main(["bucket", "server", "backup_id"])
+
+        # THEN an exit code of 4 is returned
+        assert exc.value.code == 4
+        # AND the exception message is logged
+        assert "an error happened" in caplog.text

--- a/tests/test_barman_cloud_restore.py
+++ b/tests/test_barman_cloud_restore.py
@@ -23,11 +23,42 @@ from barman.clients import cloud_restore
 from barman.clients.cloud_cli import OperationErrorExit
 from barman.clients.cloud_restore import (
     CloudBackupDownloaderObjectStore,
+    CloudBackupDownloaderSnapshot,
 )
 from barman.cloud import BackupFileInfo
+from barman.exceptions import RecoveryPreconditionException
 
 
 class TestCloudRestore(object):
+    @mock.patch("barman.clients.cloud_restore.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_restore.get_cloud_interface")
+    def test_cloud_backup_restore_missing_backup(
+        self,
+        _mock_get_cloud_interface,
+        mock_cloud_backup_catalog,
+        caplog,
+    ):
+        """
+        Verify plain output of barman-cloud-restore for a backup.
+        """
+        # GIVEN a backup catalog with a single backup
+        backup_id = "20201110T120000"
+        cloud_backup_catalog = mock_cloud_backup_catalog.return_value
+        cloud_backup_catalog.get_backup_list.return_value = {}
+        cloud_backup_catalog.get_backup_info.return_value = None
+        cloud_backup_catalog.parse_backup_id.return_value = backup_id
+        # WHEN barman_cloud_restore is called for that backup
+        # THEN an OperationErrorExit is raised
+        with pytest.raises(OperationErrorExit):
+            cloud_restore.main(
+                ["cloud_storage_url", "test_server", backup_id, "/path/to/dir"]
+            )
+        # AND an error message was logged
+        assert (
+            "Backup {} for server test_server does not exist".format(backup_id)
+            in caplog.text
+        )
+
     @pytest.mark.parametrize(
         ("backup_id_arg", "expected_backup_id"),
         (("20201110T120000", "20201110T120000"), ("backup name", "20201110T120000")),
@@ -48,7 +79,7 @@ class TestCloudRestore(object):
         # to the expected backup ID
         mock_catalog.return_value.parse_backup_id.return_value = expected_backup_id
         # AND the catalog returns a mock backup_info with the expected backup ID
-        mock_backup_info = mock.Mock(backup_id=expected_backup_id)
+        mock_backup_info = mock.Mock(backup_id=expected_backup_id, snapshots_info=None)
         mock_catalog.return_value.get_backup_info.return_value = mock_backup_info
 
         # WHEN barman-backup-restore is called with the backup_id_arg
@@ -62,17 +93,143 @@ class TestCloudRestore(object):
             mock_backup_info, recovery_dir, {}
         )
 
+    @pytest.mark.parametrize(
+        ("snapshot_args", "expected_error"),
+        (
+            [
+                [],
+                (
+                    "Incomplete options for snapshot restore - missing: "
+                    "snapshot_recovery_instance, snapshot_recovery_zone"
+                ),
+            ],
+            [
+                [
+                    "--snapshot-recovery-instance",
+                    "test_instance",
+                ],
+                (
+                    "Incomplete options for snapshot restore - missing: "
+                    "snapshot_recovery_zone"
+                ),
+            ],
+            [
+                [
+                    "--snapshot-recovery-zone",
+                    "test_zone",
+                ],
+                (
+                    "Incomplete options for snapshot restore - missing: "
+                    "snapshot_recovery_instance"
+                ),
+            ],
+            [
+                [
+                    "--snapshot-recovery-instance",
+                    "test_instance",
+                    "--snapshot-recovery-zone",
+                    "test_zone",
+                    "--tablespace",
+                    "tbs1:/path/to/tbs1",
+                ],
+                (
+                    "Backup {backup_id} is a snapshot backup therefore tablespace "
+                    "relocation rules cannot be used."
+                ),
+            ],
+        ),
+    )
+    @mock.patch("barman.clients.cloud_restore.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_restore.get_cloud_interface")
+    def test_unsupported_snapshot_args(
+        self,
+        _mock_cloud_interface_factory,
+        mock_catalog,
+        snapshot_args,
+        expected_error,
+        caplog,
+    ):
+        """
+        Verify that an error is raised if an unsupported set of snapshot arguments is
+        used.
+        """
+        # GIVEN a mock backup catalog where parse_backup_id will always resolve
+        # the backup ID
+        backup_id = "20380119T031408"
+        mock_catalog.return_value.parse_backup_id.return_value = backup_id
+        # AND the catalog returns a mock backup_info with a snapshots_info field
+        mock_backup_info = mock.Mock(backup_id=backup_id, snapshots_info=mock.Mock())
+        mock_catalog.return_value.get_backup_info.return_value = mock_backup_info
 
-class TestCloudBackupDownloaderObjectStore(object):
-    """Verify the cloud backup downloader for object store backups."""
+        # WHEN barman-cloud-restore is run with a subset of snapshot arguments
+        # THEN a SystemExit occurs
+        recovery_dir = "/path/to/restore_dir"
+        with pytest.raises(SystemExit):
+            cloud_restore.main(
+                ["cloud_storage_url", "test_server", backup_id, recovery_dir]
+                + snapshot_args
+            )
+        # AND the expected error message occurs
+        assert expected_error.format(**{"backup_id": backup_id}) in caplog.text
+
+    @mock.patch("barman.clients.cloud_restore.CloudBackupDownloaderSnapshot")
+    @mock.patch("barman.clients.cloud_restore.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_restore.get_cloud_interface")
+    def test_restore_snapshots_backup(
+        self,
+        mock_cloud_interface_factory,
+        mock_catalog,
+        mock_backup_downloader_snapshot,
+    ):
+        """
+        Verify that restoring a snapshots backup uses CloudBackupDownloaderSnapshot
+        to restore the backup.
+        """
+        # GIVEN a mock backup catalog where parse_backup_id will always resolve
+        # the backup ID
+        backup_id = "20380119T031408"
+        mock_catalog.return_value.parse_backup_id.return_value = backup_id
+        # AND the catalog returns a mock backup_info with a snapshots_info field
+        mock_backup_info = mock.Mock(backup_id=backup_id, snapshots_info=mock.Mock())
+        mock_catalog.return_value.get_backup_info.return_value = mock_backup_info
+
+        # WHEN barman-cloud-restore is run with the required arguments for a snapshots
+        # backup
+        recovery_dir = "/path/to/restore_dir"
+        recovery_instance = "test_instance"
+        recovery_zone = "test_zone"
+        cloud_restore.main(
+            [
+                "cloud_storage_url",
+                "test_server",
+                backup_id,
+                recovery_dir,
+                "--snapshot-recovery-instance",
+                recovery_instance,
+                "--snapshot-recovery-zone",
+                recovery_zone,
+            ]
+        )
+
+        # THEN a CloudBackupDownloaderSnapshot is created
+        mock_backup_downloader_snapshot.assert_called_once_with(
+            mock_cloud_interface_factory.return_value, mock_catalog.return_value
+        )
+        # AND download_backup is called with the expected arguments
+        backup_downloader = mock_backup_downloader_snapshot.return_value
+        backup_downloader.download_backup.assert_called_once_with(
+            mock_backup_info, recovery_dir, recovery_instance, recovery_zone
+        )
+
+
+class TestCloudBackupDownloader(object):
+    """Superclass containing common fixtures for CloudBackupDownloader tests."""
 
     backup_id = "20380119T031408"
 
     @pytest.fixture
     def backup_info(self):
-        backup_info = mock.Mock(backup_id=self.backup_id, snapshots_info=None)
-        backup_info.wal_directory.return_value = "/path/to/wals"
-        yield backup_info
+        yield mock.Mock(backup_id=self.backup_id)
 
     @pytest.fixture
     def mock_cloud_interface(self):
@@ -84,6 +241,16 @@ class TestCloudBackupDownloaderObjectStore(object):
         catalog.return_value.parse_backup_id.return_value = self.backup_id
         catalog.return_value.get_backup_info.return_value = backup_info
         yield catalog
+
+
+class TestCloudBackupDownloaderObjectStore(TestCloudBackupDownloader):
+    """Verify the cloud backup downloader for object store backups."""
+
+    @pytest.fixture
+    def backup_info(self):
+        backup_info = mock.Mock(backup_id=self.backup_id, snapshots_info=None)
+        backup_info.wal_directory.return_value = "/path/to/wals"
+        yield backup_info
 
     @mock.patch("barman.clients.cloud_restore.os.path.exists")
     def test_download_backup(
@@ -145,4 +312,158 @@ class TestCloudBackupDownloaderObjectStore(object):
         assert (
             "Destination {} already exists and it is not empty".format(recovery_dir)
             in caplog.text
+        )
+
+
+class TestCloudBackupDownloaderSnapshot(TestCloudBackupDownloader):
+    """Verify the cloud backup downloader for snapshot backups."""
+
+    snapshot_name = "snapshot0"
+    device_path = "/dev/dev0"
+    mount_point = "/opt/disk0"
+
+    @pytest.fixture
+    def snapshots_info(self):
+        yield mock.Mock(
+            snapshots=[
+                mock.Mock(
+                    identifier="snapshot0",
+                    device="/dev/dev0",
+                    mount_point="/opt/disk0",
+                    mount_options="rw,noatime",
+                ),
+            ]
+        )
+
+    @pytest.fixture
+    def backup_info(self, snapshots_info):
+        yield mock.Mock(backup_id=self.backup_id, snapshots_info=snapshots_info)
+
+    @mock.patch("barman.clients.cloud_restore.get_snapshot_interface_from_backup_info")
+    @mock.patch("barman.clients.cloud_restore.UnixLocalCommand")
+    def test_download_backup(
+        self,
+        mock_cmd,
+        mock_get_snapshot_interface,
+        backup_info,
+        mock_cloud_interface,
+        mock_catalog,
+    ):
+        """Verify that the backup label is downloaded if all preconditions are met."""
+        # GIVEN a CloudBackupDownloaderSnapshot
+        downloader = CloudBackupDownloaderSnapshot(mock_cloud_interface, mock_catalog)
+        # AND the specified snapshots are returned by the snapshot interface
+        mock_get_snapshot_interface.return_value.get_attached_snapshots.return_value = {
+            "snapshot0": "/dev/dev0"
+        }
+        # AND the following recovery args
+        recovery_dir = "/path/to/restore_dir"
+        recovery_instance = "test_instance"
+        recovery_zone = "test_zone"
+        # AND a mock findmnt command which returns a successful response
+        mock_cmd.return_value.findmnt.return_value = ["/opt/disk0", "rw,noatime"]
+        # AND a mock check_directory_exists command which returns True
+        mock_cmd.return_value.check_directory_exists.return_value = True
+
+        # WHEN download_backup is called
+        downloader.download_backup(
+            backup_info, recovery_dir, recovery_instance, recovery_zone
+        )
+        # THEN the backup label is downloaded to the recovery destination
+        mock_cloud_interface.download_file.assert_called_once_with(
+            "{}/base/{}/backup_label".format(
+                mock_catalog.server_name,
+                self.backup_id,
+            ),
+            "{}/backup_label".format(recovery_dir),
+            decompress=None,
+        )
+
+    @pytest.mark.parametrize(
+        (
+            "attached_snapshots",
+            "findmnt_output",
+            "check_directory_exists_output",
+            "expected_error_msg",
+        ),
+        (
+            # No disk cloned from snapshot attached
+            [
+                {},
+                None,
+                None,
+                (
+                    "The following snapshots are not attached to recovery instance "
+                    "{recovery_instance}: {snapshot_name}"
+                ),
+            ],
+            # Correct disk attached but not mounted in the right place
+            [
+                {"snapshot0": "/dev/dev0"},
+                ("/opt/disk1", "rw,noatime"),
+                None,
+                (
+                    "Error checking mount points: Device {device_path} cloned from "
+                    "snapshot {snapshot_name} is mounted at /opt/disk1 but "
+                    "{mount_point} was expected."
+                ),
+            ],
+            # Recovery directory not present
+            [
+                {"snapshot0": "/dev/dev0"},
+                ("/opt/disk0", "rw,noatime"),
+                False,
+                (
+                    "Recovery directory '{recovery_dir}' does not exist on the "
+                    "recovery instance. Check all required disks have been created, "
+                    "attached and mounted."
+                ),
+            ],
+        ),
+    )
+    @mock.patch("barman.clients.cloud_restore.get_snapshot_interface_from_backup_info")
+    @mock.patch("barman.clients.cloud_restore.UnixLocalCommand")
+    def test_download_backup_preconditions_failed(
+        self,
+        mock_cmd,
+        mock_get_snapshot_interface,
+        backup_info,
+        mock_cloud_interface,
+        mock_catalog,
+        attached_snapshots,
+        findmnt_output,
+        check_directory_exists_output,
+        expected_error_msg,
+    ):
+        """Verify that backup download fails when preconditions are not met."""
+        # GIVEN a CloudBackupDownloaderSnapshot
+        downloader = CloudBackupDownloaderSnapshot(mock_cloud_interface, mock_catalog)
+        # AND the specified snapshots are returned by the snapshot interface
+        mock_get_snapshot_interface.return_value.get_attached_snapshots.return_value = (
+            attached_snapshots
+        )
+        # AND the following recovery args
+        recovery_dir = "/path/to/restore_dir"
+        recovery_instance = "test_instance"
+        recovery_zone = "test_zone"
+        # AND a mock findmnt command which returns the specified response
+        mock_cmd.return_value.findmnt.return_value = findmnt_output
+        # AND a mock check_directory_exists command which returns the specified respone
+        mock_cmd.return_value.check_directory_exists.return_value = (
+            check_directory_exists_output
+        )
+
+        # WHEN download_backup is called
+        # THEN a RecoveryPreconditionException is raised
+        with pytest.raises(RecoveryPreconditionException) as exc:
+            downloader.download_backup(
+                backup_info, recovery_dir, recovery_instance, recovery_zone
+            )
+        # AND the exception has the expected message
+        assert str(exc.value) == expected_error_msg.format(
+            device_path=self.device_path,
+            mount_point=self.mount_point,
+            recovery_dir=recovery_dir,
+            recovery_instance=recovery_instance,
+            snapshot_name=self.snapshot_name,
         )

--- a/tests/test_barman_cloud_restore.py
+++ b/tests/test_barman_cloud_restore.py
@@ -20,6 +20,11 @@ import mock
 import pytest
 
 from barman.clients import cloud_restore
+from barman.clients.cloud_cli import OperationErrorExit
+from barman.clients.cloud_restore import (
+    CloudBackupDownloaderObjectStore,
+)
+from barman.cloud import BackupFileInfo
 
 
 class TestCloudRestore(object):
@@ -27,7 +32,7 @@ class TestCloudRestore(object):
         ("backup_id_arg", "expected_backup_id"),
         (("20201110T120000", "20201110T120000"), ("backup name", "20201110T120000")),
     )
-    @mock.patch("barman.clients.cloud_restore.CloudBackupDownloader")
+    @mock.patch("barman.clients.cloud_restore.CloudBackupDownloaderObjectStore")
     @mock.patch("barman.clients.cloud_restore.CloudBackupCatalog")
     @mock.patch("barman.clients.cloud_restore.get_cloud_interface")
     def test_restore_calls_backup_downloader_with_parsed_id(
@@ -42,6 +47,9 @@ class TestCloudRestore(object):
         # GIVEN a mock backup catalog where parse_backup_id will always resolve
         # to the expected backup ID
         mock_catalog.return_value.parse_backup_id.return_value = expected_backup_id
+        # AND the catalog returns a mock backup_info with the expected backup ID
+        mock_backup_info = mock.Mock(backup_id=expected_backup_id)
+        mock_catalog.return_value.get_backup_info.return_value = mock_backup_info
 
         # WHEN barman-backup-restore is called with the backup_id_arg
         recovery_dir = "/some/recovery/dir"
@@ -49,7 +57,92 @@ class TestCloudRestore(object):
             ["cloud_storage_url", "test_server", backup_id_arg, recovery_dir]
         )
 
-        # THEN the backup downloader is called with the expected backup ID
+        # THEN the backup downloader is called with the expected mock backup_info
         mock_downloader.return_value.download_backup.assert_called_once_with(
-            expected_backup_id, recovery_dir, {}
+            mock_backup_info, recovery_dir, {}
+        )
+
+
+class TestCloudBackupDownloaderObjectStore(object):
+    """Verify the cloud backup downloader for object store backups."""
+
+    backup_id = "20380119T031408"
+
+    @pytest.fixture
+    def backup_info(self):
+        backup_info = mock.Mock(backup_id=self.backup_id, snapshots_info=None)
+        backup_info.wal_directory.return_value = "/path/to/wals"
+        yield backup_info
+
+    @pytest.fixture
+    def mock_cloud_interface(self):
+        yield mock.Mock(path="")
+
+    @pytest.fixture
+    def mock_catalog(self, backup_info):
+        catalog = mock.Mock(prefix="test_server/base", server_name="test_server")
+        catalog.return_value.parse_backup_id.return_value = self.backup_id
+        catalog.return_value.get_backup_info.return_value = backup_info
+        yield catalog
+
+    @mock.patch("barman.clients.cloud_restore.os.path.exists")
+    def test_download_backup(
+        self,
+        mock_os_path_exists,
+        backup_info,
+        mock_cloud_interface,
+        mock_catalog,
+    ):
+        """Verify that the tar files and backup label are downloaded."""
+        # GIVEN a backup catalog with a single backup with a data.tar file
+        backup_file_path = "mock_catalog.prefix/{}/data".format(self.backup_id)
+        mock_catalog.get_backup_files.return_value = {
+            None: BackupFileInfo(oid=None, path=backup_file_path)
+        }
+        # AND a CloudBackupObjectStoreDownloader
+        downloader = CloudBackupDownloaderObjectStore(
+            mock_cloud_interface, mock_catalog
+        )
+        # AND the following recovery args
+        recovery_dir = "/path/to/restore_dir"
+        # AND the recovery_dir does not exist
+        mock_os_path_exists.side_effect = lambda x: x != recovery_dir
+
+        # WHEN download_backup is called
+        downloader.download_backup(backup_info, recovery_dir, None)
+
+        # THEN the data.tar file is extracted into the recovery dir
+        mock_cloud_interface.extract_tar.assert_called_once_with(
+            backup_file_path, recovery_dir
+        )
+
+    @mock.patch("barman.clients.cloud_restore.os.listdir")
+    @mock.patch("barman.clients.cloud_restore.os.path.exists")
+    def test_download_backup_recovery_dir_exists(
+        self,
+        mock_os_path_exists,
+        mock_os_listdir,
+        backup_info,
+        mock_cloud_interface,
+        mock_catalog,
+        caplog,
+    ):
+        """Verify that backup download fails when preconditions are not met."""
+        # GIVEN a CloudBackupObjectStoreDownloader
+        downloader = CloudBackupDownloaderObjectStore(
+            mock_cloud_interface, mock_catalog
+        )
+        # AND a recovery_dir which exists
+        recovery_dir = "/path/to/restore_dir"
+        mock_os_path_exists.return_value = True
+        mock_os_listdir.return_value = ["some_file"]
+
+        # WHEN download_backup is called
+        # THEN an OperationErrorExit is raised
+        with pytest.raises(OperationErrorExit):
+            downloader.download_backup(backup_info, recovery_dir, None)
+        # AND an error message is logged
+        assert (
+            "Destination {} already exists and it is not empty".format(recovery_dir)
+            in caplog.text
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -615,6 +615,141 @@ class TestCli(object):
             # path matches expectations
             assert server.recovery_staging_path == expected_recovery_staging_path
 
+    @pytest.mark.parametrize(
+        (
+            "snapshots_info",
+            "snapshot_recovery_args",
+            "extra_recovery_args",
+            "error_message",
+        ),
+        (
+            # If there is no snapshot_info but snapshot args are used then there should
+            # be an error
+            (
+                None,
+                {
+                    "snapshot_recovery_instance": "test_instance",
+                },
+                {},
+                (
+                    "Backup backup_id is not a snapshot backup but the following "
+                    "snapshot arguments have been used: --snapshot-recovery-instance"
+                ),
+            ),
+            (
+                None,
+                {
+                    "snapshot_recovery_zone": "test_zone",
+                },
+                {},
+                (
+                    "Backup backup_id is not a snapshot backup but the following "
+                    "snapshot arguments have been used: --snapshot-recovery-zone"
+                ),
+            ),
+            (
+                None,
+                {
+                    "snapshot_recovery_instance": "test_instance",
+                    "snapshot_recovery_zone": "test_zone",
+                },
+                {},
+                (
+                    "Backup backup_id is not a snapshot backup but the following "
+                    "snapshot arguments have been used: --snapshot-recovery-instance, "
+                    "--snapshot-recovery-zone"
+                ),
+            ),
+            # If there is snapshot_info but no snapshot args then there should be an
+            # error
+            (
+                Mock(snapshots=[]),
+                {},
+                {},
+                (
+                    "Backup backup_id is a snapshot backup and the following required "
+                    "arguments have not been provided: --snapshot-recovery-instance, "
+                    "--snapshot-recovery-zone"
+                ),
+            ),
+            # If there is snapshot_info, snapshot args and also tablespace mappings
+            # then there should be an error
+            (
+                Mock(snapshots=[]),
+                {
+                    "snapshot_recovery_instance": "test_instance",
+                    "snapshot_recovery_zone": "test_zone",
+                },
+                {"tablespace": ("tbs1:/path/to/tbs1",)},
+                (
+                    "Backup backup_id is a snapshot backup therefore tablespace "
+                    "relocation rules cannot be used"
+                ),
+            ),
+            # If there is snapshot_info and snapshot args then there should not be an
+            # error
+            (
+                Mock(snapshots=[]),
+                {
+                    "snapshot_recovery_instance": "test_instance",
+                    "snapshot_recovery_zone": "test_zone",
+                },
+                {},
+                None,
+            ),
+        ),
+    )
+    @patch("barman.cli.get_server")
+    @patch("barman.cli.parse_backup_id")
+    def test_recover_snapshots(
+        self,
+        parse_backup_id_mock,
+        get_server_mock,
+        mock_backup_info,
+        mock_recover_args,
+        snapshots_info,
+        snapshot_recovery_args,
+        extra_recovery_args,
+        error_message,
+        capsys,
+    ):
+        # GIVEN a backup with the specified snapshots_info
+        mock_backup_info.snapshots_info = snapshots_info
+        mock_backup_info.backup_id = "backup_id"
+        mock_backup_info.tablespaces.append(Mock())
+        mock_backup_info.tablespaces[-1].name = "tbs1"
+        parse_backup_id_mock.return_value = mock_backup_info
+        # AND the specified additional recovery args
+        mock_recover_args.snapshot_recovery_instance = None
+        mock_recover_args.snapshot_recovery_zone = None
+        extra_recovery_args.update(snapshot_recovery_args)
+        for k, v in extra_recovery_args.items():
+            setattr(mock_recover_args, k, v)
+
+        # WHEN barman recover is called
+        with pytest.raises(SystemExit):
+            recover(mock_recover_args)
+
+        # THEN if we expected an error the error was observed
+        server = get_server_mock.return_value
+        _, err = capsys.readouterr()
+        if error_message:
+            assert error_message in err
+            # AND recover was not called
+            server.recover.assert_not_called()
+        else:
+            # AND if we expected success, the server's recover method was called
+            server.recover.assert_called_once()
+            # AND the snapshot arguments were passed
+            assert (
+                server.recover.call_args_list[0][1]["recovery_instance"]
+                == snapshot_recovery_args["snapshot_recovery_instance"]
+            )
+            assert (
+                server.recover.call_args_list[0][1]["recovery_zone"]
+                == snapshot_recovery_args["snapshot_recovery_zone"]
+            )
+
     def test_check_target_action(self):
         # The following ones must work
         assert None is check_target_action(None)

--- a/tests/test_cloud_snapshot_interface.py
+++ b/tests/test_cloud_snapshot_interface.py
@@ -26,6 +26,7 @@ from barman.cloud import CloudProviderError
 
 from barman.cloud_providers import (
     CloudProviderUnsupported,
+    get_snapshot_interface,
     get_snapshot_interface_from_backup_info,
     get_snapshot_interface_from_server_config,
 )
@@ -131,6 +132,55 @@ class TestGetSnapshotInterface(object):
         assert "backup_info has snapshot provider 'gcp' but project is not set" in str(
             exc.value
         )
+
+    @pytest.mark.parametrize(
+        ("cloud_provider", "interface_cls"),
+        [
+            ("aws-s3", None),
+            ("azure-blob-storage", None),
+            ("google-cloud-storage", GcpCloudSnapshotInterface),
+        ],
+    )
+    @mock.patch(
+        "barman.cloud_providers.google_cloud_storage.import_google_cloud_compute"
+    )
+    def test_from_args_cloud_provider(
+        self, _mock_google_cloud_compute, cloud_provider, interface_cls
+    ):
+        """Verify supported and unsupported cloud providers with config args."""
+        # GIVEN a cloud config with the specified snapshot provider
+        mock_config = mock.Mock(cloud_provider=cloud_provider)
+
+        # WHEN get_snapshot_interface_from_server_config is called
+        if interface_cls:
+            # THEN supported providers return the expected interface
+            assert isinstance(get_snapshot_interface(mock_config), interface_cls)
+        else:
+            # AND unsupported providers raise the expected exception
+            with pytest.raises(CloudProviderUnsupported) as exc:
+                get_snapshot_interface(mock_config)
+            assert "No snapshot provider for cloud provider: {}".format(
+                cloud_provider
+            ) == str(exc.value)
+
+    def test_from_args_gcp_no_project(self):
+        """
+        Verify an exception is raised for gcp snapshots with no project in args.
+        """
+        # GIVEN a cloud config with the specified snapshot provider and a missing
+        # snapshot_gcp_project argument
+        mock_config = mock.Mock(
+            cloud_provider="google-cloud-storage", snapshot_gcp_project=None
+        )
+
+        # WHEN get snapshot_interface_from_backup_info is called
+        with pytest.raises(ConfigurationException) as exc:
+            get_snapshot_interface(mock_config)
+        # AND the exception has the expected message
+        assert (
+            "--snapshot-gcp-project option must be set for snapshot backups when "
+            "cloud provider is google-cloud-storage"
+        ) == str(exc.value)
 
 
 class TestGcpCloudSnapshotInterface(object):

--- a/tests/test_cloud_snapshot_interface.py
+++ b/tests/test_cloud_snapshot_interface.py
@@ -1,0 +1,966 @@
+# -*- coding: utf-8 -*-
+# © Copyright EnterpriseDB UK Limited 2013-2022
+#
+# Client Utilities for Barman, Backup and Recovery Manager for PostgreSQL
+#
+# Barman is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Barman is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Barman.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import mock
+import pytest
+
+from google.api_core.exceptions import NotFound
+
+from barman.cloud import CloudProviderError
+
+from barman.cloud_providers import (
+    CloudProviderUnsupported,
+    get_snapshot_interface_from_backup_info,
+    get_snapshot_interface_from_server_config,
+)
+from barman.cloud_providers.google_cloud_storage import GcpCloudSnapshotInterface
+from barman.exceptions import (
+    BarmanException,
+    ConfigurationException,
+    SnapshotBackupException,
+)
+
+
+class TestGetSnapshotInterface(object):
+    """
+    Verify get_snapshot_interface creates the required CloudSnapshotInterface
+    """
+
+    @pytest.mark.parametrize(
+        ("snapshot_provider", "interface_cls"),
+        [("aws", None), ("azure", None), ("gcp", GcpCloudSnapshotInterface)],
+    )
+    @mock.patch(
+        "barman.cloud_providers.google_cloud_storage.import_google_cloud_compute"
+    )
+    def test_from_config_cloud_provider(
+        self, _mock_google_cloud_compute, snapshot_provider, interface_cls
+    ):
+        """Verify supported and unsupported cloud providers with server config."""
+        # GIVEN a server config with the specified snapshot provider
+        mock_config = mock.Mock(snapshot_provider=snapshot_provider)
+
+        # WHEN get_snapshot_interface_from_server_config is called
+        if interface_cls:
+            # THEN supported providers return the expected interface
+            assert isinstance(
+                get_snapshot_interface_from_server_config(mock_config), interface_cls
+            )
+        else:
+            # AND unsupported providers raise the expected exception
+            with pytest.raises(CloudProviderUnsupported) as exc:
+                get_snapshot_interface_from_server_config(mock_config)
+            assert "Unsupported snapshot provider: {}".format(snapshot_provider) == str(
+                exc.value
+            )
+
+    def test_from_config_gcp_no_project(self):
+        """
+        Verify an exception is raised for gcp snapshots with no project in server config.
+        """
+        # GIVEN a server config with the gcp snapshot provider and no snapshot_gcp_project
+        mock_config = mock.Mock(snapshot_provider="gcp", snapshot_gcp_project=None)
+        # WHEN get snapshot_interface_from_server_config is called
+        with pytest.raises(ConfigurationException) as exc:
+            get_snapshot_interface_from_server_config(mock_config)
+        # THEN the expected exception is raised
+        assert (
+            "snapshot_gcp_project option must be set when snapshot_provider is gcp"
+            in str(exc.value)
+        )
+
+    @pytest.mark.parametrize(
+        ("snapshot_provider", "interface_cls"),
+        [("aws", None), ("azure", None), ("gcp", GcpCloudSnapshotInterface)],
+    )
+    @mock.patch(
+        "barman.cloud_providers.google_cloud_storage.import_google_cloud_compute"
+    )
+    def test_from_backup_info_cloud_provider(
+        self, _mock_google_cloud_compute, snapshot_provider, interface_cls
+    ):
+        """Verify supported and unsupported cloud providers with backup_info."""
+        # GIVEN a backup_info with snapshots_info containing the specified snapshot
+        # provider
+        mock_backup_info = mock.Mock(
+            snapshots_info=mock.Mock(provider=snapshot_provider)
+        )
+
+        # WHEN get_snapshot_interface_from_server_config is called
+        if interface_cls:
+            # THEN supported providers return the expected interface
+            assert isinstance(
+                get_snapshot_interface_from_backup_info(mock_backup_info), interface_cls
+            )
+        else:
+            # AND unsupported providers raise the expected exception
+            with pytest.raises(CloudProviderUnsupported) as exc:
+                get_snapshot_interface_from_backup_info(mock_backup_info)
+            assert "Unsupported snapshot provider in backup info: {}".format(
+                snapshot_provider
+            ) == str(exc.value)
+
+    def test_from_backup_info_gcp_no_project(self):
+        """
+        Verify an exception is raised for gcp snapshots with no project in backup_info.
+        """
+        # GIVEN a server config with the gcp snapshot provider and no snapshot_gcp_project
+        mock_backup_info = mock.Mock(
+            snapshots_info=mock.Mock(provider="gcp", project=None)
+        )
+        # WHEN get snapshot_interface_from_backup_info is called
+        with pytest.raises(BarmanException) as exc:
+            get_snapshot_interface_from_backup_info(mock_backup_info)
+        # THEN the expected exception is raised
+        assert "backup_info has snapshot provider 'gcp' but project is not set" in str(
+            exc.value
+        )
+
+
+class TestGcpCloudSnapshotInterface(object):
+    """
+    Verify behaviour of the GcpCloudSnapshotInterface class.
+    """
+
+    backup_id = "20380119T031407"
+    gcp_disks = (
+        {
+            "name": "test_disk_0",
+            "device_name": "dev0",
+            "physical_block_size": 1024,
+            "size_gb": 1,
+        },
+        {
+            "name": "test_disk_1",
+            "device_name": "dev1",
+            "physical_block_size": 2048,
+            "size_gb": 10,
+        },
+        {
+            "name": "test_disk_2",
+            "device_name": "dev2",
+            "physical_block_size": 4096,
+            "size_gb": 100,
+        },
+    )
+    gcp_zone = "us-east1-b"
+    gcp_project = "test_project"
+    gcp_instance_name = "test_instance"
+    server_name = "test_server"
+
+    def _get_disk_link(self, project, zone, disk_name):
+        return "projects/{}/zones/{}/disks/{}".format(project, zone, disk_name)
+
+    def _get_snapshot_name(self, disk_name):
+        return "{}-{}".format(disk_name, self.backup_id.lower())
+
+    def _get_device_path(self, device):
+        return "/dev/disk/by-id/google-{}".format(device)
+
+    @mock.patch(
+        "barman.cloud_providers.google_cloud_storage.import_google_cloud_compute"
+    )
+    def test_init_with_null_project(self, _mock_google_cloud_compute):
+        """
+        Verify creating GcpCloudSnapshotInterface fails if gcp_project is not set.
+        """
+        # GIVEN a null project
+        gcp_project = None
+
+        # WHEN a GcpCloudSnapshotInterface is created
+        # THEN a TypeError is raised
+        with pytest.raises(TypeError) as exc:
+            GcpCloudSnapshotInterface(gcp_project)
+
+        # AND the expected message is included
+        assert str(exc.value) == "project cannot be None"
+
+    @pytest.fixture
+    def mock_google_cloud_compute(self):
+        with mock.patch(
+            "barman.cloud_providers.google_cloud_storage.import_google_cloud_compute"
+        ) as mock_import_google_cloud_compute:
+            yield mock_import_google_cloud_compute.return_value
+
+    def test_init(self, mock_google_cloud_compute):
+        """
+        Verify creating GcpCloudSnapshotInterface creates the necessary GCP clients.
+        """
+        # GIVEN a non-null project
+        gcp_project = self.gcp_project
+        # WHEN a GcpCloudSnapshotInterface is created
+        snapshot_interface = GcpCloudSnapshotInterface(gcp_project)
+        # THEN a SnapshotsClient was created
+        assert snapshot_interface.client == (
+            mock_google_cloud_compute.SnapshotsClient.return_value
+        )
+        # AND a DisksClient was created
+        assert snapshot_interface.disks_client == (
+            mock_google_cloud_compute.DisksClient.return_value
+        )
+        # AND an InstancesClient was created
+        assert snapshot_interface.instances_client == (
+            mock_google_cloud_compute.InstancesClient.return_value
+        )
+
+    def test_take_snapshot(self, mock_google_cloud_compute, caplog):
+        """
+        Verify that take_snapshot calls the GCP library and waits for the result.
+        """
+        # GIVEN a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        # AND a backup_info for a given server name and backup ID
+        backup_info = mock.Mock(backup_id=self.backup_id, server_name=self.server_name)
+        # AND a mock SnapshotsClient which returns a successful response
+        mock_snapshots_client = mock_google_cloud_compute.SnapshotsClient.return_value
+        mock_resp = mock_snapshots_client.insert.return_value
+        mock_resp.result.return_value = True
+        mock_resp.error_code = None
+        mock_resp.warnings = None
+        # AND log level is INFO
+        caplog.set_level(logging.INFO)
+
+        # WHEN take_snapshot is called
+        snapshot_name = snapshot_interface.take_snapshot(
+            backup_info,
+            self.gcp_zone,
+            self.gcp_disks[0]["name"],
+        )
+
+        # THEN insert is called on the SnapshotsClient with the expected args
+        expected_disk_name = self.gcp_disks[0]["name"]
+        expected_full_disk_name = self._get_disk_link(
+            self.gcp_project,
+            self.gcp_zone,
+            self.gcp_disks[0]["name"],
+        )
+        expected_snapshot_name = self._get_snapshot_name(expected_disk_name)
+        mock_snapshots_client.insert.assert_called_once_with(
+            {
+                "project": self.gcp_project,
+                "snapshot_resource": {
+                    "name": expected_snapshot_name,
+                    "source_disk": expected_full_disk_name,
+                },
+            }
+        )
+        # AND result() was called on the response to await completion of the snapshot
+        mock_resp.result.assert_called_once()
+        # AND the name of the snapshot was returned
+        assert snapshot_name == expected_snapshot_name
+        # AND the expected log output occurred
+        expected_log_content = (
+            "Taking snapshot '{}' of disk '{}'".format(
+                expected_snapshot_name, expected_disk_name
+            ),
+            "Waiting for snapshot '{}' completion".format(expected_snapshot_name),
+            "Snapshot '{}' completed".format(expected_snapshot_name),
+        )
+        for expected_log, log_line in zip(
+            expected_log_content, caplog.text.split("\n")
+        ):
+            assert expected_log in log_line
+
+    def test_take_snapshot_warnings(self, mock_google_cloud_compute, caplog):
+        """
+        Verify that warnings are logged if present in the snapshots response.
+        """
+        # GIVEN a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        # AND a backup_info for a given server name and backup ID
+        backup_info = mock.Mock(backup_id=self.backup_id, server_name=self.server_name)
+        # AND a mock SnapshotsClient which returns a successful response
+        mock_snapshots_client = mock_google_cloud_compute.SnapshotsClient.return_value
+        mock_resp = mock_snapshots_client.insert.return_value
+        mock_resp.result.return_value = True
+        mock_resp.error_code = None
+        # AND the response has warnings
+        mock_resp.warnings = [mock.Mock(code="123", message="warning message")]
+
+        # WHEN take_snapshot is called
+        snapshot_name = snapshot_interface.take_snapshot(
+            backup_info,
+            self.gcp_zone,
+            self.gcp_disks[0]["name"],
+        )
+
+        # THEN the warning is included in the log output
+        assert (
+            "Warnings encountered during snapshot {}: 123:warning message".format(
+                snapshot_name
+            )
+            in caplog.text
+        )
+
+    def test_take_snapshot_failed(self, mock_google_cloud_compute):
+        """
+        Verify that take_snapshot raises an exception on failure.
+        """
+        # GIVEN a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        # AND a backup_info for a given server name and backup ID
+        backup_info = mock.Mock(backup_id=self.backup_id, server_name=self.server_name)
+        # AND a mock SnapshotsClient which returns a failed response
+        mock_snapshots_client = mock_google_cloud_compute.SnapshotsClient.return_value
+        mock_resp = mock_snapshots_client.insert.return_value
+        mock_resp.result.return_value = True
+        mock_resp.error_code = "503"
+        mock_resp.error_message = "test error message"
+
+        # WHEN take_snapshot is called
+        # THEN a CloudProviderError is raised
+        with pytest.raises(CloudProviderError) as exc:
+            snapshot_interface.take_snapshot(
+                backup_info,
+                self.gcp_zone,
+                self.gcp_disks[0]["name"],
+            )
+
+        # AND the exception message contains the snapshot name, error code and error
+        # message
+        expected_snapshot_name = self._get_snapshot_name(self.gcp_disks[0]["name"])
+        expected_message = "Snapshot '{}' failed with error code {}: {}".format(
+            expected_snapshot_name,
+            mock_resp.error_code,
+            mock_resp.error_message,
+        )
+        assert str(exc.value) == expected_message
+
+    def _get_mock_instances_client(self, gcp_project, gcp_zone, gcp_instance, disks):
+        """
+        Helper which create a mock instances client for the given project/zone/instance
+        with the specified disks attached as the specified device.
+        """
+
+        def get_fun(instance, zone, project):
+            if instance == gcp_instance and zone == gcp_zone and project == gcp_project:
+                mock_attached_disks = [
+                    mock.Mock(
+                        device_name=disk["device_name"],
+                        source=self._get_disk_link(project, zone, disk["name"]),
+                    )
+                    for disk in disks
+                ]
+                return mock.Mock(disks=mock_attached_disks)
+            else:
+                raise NotFound("instance not found")
+
+        return mock.Mock(get=get_fun)
+
+    def _get_mock_disks_client(self, gcp_project, gcp_zone, disks):
+        """
+        Helper which creates a mock disks client for the given project/zone with the
+        specified disks available with the specified physical_block_size and size_gb.
+        """
+        disk_metadata = dict(
+            (
+                disk["name"],
+                mock.Mock(
+                    physical_block_size_bytes=disk["physical_block_size"],
+                    self_link="projects/{}/zones/{}/disks/{}".format(
+                        gcp_project, gcp_zone, disk["name"]
+                    ),
+                    size_gb=disk["size_gb"],
+                    source_snapshot="source_snapshot" in disk
+                    and disk["source_snapshot"]
+                    or "",
+                ),
+            )
+            for disk in disks
+        )
+
+        def get_fun(disk, zone, project):
+            if zone == self.gcp_zone and project == self.gcp_project:
+                try:
+                    return disk_metadata[disk]
+                except KeyError:
+                    raise NotFound("disk not found")
+
+        return mock.Mock(get=get_fun)
+
+    def _get_mock_snapshots_client(self):
+        """
+        Helper which returns a mock snapshots client that always succeeds.
+        """
+        snapshots_client = mock.Mock()
+        snapshots_client.insert.return_value = mock.Mock(error_code=None, warnings=None)
+        snapshots_client.delete.return_value = mock.Mock(error_code=None, warnings=None)
+        return snapshots_client
+
+    @pytest.mark.parametrize("number_of_disks", (1, 2, 3))
+    def test_take_snapshot_backup(
+        self,
+        number_of_disks,
+        mock_google_cloud_compute,
+    ):
+        """
+        Verify that take_snapshot_backup takes the required snapshots and updates the
+        backup_info when prerequisites are met.
+        """
+        # GIVEN a set of disks
+        disks = self.gcp_disks[:number_of_disks]
+        # AND a backup_info for a given server name and backup ID
+        backup_info = mock.Mock(backup_id=self.backup_id, server_name=self.server_name)
+        # AND a mock InstancesClient which returns an instance with the required disks
+        # attached
+        mock_instances_client = self._get_mock_instances_client(
+            self.gcp_project, self.gcp_zone, self.gcp_instance_name, disks
+        )
+        mock_google_cloud_compute.InstancesClient.return_value = mock_instances_client
+        # AND a mock DisksClient which returns the required disks
+        mock_disks_client = self._get_mock_disks_client(
+            self.gcp_project, self.gcp_zone, disks
+        )
+        mock_google_cloud_compute.DisksClient.return_value = mock_disks_client
+        # AND a mock SnapshotsClient which returns successful responses
+        mock_google_cloud_compute.SnapshotsClient.return_value = (
+            self._get_mock_snapshots_client()
+        )
+        # AND a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+
+        # WHEN take_snapshot_backup is called for multiple disks
+        snapshot_interface.take_snapshot_backup(
+            backup_info,
+            self.gcp_instance_name,
+            self.gcp_zone,
+            (disk["name"] for disk in disks),
+        )
+
+        # THEN the backup_info is updated with the expected snapshot metadata
+        snapshots_info = backup_info.snapshots_info
+        assert snapshots_info.project == self.gcp_project
+        assert snapshots_info.provider == "gcp"
+        assert len(snapshots_info.snapshots) == len(disks)
+        for disk in disks:
+            snapshot_name = self._get_snapshot_name(disk["name"])
+            snapshot = next(
+                snapshot
+                for snapshot in snapshots_info.snapshots
+                if snapshot.snapshot_name == snapshot_name
+            )
+            assert snapshot.identifier == snapshot_name
+            assert snapshot.device == self._get_device_path(disk["device_name"])
+            assert snapshot.snapshot_name == snapshot_name
+            assert snapshot.snapshot_project == self.gcp_project
+            assert snapshot.device_name == disk["device_name"]
+
+    def test_take_snapshot_backup_instance_not_found(self, mock_google_cloud_compute):
+        """
+        Verify that a SnapshotBackupException is raised if the instance cannot be
+        found.
+        """
+        # GIVEN a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        # AND a mock InstancesClient which cannot find the instance
+        mock_instances_client = mock_google_cloud_compute.InstancesClient.return_value
+        mock_instances_client.get.side_effect = NotFound("instance not found")
+
+        # WHEN take_snapshot_backup is called
+        # THEN a SnapshotBackupException is raised
+        with pytest.raises(SnapshotBackupException) as exc:
+            snapshot_interface.take_snapshot_backup(
+                mock.Mock(), self.gcp_instance_name, self.gcp_zone, self.gcp_disks
+            )
+
+        # AND the exception contains the expected message
+        assert str(
+            exc.value
+        ) == "Cannot find instance with name {} in zone {} for project {}".format(
+            self.gcp_instance_name, self.gcp_zone, self.gcp_project
+        )
+
+    def test_take_snapshot_backup_disk_not_found(
+        self,
+        mock_google_cloud_compute,
+    ):
+        """
+        Verify that a SnapshotBackupException is raised if a disk cannot be found.
+        """
+        # GIVEN a set of disks
+        disks = self.gcp_disks
+        # AND a mock InstancesClient which returns an instance with a subset of the
+        # required disks attached
+        mock_instances_client = self._get_mock_instances_client(
+            self.gcp_project, self.gcp_zone, self.gcp_instance_name, disks[:-1]
+        )
+        mock_google_cloud_compute.InstancesClient.return_value = mock_instances_client
+        # AND a mock DisksClient which returns only that same subset of disks
+        mock_disks_client = self._get_mock_disks_client(
+            self.gcp_project, self.gcp_zone, disks[:-1]
+        )
+        mock_google_cloud_compute.DisksClient.return_value = mock_disks_client
+        # AND a mock SnapshotsClient which returns successful responses
+        mock_google_cloud_compute.SnapshotsClient.return_value = (
+            self._get_mock_snapshots_client()
+        )
+        # AND a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+
+        # WHEN take snapshot_backup is called
+        # THEN a SnapshotBackupException is raised
+        with pytest.raises(SnapshotBackupException) as exc:
+            snapshot_interface.take_snapshot_backup(
+                mock.Mock(),
+                self.gcp_instance_name,
+                self.gcp_zone,
+                (disk["name"] for disk in disks),
+            )
+
+        # AND the exception contains the expected message
+        assert str(
+            exc.value
+        ) == "Cannot find disk with name {} in zone {} for project {}".format(
+            disks[-1]["name"], self.gcp_zone, self.gcp_project
+        )
+
+    def test_take_snapshot_backup_disk_not_attached(
+        self,
+        mock_google_cloud_compute,
+    ):
+        """
+        Verify that a SnapshotBackupException is raised if a disk is not attached.
+        """
+        # GIVEN a set of disks
+        disks = self.gcp_disks
+        # AND a mock InstancesClient which returns an instance with a subset of the
+        # required disks attached
+        mock_instances_client = self._get_mock_instances_client(
+            self.gcp_project, self.gcp_zone, self.gcp_instance_name, disks[:-1]
+        )
+        mock_google_cloud_compute.InstancesClient.return_value = mock_instances_client
+        # AND a mock DisksClient which returns all required disks
+        mock_disks_client = self._get_mock_disks_client(
+            self.gcp_project, self.gcp_zone, disks
+        )
+        mock_google_cloud_compute.DisksClient.return_value = mock_disks_client
+        # AND a mock SnapshotsClient which returns successful responses
+        mock_google_cloud_compute.SnapshotsClient.return_value = (
+            self._get_mock_snapshots_client()
+        )
+        # AND a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+
+        # WHEN take snapshot_backup is called
+        # THEN a SnapshotBackupException is raised
+        with pytest.raises(SnapshotBackupException) as exc:
+            snapshot_interface.take_snapshot_backup(
+                mock.Mock(),
+                self.gcp_instance_name,
+                self.gcp_zone,
+                (disk["name"] for disk in disks),
+            )
+
+        # AND the exception contains the expected message
+        assert str(exc.value) == "Disk {} not attached to instance {}".format(
+            disks[-1]["name"], self.gcp_instance_name
+        )
+
+    def test_take_snapshot_backup_disk_attached_multiple_times(
+        self,
+        mock_google_cloud_compute,
+    ):
+        """
+        Verify that a SnapshotBackupException is raised if a disk appears to be
+        attached more than once.
+        """
+        # GIVEN a set of disks
+        disks = self.gcp_disks
+        # AND a mock InstancesClient which returns an instance where one named disk is
+        # attached twice
+        mock_instances_client = self._get_mock_instances_client(
+            self.gcp_project, self.gcp_zone, self.gcp_instance_name, disks + disks[-1:]
+        )
+        mock_google_cloud_compute.InstancesClient.return_value = mock_instances_client
+        # AND a mock DisksClient which returns all required disks
+        mock_disks_client = self._get_mock_disks_client(
+            self.gcp_project, self.gcp_zone, disks
+        )
+        mock_google_cloud_compute.DisksClient.return_value = mock_disks_client
+        # AND a mock SnapshotsClient which returns successful responses
+        mock_google_cloud_compute.SnapshotsClient.return_value = (
+            self._get_mock_snapshots_client()
+        )
+        # AND a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+
+        # WHEN take snapshot_backup is called
+        # THEN a SnapshotBackupException is raised
+        with pytest.raises(AssertionError):
+            snapshot_interface.take_snapshot_backup(
+                mock.Mock(),
+                self.gcp_instance_name,
+                self.gcp_zone,
+                (disk["name"] for disk in disks),
+            )
+
+    def test_delete_snapshot(self, mock_google_cloud_compute, caplog):
+        """Verify that a snapshot can be deleted successfully."""
+        # GIVEN the snapshots client deletes successfully
+        mock_google_cloud_compute.SnapshotsClient.return_value = (
+            self._get_mock_snapshots_client()
+        )
+        # AND a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        # AND log level is info
+        caplog.set_level(logging.INFO)
+
+        # WHEN a snapshot is deleted
+        snapshot_name = self._get_snapshot_name(self.gcp_disks[0])
+        snapshot_interface.delete_snapshot(snapshot_name)
+
+        # THEN delete was called on the SnapshotsClient for that project/snapshot
+        mock_snapshots_client = mock_google_cloud_compute.SnapshotsClient.return_value
+        mock_snapshots_client.delete.assert_called_once_with(
+            {"project": self.gcp_project, "snapshot": snapshot_name}
+        )
+        # AND result was called on the response
+        resp = mock_snapshots_client.delete.return_value
+        resp.result.assert_called_once()
+        # AND a success message was logged
+        assert "Snapshot {} deleted".format(snapshot_name) in caplog.text
+
+    def test_delete_snapshot_not_found(self, mock_google_cloud_compute, caplog):
+        """
+        Verify that a snapshot deletion which fails with NotFound is considered
+        successful.
+        """
+        # GIVEN a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        # AND a snapshots client which will fail with a NotFound error
+        mock_snapshots_client = mock_google_cloud_compute.SnapshotsClient.return_value
+        mock_snapshots_client.delete.side_effect = NotFound("snapshot not found")
+
+        # WHEN a snapshot is deleted
+        snapshot_name = self._get_snapshot_name(self.gcp_disks[0])
+        snapshot_interface.delete_snapshot(snapshot_name)
+
+        # THEN delete was called on the SnapshotsClient for that project/snapshot
+        mock_snapshots_client = mock_google_cloud_compute.SnapshotsClient.return_value
+        mock_snapshots_client.delete.assert_called_once_with(
+            {"project": self.gcp_project, "snapshot": snapshot_name}
+        )
+        # AND result was not called on the response
+        resp = mock_snapshots_client.delete.return_value
+        resp.result.assert_not_called()
+
+    def test_delete_snapshot_warnings(self, mock_google_cloud_compute, caplog):
+        """Verify that warnings are logged if present in the snapshots response."""
+        # GIVEN a snapshots client which will delete a snapshot
+        mock_snapshots_client = self._get_mock_snapshots_client()
+        mock_google_cloud_compute.SnapshotsClient.return_value = mock_snapshots_client
+        # AND the response has warnings
+        mock_snapshots_client.delete.return_value.warnings = [
+            mock.Mock(code="123", message="warning message")
+        ]
+        # AND a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+
+        # WHEN a snapshot is deleted
+        snapshot_name = self._get_snapshot_name(self.gcp_disks[0])
+        snapshot_interface.delete_snapshot(snapshot_name)
+
+        # THEN the warning is included in the log output
+        assert (
+            "Warnings encountered during deletion of {}: 123:warning message".format(
+                snapshot_name
+            )
+            in caplog.text
+        )
+
+    def test_delete_snapshot_failed(self, mock_google_cloud_compute, caplog):
+        """Verify that a snapshot can be deleted successfully."""
+        # GIVEN a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        # AND a snapshots client which will fail to delete a snapshot
+        mock_snapshots_client = mock_google_cloud_compute.SnapshotsClient.return_value
+        mock_resp = mock_snapshots_client.delete.return_value
+        mock_resp.result.return_value = True
+        mock_resp.error_code = "503"
+        mock_resp.error_message = "test error message"
+
+        # WHEN a snapshot is deleted
+        # THEN a CloudProviderError is raised
+        snapshot_name = self._get_snapshot_name(self.gcp_disks[0])
+        with pytest.raises(CloudProviderError) as exc:
+            snapshot_interface.delete_snapshot(snapshot_name)
+
+        # AND the exception message contains the snapshot name, error code and error
+        # message
+        expected_message = (
+            "Deletion of snapshot {} failed with error code {}: {}".format(
+                snapshot_name,
+                mock_resp.error_code,
+                mock_resp.error_message,
+            )
+        )
+        assert str(exc.value) == expected_message
+
+    @pytest.mark.parametrize(
+        "snapshots_list",
+        (
+            [],
+            [mock.Mock(identifier="snapshot0")],
+            [mock.Mock(identifier="snapshot0"), mock.Mock(identifier="snapshot1")],
+        ),
+    )
+    def test_delete_snapshot_backup(
+        self, snapshots_list, mock_google_cloud_compute, caplog
+    ):
+        """Verfiy that all snapshots for a backup are deleted."""
+        # GIVEN a backup_info specifying zero or more snapshots
+        backup_info = mock.Mock(
+            backup_id=self.backup_id, snapshots_info=mock.Mock(snapshots=snapshots_list)
+        )
+        # AND log level is info
+        caplog.set_level(logging.INFO)
+        # AND the snapshots client deletes successfully
+        mock_google_cloud_compute.SnapshotsClient.return_value = (
+            self._get_mock_snapshots_client()
+        )
+        # AND a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+
+        # WHEN delete_snapshot_backup is called
+        snapshot_interface.delete_snapshot_backup(backup_info)
+
+        # THEN delete was called on the SnapshotsClient for each snapshot
+        mock_snapshots_client = mock_google_cloud_compute.SnapshotsClient.return_value
+        assert mock_snapshots_client.delete.call_count == len(snapshots_list)
+        for snapshot in snapshots_list:
+            assert (
+                ({"project": self.gcp_project, "snapshot": snapshot.identifier},),
+                {},
+            ) in mock_snapshots_client.delete.call_args_list
+            # AND the expected log message was logged for each snapshot
+            assert (
+                "Deleting snapshot '{}' for backup {}".format(
+                    snapshot.identifier, self.backup_id
+                )
+                in caplog.text
+            )
+
+    @pytest.mark.parametrize(
+        ("mock_disks", "expected_disk_names", "expected_device_names"),
+        (
+            ([], [], []),
+            (
+                [
+                    mock.Mock(
+                        source="projects/test_project/zones/us-east1-b/disks/disk0",
+                        device_name="dev0",
+                    )
+                ],
+                ["disk0"],
+                ["dev0"],
+            ),
+            (
+                [
+                    mock.Mock(
+                        source="projects/test_project/zones/us-east1-b/disks/disk0",
+                        device_name="dev0",
+                    ),
+                    mock.Mock(
+                        source="projects/test_project/zones/us-east1-b/disks/disk1",
+                        device_name="dev1",
+                    ),
+                ],
+                ["disk0", "disk1"],
+                ["dev0", "dev1"],
+            ),
+        ),
+    )
+    def test_get_attached_devices(
+        self,
+        mock_disks,
+        expected_disk_names,
+        expected_device_names,
+        mock_google_cloud_compute,
+    ):
+        """Verify that attached devices are returned as a dict keyed by disk name."""
+        # GIVEN a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        # AND a mock InstancesClient which returns metadata listing the devices
+        mock_instances_client = mock_google_cloud_compute.InstancesClient.return_value
+        mock_instance_metadata = mock.Mock(disks=mock_disks)
+        mock_instances_client.get.return_value = mock_instance_metadata
+
+        # WHEN get_attached_devices is called
+        attached_devices = snapshot_interface.get_attached_devices(
+            self.gcp_instance_name, self.gcp_zone
+        )
+
+        # THEN a dict of devices returned by the instance metadata is returned, keyed
+        # by disk name
+        assert len(attached_devices) == len(expected_disk_names)
+        for expected_disk_name, expected_device_name in zip(
+            expected_disk_names, expected_device_names
+        ):
+            assert expected_disk_name in attached_devices
+            # AND the device name matches that returned by the instance metadata
+            assert attached_devices[expected_disk_name] == self._get_device_path(
+                expected_device_name
+            )
+
+    @pytest.mark.parametrize(
+        "mock_disks",
+        (
+            [mock.Mock(source="", device_name="dev0")],
+            [mock.Mock(source="/", device_name="dev0")],
+            [mock.Mock(source="foo/", device_name="dev0")],
+        ),
+    )
+    def test_get_attached_devices_bad_disk_name(
+        self,
+        mock_disks,
+        mock_google_cloud_compute,
+    ):
+        """Verify that unparseable disk names are handled."""
+        # GIVEN a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        # AND a mock InstancesClient which returns metadata listing the devices
+        mock_instances_client = mock_google_cloud_compute.InstancesClient.return_value
+        mock_instance_metadata = mock.Mock(disks=mock_disks)
+        mock_instances_client.get.return_value = mock_instance_metadata
+
+        # WHEN get_attached_devices is called
+        # THEN a SnapshotBackupException is raised
+        with pytest.raises(SnapshotBackupException) as exc:
+            snapshot_interface.get_attached_devices(
+                self.gcp_instance_name, self.gcp_zone
+            )
+        # AND the expected message is included
+        assert str(
+            exc.value
+        ) == "Could not parse disk name for source {} attached to instance {}".format(
+            mock_disks[0].source, self.gcp_instance_name
+        )
+
+    @pytest.mark.parametrize(
+        "mock_disks",
+        (
+            [
+                mock.Mock(
+                    source="projects/test_project/zones/us-east1-b/disks/disk0",
+                    device_name="dev0",
+                ),
+                mock.Mock(
+                    source="projects/test_project/zones/us-east1-b/disks/disk0",
+                    device_name="dev1",
+                ),
+            ],
+            [
+                mock.Mock(
+                    source="projects/test_project/zones/us-east1-b/disks/disk1",
+                    device_name="dev2",
+                ),
+                mock.Mock(
+                    source="projects/test_project/zones/us-east1-b/disks/disk0",
+                    device_name="dev0",
+                ),
+                mock.Mock(
+                    source="projects/test_project/zones/us-east1-b/disks/disk0",
+                    device_name="dev1",
+                ),
+            ],
+        ),
+    )
+    def test_get_attached_devices_multiple_names(
+        self,
+        mock_disks,
+        mock_google_cloud_compute,
+    ):
+        """
+        Verify that an exception is raised if a disk appears to be attached more than
+        once.
+        """
+        # GIVEN a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        # AND a mock InstancesClient which returns metadata listing the devices
+        mock_instances_client = mock_google_cloud_compute.InstancesClient.return_value
+        mock_instance_metadata = mock.Mock(disks=mock_disks)
+        mock_instances_client.get.return_value = mock_instance_metadata
+
+        # WHEN get_attached_devices is called
+        # THEN a SnapshotBackupException is raised
+        with pytest.raises(SnapshotBackupException) as exc:
+            snapshot_interface.get_attached_devices(
+                self.gcp_instance_name, self.gcp_zone
+            )
+        # AND the expected message is included
+        assert str(exc.value) == (
+            "Disk projects/test_project/zones/us-east1-b/disks/disk0 appears to be "
+            "attached with name disk0 as devices {} and {}".format(
+                self._get_device_path("dev1"), self._get_device_path("dev0")
+            )
+        )
+
+    def test_get_attached_devices_instance_not_found(self, mock_google_cloud_compute):
+        """
+        Verify that a SnapshotBackupException is raised if the instance cannot be
+        found.
+        """
+        # GIVEN a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        # AND a mock InstancesClient which cannot find the instance
+        mock_instances_client = mock_google_cloud_compute.InstancesClient.return_value
+        mock_instances_client.get.side_effect = NotFound("instance not found")
+
+        # WHEN get_attached_devices is called
+        # THEN a SnapshotBackupException is raised
+        with pytest.raises(SnapshotBackupException) as exc:
+            snapshot_interface.get_attached_devices(
+                self.gcp_instance_name, self.gcp_zone
+            )
+
+        # AND the exception contains the expected message
+        assert str(
+            exc.value
+        ) == "Cannot find instance with name {} in zone {} for project {}".format(
+            self.gcp_instance_name, self.gcp_zone, self.gcp_project
+        )
+
+    def test_instance_exists(self, mock_google_cloud_compute):
+        """Verify successfully retrieving the instance results in a True response."""
+        # GIVEN a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+
+        # WHEN instance_exists is called for an instance which exists
+        result = snapshot_interface.instance_exists(
+            self.gcp_instance_name, self.gcp_zone
+        )
+
+        # THEN it returns False
+        assert result is True
+
+    def test_instance_exists_not_found(self, mock_google_cloud_compute):
+        """Verify a NotFound error results in a False response."""
+        # GIVEN a new GcpCloudSnapshotInterface
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        # AND a mock InstancesClient which cannot find the instance
+        mock_instances_client = mock_google_cloud_compute.InstancesClient.return_value
+        mock_instances_client.get.side_effect = NotFound("instance not found")
+
+        # WHEN instance_exists is called
+        result = snapshot_interface.instance_exists(
+            self.gcp_instance_name, self.gcp_zone
+        )
+
+        # THEN it returns False
+        assert result is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,6 +32,7 @@ from barman.config import (
     parse_si_suffix,
     parse_recovery_staging_path,
     parse_slot_name,
+    parse_snapshot_disks,
     parse_time_interval,
 )
 import testing_helpers
@@ -483,6 +484,29 @@ class TestConfig(object):
 
         with pytest.raises(ValueError):
             parse_slot_name("barman slot name")
+
+    @pytest.mark.parametrize(
+        ("disk_names", "is_allowed"),
+        (
+            # Strings where each comma-separated string is non-empty are allowed
+            ["disk0", True],
+            ["disk0,disk1", True],
+            ["disk0,disk1,disk2", True],
+            # Empty values are not allowed
+            ["disk0,,disk2", False],
+            ["", False],
+        ),
+    )
+    def test_parse_snapshot_disks(self, disk_names, is_allowed):
+        # GIVEN a list of disk names
+        # WHEN parse_snapshot_disks is called
+        # THEN if the value is allowed we have a list of disk names
+        if is_allowed:
+            assert parse_snapshot_disks(disk_names) == disk_names.split(",")
+        # AND if the value is not allowed we receive a ValueError
+        else:
+            with pytest.raises(ValueError):
+                parse_snapshot_disks(disk_names)
 
     @pytest.mark.parametrize(
         ("compression", "is_allowed"),

--- a/tests/test_infofile.py
+++ b/tests/test_infofile.py
@@ -24,6 +24,10 @@ from datetime import datetime
 import mock
 import pytest
 from dateutil.tz import tzlocal, tzoffset
+from barman.cloud_providers.google_cloud_storage import (
+    GcpSnapshotMetadata,
+    GcpSnapshotsInfo,
+)
 
 from barman.infofile import (
     BackupInfo,
@@ -689,3 +693,75 @@ class TestBackupInfo(object):
         assert "backup_name" not in infofile.read()
         # AND the backup name is not included in the JSON output
         assert "backup_name" not in b_info.to_json().keys()
+
+    def test_with_snapshots_info_gcp(self, tmpdir):
+        """
+        Test that snapshots_info is included in file and output if set.
+        """
+        # GIVEN a backup.info file for a server
+        server = build_mocked_server(
+            main_conf={"basebackups_directory": tmpdir.strpath},
+        )
+        backup_dir = tmpdir.mkdir("fake_name")
+        infofile = backup_dir.join("backup.info")
+        b_info = LocalBackupInfo(server, backup_id="fake_name")
+        b_info.status = BackupInfo.DONE
+
+        # WHEN snapshots_info is set and the file is saved
+        snapshots_info = GcpSnapshotsInfo(
+            project="project_name",
+            snapshots=[
+                GcpSnapshotMetadata(
+                    mount_point="/opt/mount0",
+                    mount_options="rw",
+                    device_name="dev0",
+                    snapshot_name="short_snapshot_name",
+                    snapshot_project="project_name",
+                )
+            ],
+        )
+        b_info.snapshots_info = snapshots_info
+        b_info.save()
+
+        # THEN a new BackupInfo created from the saved file has the SnapshotsInfo attributes
+        new_backup_info = LocalBackupInfo(server, info_file=infofile.strpath)
+        assert new_backup_info.snapshots_info.provider == "gcp"
+        assert new_backup_info.snapshots_info.project == "project_name"
+        snapshot0 = new_backup_info.snapshots_info.snapshots[0]
+        assert snapshot0.mount_point == "/opt/mount0"
+        assert snapshot0.mount_options == "rw"
+        assert snapshot0.device_name == "dev0"
+        assert snapshot0.snapshot_name == "short_snapshot_name"
+        assert snapshot0.snapshot_project == "project_name"
+
+        # AND the snapshots_info is included in the JSON output
+        snapshots_json = b_info.to_json()["snapshots_info"]
+        assert snapshots_json["provider"] == "gcp"
+        assert snapshots_json["provider_info"]["project"] == "project_name"
+        snapshot0_json = snapshots_json["snapshots"][0]
+        assert snapshot0_json["mount"]["mount_point"] == "/opt/mount0"
+        assert snapshot0_json["mount"]["mount_options"] == "rw"
+        assert snapshot0_json["provider"]["device_name"] == "dev0"
+        assert snapshot0_json["provider"]["snapshot_name"] == "short_snapshot_name"
+        assert snapshot0_json["provider"]["snapshot_project"] == "project_name"
+
+    def test_with_no_snapshots_info(self, tmpdir):
+        """
+        Test that snapshots_info is not included in file and output if not set.
+        """
+        # GIVEN a backup.info file for a server
+        server = build_mocked_server(
+            main_conf={"basebackups_directory": tmpdir.strpath},
+        )
+        backup_dir = tmpdir.mkdir("fake_name")
+        infofile = backup_dir.join("backup.info")
+        b_info = LocalBackupInfo(server, backup_id="fake_name")
+        b_info.status = BackupInfo.DONE
+
+        # WHEN no snapshots_info is set
+        b_info.save()
+
+        # THEN the backup name is not written to the file
+        assert "snapshots_info" not in infofile.read()
+        # AND the backup name is not included in the JSON output
+        assert "snapshots_info" not in b_info.to_json().keys()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1181,7 +1181,13 @@ class TestConsoleWriter(object):
         # mock the backup ext info
         wal_per_second = 0.01
         ext_info = mock_backup_ext_info(
-            status=BackupInfo.DONE, wals_per_second=wal_per_second
+            children_timelines=(mock.Mock(tli="1"),),
+            copy_stats={"analysis_time": 2, "copy_time": 1},
+            deduplicated_size=1234,
+            status=BackupInfo.DONE,
+            systemid="systemid",
+            wal_until_next_compression_ratio=1.5,
+            wals_per_second=wal_per_second,
         )
 
         writer = output.ConsoleOutputWriter()
@@ -1194,9 +1200,11 @@ class TestConsoleWriter(object):
         assert ext_info["backup_id"] in out
         assert ext_info["status"] in out
         assert str(ext_info["end_time"]) in out
+        assert ext_info["systemid"] in out
         for name, _, location in ext_info["tablespaces"]:
-            assert "%s: %s" % (name, location) in out
+            assert "{:<21}: {}".format(name, location) in out
         assert (pretty_size(ext_info["size"] + ext_info["wal_size"])) in out
+        assert (pretty_size(ext_info["deduplicated_size"])) in out
         assert (pretty_size(ext_info["wal_until_next_size"])) in out
         assert "WAL rate             : %0.2f/hour" % (wal_per_second * 3600) in out
         # TODO: this test can be expanded

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
+from functools import partial
 import os
 import shutil
 import time
@@ -29,8 +30,11 @@ from mock import MagicMock
 import testing_helpers
 from barman import xlog
 from barman.exceptions import (
+    CommandException,
     CommandFailedException,
+    DataTransferFailure,
     RecoveryInvalidTargetException,
+    RecoveryPreconditionException,
     RecoveryStandbyModeException,
     RecoveryTargetActionException,
 )
@@ -39,6 +43,7 @@ from barman.recovery_executor import (
     Assertion,
     RecoveryExecutor,
     RemoteConfigRecoveryExecutor,
+    SnapshotRecoveryExecutor,
     TarballRecoveryExecutor,
     ConfigurationFileMangeler,
     recovery_executor_factory,
@@ -1494,36 +1499,503 @@ class TestTarballRecoveryExecutor(object):
         ]
 
 
+class TestSnapshotRecoveryExecutor(object):
+    @mock.patch("barman.recovery_executor.RecoveryExecutor.recover")
+    @mock.patch("barman.recovery_executor.fs")
+    @mock.patch("barman.recovery_executor.get_snapshot_interface_from_backup_info")
+    def test_recover_success(
+        self,
+        _mock_get_snapshot_interface,
+        mock_fs,
+        mock_superclass_recover,
+    ):
+        """Verify that the recover method starts a recovery when all checks pass."""
+        # GIVEN a SnapshotRecoveryExecutor
+        mock_backup_manager = mock.Mock()
+        executor = SnapshotRecoveryExecutor(mock_backup_manager)
+        # AND a mock backup_info with snapshots
+        backup_info = mock.Mock(
+            snapshots_info=mock.Mock(
+                snapshots=[
+                    mock.Mock(
+                        identifier="snapshot0",
+                        device="/dev/dev0",
+                        mount_point="/opt/disk0",
+                        mount_options="rw,noatime",
+                    ),
+                ]
+            )
+        )
+        # AND a given recovery destination, instance and zone
+        recovery_dest = "/path/to/dest"
+        recovery_instance = "test_instance"
+        recovery_zone = "test_zone"
+        # AND a mock findmnt command which always returns the correct response
+        mock_fs.unix_command_factory.return_value.findmnt.return_value = (
+            "/opt/disk0",
+            "rw,noatime",
+        )
+
+        # WHEN recover is called
+        # THEN there are no errors
+        executor.recover(
+            backup_info,
+            recovery_dest,
+            recovery_instance=recovery_instance,
+            recovery_zone=recovery_zone,
+        )
+
+        # AND the superclass recovery method was called with the expected args
+        mock_superclass_recover.assert_called_once_with(
+            backup_info,
+            recovery_dest,
+            tablespaces=None,
+            remote_command=None,
+            target_tli=None,
+            target_time=None,
+            target_xid=None,
+            target_lsn=None,
+            target_name=None,
+            target_immediate=False,
+            exclusive=False,
+            target_action=None,
+            standby_mode=None,
+        )
+
+    @pytest.mark.parametrize(
+        (
+            "attached_snapshots",
+            "findmnt_output",
+            "check_directory_exists_output",
+            "should_fail",
+        ),
+        (
+            # No disk cloned from snapshot attached
+            [{}, None, None, True],
+            # Correct disk attached but not mounted in the right place
+            [{"snapshot0": "/dev/dev0"}, ("/opt/disk1", "rw,noatime"), None, True],
+            # Recovery directory not present
+            [{"snapshot0": "/dev/dev0"}, ("/opt/disk0", "rw,noatime"), False, True],
+            # All checks passing
+            [{"snapshot0": "/dev/dev0"}, ("/opt/disk0", "rw,noatime"), True, False],
+        ),
+    )
+    @mock.patch("barman.recovery_executor.RecoveryExecutor.recover")
+    @mock.patch("barman.recovery_executor.fs")
+    @mock.patch("barman.recovery_executor.get_snapshot_interface_from_backup_info")
+    def test_recover_failure(
+        self,
+        mock_get_snapshot_interface,
+        mock_fs,
+        _mock_superclass_recover,
+        attached_snapshots,
+        findmnt_output,
+        check_directory_exists_output,
+        should_fail,
+    ):
+        """Verify that the recover method fails when checks fail."""
+        # GIVEN a SnapshotRecoveryExecutor
+        mock_backup_manager = mock.Mock()
+        executor = SnapshotRecoveryExecutor(mock_backup_manager)
+        # AND the specified snapshots are returned by the snapshot interface
+        mock_get_snapshot_interface.return_value.get_attached_snapshots.return_value = (
+            attached_snapshots
+        )
+        # AND a mock backup_info with snapshots
+        backup_info = mock.Mock(
+            snapshots_info=mock.Mock(
+                snapshots=[
+                    mock.Mock(
+                        identifier="snapshot0",
+                        device="/dev/dev0",
+                        mount_point="/opt/disk0",
+                        mount_options="rw,noatime",
+                    ),
+                ]
+            )
+        )
+        # AND a given recovery destination, instance and zone
+        recovery_dest = "/path/to/dest"
+        recovery_instance = "test_instance"
+        recovery_zone = "test_zone"
+        # AND a mock findmnt command which returns the specified response
+        mock_cmd = mock_fs.unix_command_factory.return_value
+        mock_cmd.findmnt.return_value = findmnt_output
+        # AND a mock check_directory_exists command which returns the specified respone
+        mock_cmd.check_directory_exists.return_value = check_directory_exists_output
+
+        # WHEN recover is called AND an error is expected
+        if should_fail:
+            # THEN a RecoveryPreconditionException is raised and we intentionally
+            # avoid checking the content because this is verified in tests for the
+            # specific checks.
+            with pytest.raises(RecoveryPreconditionException):
+                executor.recover(
+                    backup_info,
+                    recovery_dest,
+                    recovery_instance=recovery_instance,
+                    recovery_zone=recovery_zone,
+                )
+        else:
+            # WHEN recover is called AND no error is expected then there is no error
+            executor.recover(
+                backup_info,
+                recovery_dest,
+                recovery_instance=recovery_instance,
+                recovery_zone=recovery_zone,
+            )
+
+    @mock.patch("barman.recovery_executor.fs.unix_command_factory")
+    @mock.patch("barman.recovery_executor.RsyncCopyController")
+    def test_backup_copy(self, copy_controller_mock, command_factory_mock, tmpdir):
+        """Verify that _backup_copy copies the backup_label into the destination."""
+        # GIVEN a basic folder/files structure
+        dest = tmpdir.mkdir("destination")
+        barman_home = "/some/barman/home"
+        server = testing_helpers.build_real_server(
+            main_conf={"recovery_staging_path": "/wherever"}
+        )
+        backup_id = "111111"
+        backup_info = testing_helpers.build_test_backup_info(
+            backup_id=backup_id,
+            server=server,
+            snapshots_info=mock.Mock(),
+        )
+        # AND a SnapshotRecoveryExecutor
+        executor = SnapshotRecoveryExecutor(server.backup_manager)
+        # AND a mock command which always completes successfully
+        command = command_factory_mock.return_value
+        recovery_info = {"cmd": command}
+
+        # WHEN _backup_copy is called
+        executor._backup_copy(
+            backup_info,
+            dest.strpath,
+            recovery_info=recovery_info,
+        )
+
+        # THEN the expected calls were made to the copy controller
+        assert copy_controller_mock.mock_calls == [
+            mock.call(
+                network_compression=False,
+                path=None,
+                ssh_command=None,
+                retry_sleep=30,
+                retry_times=0,
+                workers=1,
+            ),
+            mock.call().add_file(
+                bwlimit=None,
+                src="%s/main/base/%s/data/backup_label" % (barman_home, backup_id),
+                dst="%s/backup_label" % dest.strpath,
+                item_class=copy_controller_mock.return_value.PGDATA_CLASS,
+                label="pgdata",
+            ),
+            mock.call().copy(),
+        ]
+
+    @mock.patch("barman.recovery_executor.fs.unix_command_factory")
+    @mock.patch("barman.recovery_executor.RsyncCopyController")
+    def test_backup_copy_command_failure(
+        self, copy_controller_mock, command_factory_mock, tmpdir
+    ):
+        """Verify that _backup_copy fails when RsyncCopyController.copy fails."""
+        # GIVEN a basic folder/files structure
+        dest = tmpdir.mkdir("destination")
+        server = testing_helpers.build_real_server(
+            main_conf={"recovery_staging_path": "/wherever"}
+        )
+        backup_info = testing_helpers.build_test_backup_info(
+            backup_id="backup_id",
+            server=server,
+            snapshots_info=mock.Mock(),
+        )
+        # AND a SnapshotRecoveryExecutor
+        executor = SnapshotRecoveryExecutor(server.backup_manager)
+        # AND a mock command which always completes successfully
+        command = command_factory_mock.return_value
+        recovery_info = {"cmd": command}
+        # AND the copy controller fails with a CommandFailedException
+        copy_controller_mock.return_value.copy.side_effect = CommandFailedException(
+            "error message"
+        )
+
+        # WHEN _backup_copy is called
+        # THEN a DataTransferFailure exception is raised
+        with pytest.raises(DataTransferFailure) as exc:
+            executor._backup_copy(
+                backup_info, dest.strpath, recovery_info=recovery_info
+            )
+        # AND it has the expected error message
+        assert str(exc.value) == "('error message',)"
+
+    def test_check_recovery_dir_exists(self):
+        """Verify check_recovery_dir_exists passes if the directory exists."""
+        # GIVEN a mock check_directory_exists command which returns True
+        cmd = mock.Mock()
+        cmd.check_directory_exists.return_value = True
+
+        # WHEN check_recovery_dir_exists is called, no exceptions are raised
+        SnapshotRecoveryExecutor.check_recovery_dir_exists("/path/to/recovery_dir", cmd)
+
+    def test_check_recovery_dir_exists_faiure(self):
+        """Verify check_recovery_dir_exists raises exception if no directory exists."""
+        # GIVEN a mock check_directory_exists command which returns True
+        cmd = mock.Mock()
+        cmd.check_directory_exists.return_value = False
+
+        # WHEN check_recovery_dir_exists is called
+        # THEN a RecoveryPreconditionException is raised
+        with pytest.raises(RecoveryPreconditionException) as exc:
+            SnapshotRecoveryExecutor.check_recovery_dir_exists(
+                "/path/to/recovery_dir", cmd
+            )
+
+        # AND the exception has the expected message
+        expected_message = (
+            "Recovery directory '{}' does not exist on the recovery instance. "
+            "Check all required disks have been created, attached and mounted."
+        ).format("/path/to/recovery_dir")
+        assert str(exc.value) == expected_message
+
+    @pytest.mark.parametrize(
+        ("attached_snapshots", "snapshots_info", "expected_missing"),
+        (
+            # If all snapshots are present we expect success
+            [
+                {"snapshot0": "/dev/dev0", "snapshot1": "/dev/dev1"},
+                mock.Mock(
+                    snapshots=[mock.Mock(identifier="snapshot0", device="/dev/dev0")]
+                ),
+                [],
+            ],
+            [
+                {"snapshot0": "/dev/dev0", "snapshot1": "/dev/dev1"},
+                mock.Mock(
+                    snapshots=[
+                        mock.Mock(identifier="snapshot0", device="/dev/dev0"),
+                        mock.Mock(identifier="snapshot1", device="/dev/dev1"),
+                    ]
+                ),
+                [],
+            ],
+            # One or more snapshots are not attached so we expected failure
+            [
+                {"snapshot0": "/dev/dev0"},
+                mock.Mock(
+                    snapshots=[
+                        mock.Mock(identifier="snapshot0", device="/dev/dev0"),
+                        mock.Mock(identifier="snapshot1", device="/dev/dev1"),
+                    ]
+                ),
+                ["snapshot1"],
+            ],
+            [
+                {},
+                mock.Mock(
+                    snapshots=[
+                        mock.Mock(identifier="snapshot0", device="/dev/dev0"),
+                        mock.Mock(identifier="snapshot1", device="/dev/dev1"),
+                    ]
+                ),
+                ["snapshot0", "snapshot1"],
+            ],
+        ),
+    )
+    def test_get_attached_snapshots_for_backup(
+        self, attached_snapshots, snapshots_info, expected_missing
+    ):
+        """Verify that the attached snapshots for the backup are returned."""
+        # GIVEN a mock CloudSnapshotInterface which returns the specified attached
+        # snapshots
+        mock_snapshot_interface = mock.Mock()
+        mock_snapshot_interface.get_attached_snapshots.return_value = attached_snapshots
+        # AND a mock backup_info which contains the specified snapshots
+        mock_backup_info = mock.Mock(snapshots_info=snapshots_info)
+        # AND a given instance and zone
+        instance = "gcp_instance_name"
+        zone = "gcp_zone"
+
+        # WHEN get_attached_snapshots_for_backup is called
+        # THEN if we expect missing snapshots, a RecoveryPreconditionException is
+        # raised
+        if expected_missing:
+            with pytest.raises(RecoveryPreconditionException) as exc:
+                SnapshotRecoveryExecutor.get_attached_snapshots_for_backup(
+                    mock_snapshot_interface, mock_backup_info, instance, zone
+                )
+            # AND the exception has the expected message
+            message_part_1, message_part_2 = str(exc.value).split(": ")
+            expected_message = "The following snapshots are not attached to recovery instance {}".format(
+                instance
+            )
+            assert message_part_1 == expected_message
+            assert set(message_part_2.split(", ")) == set(expected_missing)
+        else:
+            # AND if we do not expect missing snapshots, no exception is raised and
+            # the expected snapshots are returned
+            attached_snapshots_for_backup = (
+                SnapshotRecoveryExecutor.get_attached_snapshots_for_backup(
+                    mock_snapshot_interface, mock_backup_info, instance, zone
+                )
+            )
+            for snapshot_metadata in snapshots_info.snapshots:
+                assert (
+                    attached_snapshots_for_backup[snapshot_metadata.identifier]
+                    == snapshot_metadata.device
+                )
+
+    def test_get_attached_snapshots_for_backup_no_snapshots_info(
+        self,
+    ):
+        """
+        Verify that an empty dict is returned for backups which have no snapshots_info.
+        """
+        # GIVEN a backup_info with no snapshots_info
+        mock_backup_info = mock.Mock(snapshots_info=None)
+        # WHEN get_attached_snapshots_for_backup is called
+        snapshots = SnapshotRecoveryExecutor.get_attached_snapshots_for_backup(
+            mock.Mock(), mock_backup_info, "instance", "zone"
+        )
+        # THEN we expect an empty list to be returned
+        assert snapshots == {}
+
+    @pytest.mark.parametrize(
+        ("findmnt_output", "expected_error"),
+        (
+            # If the mount_point and mount_options returned by findmnt match those in
+            # backup_info.snapshots_info then we expect success.
+            [
+                (("/opt/disk0", "rw,noatime"), ("/opt/disk1", "rw")),
+                None,
+            ],
+            # If findmnt raises a CommandException we expect an error finding that
+            # mount point
+            [
+                CommandException("ssh error"),
+                (
+                    "Error checking mount points: Error finding mount point for device "
+                    "/dev/dev0: ssh error, Error finding mount point for device "
+                    "/dev/dev1: ssh error"
+                ),
+            ],
+            # If a mount point cannot be found we expect an error message reporting
+            # it could not be found
+            [
+                ([None, None], [None, None]),
+                (
+                    "Error checking mount points: Could not find device /dev/dev0 "
+                    "at any mount point, Could not find device /dev/dev1 at any mount "
+                    "point"
+                ),
+            ],
+            # If a snapshot is mounted at an unexpected location then we expect an
+            # error message reporting that this is the case
+            [
+                (("/opt/disk2", "rw,noatime"), ("/opt/disk3", "rw")),
+                (
+                    "Error checking mount points: Device /dev/dev0 cloned from "
+                    "snapshot snapshot0 is mounted at /opt/disk2 but /opt/disk0 was "
+                    "expected., Device /dev/dev1 cloned from snapshot snapshot1 is "
+                    "mounted at /opt/disk3 but /opt/disk1 was expected."
+                ),
+            ],
+            # If a snapshot is mounted with unexpected options then we expect an
+            # error message reporting that this is the case
+            [
+                (("/opt/disk0", "rw"), ("/opt/disk1", "rw,noatime")),
+                (
+                    "Error checking mount options: Device /dev/dev0 cloned from "
+                    "snapshot snapshot0 is mounted with rw but rw,noatime was "
+                    "expected., Device /dev/dev1 cloned from snapshot snapshot1 is "
+                    "mounted with rw,noatime but rw was expected."
+                ),
+            ],
+        ),
+    )
+    def test_check_mount_points(self, findmnt_output, expected_error):
+        """Verify check_mount_points fails when expected."""
+        # GIVEN a findmnt command which returns the specified output
+        cmd = mock.Mock()
+        cmd.findmnt.side_effect = findmnt_output
+        # AND a backup_info which contains the specified snapshots_info
+        snapshots_info = mock.Mock(
+            snapshots=[
+                mock.Mock(
+                    identifier="snapshot0",
+                    device="/dev/dev0",
+                    mount_point="/opt/disk0",
+                    mount_options="rw,noatime",
+                ),
+                mock.Mock(
+                    identifier="snapshot1",
+                    device="/dev/dev1",
+                    mount_point="/opt/disk1",
+                    mount_options="rw",
+                ),
+            ]
+        )
+        backup_info = mock.Mock(snapshots_info=snapshots_info)
+        # AND each snapshot is attached as a specified device
+        attached_snapshots = {
+            "snapshot0": "/dev/dev0",
+            "snapshot1": "/dev/dev1",
+        }
+
+        # WHEN check_mount_points is called and no error is expected
+        # THEN no exception is raised
+        if not expected_error:
+            SnapshotRecoveryExecutor.check_mount_points(
+                backup_info, attached_snapshots, cmd
+            )
+        # WHEN errors are expected
+        else:
+            # THEN a RecoveryPreconditionException is raised
+            with pytest.raises(RecoveryPreconditionException) as exc:
+                SnapshotRecoveryExecutor.check_mount_points(
+                    backup_info, attached_snapshots, cmd
+                )
+            # AND the message matches the expected error message
+            assert str(exc.value) == expected_error
+
+
 class TestRecoveryExecutorFactory(object):
     @pytest.mark.parametrize(
-        ("compression", "expected_executor", "should_error"),
+        ("compression", "expected_executor", "snapshots_info", "should_error"),
         [
-            # No compression should return RecoveryExecutor
-            (None, RecoveryExecutor, False),
+            # No compression or snapshots_info should return RecoveryExecutor
+            (None, RecoveryExecutor, None, False),
             # Supported compression should return TarballRecoveryExecutor
-            ("gzip", TarballRecoveryExecutor, False),
+            ("gzip", TarballRecoveryExecutor, None, False),
             # Unrecognised compression should cause an error
-            ("snappy", None, True),
+            ("snappy", None, None, True),
+            # A backup_info with snapshots_info should return SnapshotRecoveryExecutor
+            (None, SnapshotRecoveryExecutor, mock.Mock(), False),
         ],
     )
     def test_recovery_executor_factory(
-        self, compression, expected_executor, should_error
+        self, compression, expected_executor, snapshots_info, should_error
     ):
         mock_backup_manager = mock.Mock()
         mock_command = mock.Mock()
+        mock_backup_info = mock.Mock(
+            compression=compression, snapshots_info=snapshots_info
+        )
 
         # WHEN recovery_executor_factory is called with the specified compression
+        function_under_test = partial(
+            recovery_executor_factory,
+            mock_backup_manager,
+            mock_command,
+            mock_backup_info,
+        )
         # THEN if an error is expected we see an error
         if should_error:
             with pytest.raises(AttributeError):
-                recovery_executor_factory(
-                    mock_backup_manager, mock_command, compression
-                )
+                function_under_test()
         # OR the expected type of recovery executor is returned
         else:
-            executor = recovery_executor_factory(
-                mock_backup_manager, mock_command, compression
-            )
+            executor = function_under_test()
             assert type(executor) is expected_executor
 
 

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -45,6 +45,7 @@ def build_test_backup_info(
     begin_wal="000000010000000000000002",
     begin_xlog="0/2000028",
     config_file="/pgdata/location/postgresql.conf",
+    deduplicated_size=None,
     end_offset=184,
     end_time=None,
     end_wal="000000010000000000000002",
@@ -65,6 +66,7 @@ def build_test_backup_info(
     timeline=1,
     version=90302,
     server=None,
+    systemid=None,
     copy_stats=None,
 ):
     """

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -57,6 +57,7 @@ def build_test_backup_info(
     pgdata="/pgdata/location",
     server_name="test_server",
     size=12345,
+    snapshots_info=None,
     status=BackupInfo.DONE,
     included_files=None,
     tablespaces=(
@@ -315,6 +316,11 @@ def build_config_dictionary(config_keys=None):
         "create_slot": "manual",
         "forward_config_path": False,
         "primary_conninfo": None,
+        "snapshot_disks": None,
+        "snapshot_instance": None,
+        "snapshot_provider": None,
+        "snapshot_zone": None,
+        "snapshot_gcp_project": None,
     }
     # Check for overriding keys
     if config_keys is not None:

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,22 @@ basepython = python3.7
 commands = flake8 {posargs}
 deps = -r tests/requirements_flake8.txt
 
+[testenv:py37]
+deps = -r tests/requirements_dev.txt
+       .[google-snapshots]
+
+[testenv:py38]
+deps = -r tests/requirements_dev.txt
+       .[google-snapshots]
+
+[testenv:py39]
+deps = -r tests/requirements_dev.txt
+       .[google-snapshots]
+
+[testenv:py310]
+deps = -r tests/requirements_dev.txt
+       .[google-snapshots]
+
 [flake8]
 select = E,F,W,C
 ignore = E203, E501, W503


### PR DESCRIPTION
This is the PR #710 branch ([#620-gce-snapshots-barman-cloud-refactor](https://github.com/EnterpriseDB/barman/tree/620-gce-snapshots-barman-cloud-refactor)) with the commit history rewritten into a more easily consumable form, PR feedback from the draft PR addressed, and rebased onto the latest barman trunk.

The diff between this PR branch and #710 can be found [here](https://github.com/EnterpriseDB/barman/compare/620-gce-snapshots-barman-cloud-refactor..620-gcp-snapshots).

Notes for reviewers:

- The new code is broken down into four separate commits:
  - Support for snapshot backups in Barman.
  - Support for recovery of snapshot backups in Barman.
  - Support for snapshot backups in Barman Cloud.
  - Support for restore of snapshot backups in Barman Cloud.
 - Each commit is preceded by one or more refactoring commits which prepare the existing code for the snapshot-related additions.
 - Unit tests for each part of the feature (or refactoring) are included in the relevant commit.
 - It is suggested that the code is reviewed on a commit-by-commit basis.
 - No documentation changes are included. When the documentation changes are ready they will be a separate PR as this is already a +++ridiculous LOC PR.
 - There is no corresponding integration tests PR. The integration tests still need to run to validate that no existing functionality is broken however snapshot functionality will be tested using a specific test suite for the snapshot feature (not yet ready for PR but a functioning branch is available [here](https://github.com/EnterpriseDB/barman-av/compare/snapshot-integration-testing?expand=1)).