### PR TITLE
Remove google snapshots deps from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,22 +16,6 @@ basepython = python3.7
 commands = flake8 {posargs}
 deps = -r tests/requirements_flake8.txt
 
-[testenv:py37]
-deps = -r tests/requirements_dev.txt
-       .[google-snapshots]
-
-[testenv:py38]
-deps = -r tests/requirements_dev.txt
-       .[google-snapshots]
-
-[testenv:py39]
-deps = -r tests/requirements_dev.txt
-       .[google-snapshots]
-
-[testenv:py310]
-deps = -r tests/requirements_dev.txt
-       .[google-snapshots]
-
 [flake8]
 select = E,F,W,C
 ignore = E203, E501, W503


### PR DESCRIPTION
These were added so that the unit tests could pass in CI however since adding them the unit tests were updated to mock out the underlying library and no longer need it.