### PR TITLE
Store backup_name in backup_info at the earliest opportunity

### DIFF
--- a/barman/backup.py
+++ b/barman/backup.py
@@ -595,9 +595,12 @@ class BackupManager(RemoteStatusMixin, KeepManagerMixin):
         try:
             # Create the BackupInfo object representing the backup
             backup_info = LocalBackupInfo(
-                self.server, backup_id=datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
+                self.server,
+                backup_id=datetime.datetime.now().strftime("%Y%m%dT%H%M%S"),
+                backup_name=name,
             )
             backup_info.set_attribute("systemid", self.server.systemid)
+
             backup_info.save()
             self.backup_cache_add(backup_info)
             output.info(
@@ -688,9 +691,6 @@ class BackupManager(RemoteStatusMixin, KeepManagerMixin):
         finally:
             if backup_info:
                 backup_info.save()
-
-                # Set the backup friendly name if there is one
-                backup_info.backup_name = name
 
                 # Make sure we are not holding any PostgreSQL connection
                 # during the post-backup scripts

--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -159,7 +159,6 @@ def main(args=None):
             raise SystemExit(0)
 
         with closing(cloud_interface):
-
             # TODO: Should the setup be optional?
             cloud_interface.setup_bucket()
 

--- a/barman/clients/walrestore.py
+++ b/barman/clients/walrestore.py
@@ -411,7 +411,6 @@ def parse_arguments(args=None):
 
 
 class RemoteGetWal(object):
-
     processes = set()
     """
     The list of processes that has been spawned by RemoteGetWal

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -162,7 +162,6 @@ class TarFileIgnoringTruncate(tarfile.TarFile):
 
 
 class CloudTarUploader(object):
-
     # This is the method we use to create new buffers
     # We use named temporary files, so we can pass them by name to
     # other processes
@@ -317,7 +316,6 @@ class CloudUploadController(object):
         :rtype: tarfile.TarFile
         """
         if name not in self.tar_list or not self.tar_list[name]:
-
             self.tar_list[name] = [
                 CloudTarUploader(
                     cloud_interface=self.cloud_interface,
@@ -2023,7 +2021,6 @@ class CloudBackupCatalog(KeepManagerMixinCloud):
         :rtype: Dict[str,BackupInfo]
         """
         if self._backup_list is None:
-
             backup_list = {}
 
             # get backups metadata

--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -125,7 +125,6 @@ def get_cloud_interface(config):
     elif config.cloud_provider == "azure-blob-storage":
         return _make_azure_cloud_interface(config, cloud_interface_kwargs)
     elif config.cloud_provider == "google-cloud-storage":
-
         return _make_google_cloud_interface(config, cloud_interface_kwargs)
     else:
         raise CloudProviderUnsupported(

--- a/barman/command_wrappers.py
+++ b/barman/command_wrappers.py
@@ -954,7 +954,7 @@ class PgBaseBackup(PostgreSQLClient):
 
         # The tablespace mapping option is repeated once for each tablespace
         if tbs_mapping:
-            for (tbs_source, tbs_destination) in tbs_mapping.items():
+            for tbs_source, tbs_destination in tbs_mapping.items():
                 self.args.append(
                     "--tablespace-mapping=%s=%s" % (tbs_source, tbs_destination)
                 )

--- a/barman/copy_controller.py
+++ b/barman/copy_controller.py
@@ -522,7 +522,6 @@ class RsyncCopyController(object):
 
             # Execute some preliminary steps for each item to be copied
             for item in self.item_list:
-
                 # The initial preparation is necessary only for directories
                 if not item.is_directory:
                     continue
@@ -614,7 +613,6 @@ class RsyncCopyController(object):
         :rtype: iter[_RsyncJob]
         """
         for item_idx, item in enumerate(self.item_list):
-
             # Skip items of classes which are not required
             if include_classes and item.item_class not in include_classes:
                 continue
@@ -624,7 +622,6 @@ class RsyncCopyController(object):
             # If the item is a directory then copy it in two stages,
             # otherwise copy it using a plain rsync
             if item.is_directory:
-
                 # Copy the safe files using the default rsync algorithm
                 msg = self._progress_message("[%%s] %%s copy safe files from %s" % item)
                 phase_skipped = True

--- a/barman/fs.py
+++ b/barman/fs.py
@@ -316,7 +316,6 @@ class UnixLocalCommand(object):
         return result == 0
 
     def ping(self):
-
         """
         'Ping' the server executing the `true` command.
 

--- a/barman/infofile.py
+++ b/barman/infofile.py
@@ -161,7 +161,6 @@ class Field(object):
 
 
 class FieldListFile(object):
-
     __slots__ = ("_fields", "filename")
 
     # A list of fields which should be hidden if they are not set.
@@ -431,7 +430,6 @@ class WalFileInfo(FieldListFile):
 
 
 class BackupInfo(FieldListFile):
-
     #: Conversion to string
     EMPTY = "EMPTY"
     STARTED = "STARTED"

--- a/barman/output.py
+++ b/barman/output.py
@@ -383,7 +383,6 @@ class ConsoleOutputWriter(object):
     SERVER_OUTPUT_PREFIX = "Server %s:"
 
     def __init__(self, debug=False, quiet=False):
-
         """
         Default output writer that output everything on console.
 

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -620,7 +620,6 @@ class RecoveryExecutor(object):
             )
             output.close_and_exit()
         for item in backup_info.tablespaces:
-
             # build the filename of the link under pg_tblspc directory
             pg_tblspc_file = os.path.join(tblspc_dir, str(item.oid))
 
@@ -1200,7 +1199,6 @@ class RecoveryExecutor(object):
         validator = ConfigIssueDetection()
         # Check for dangerous options inside every config file
         for conf_file in recovery_info["temporary_configuration_files"]:
-
             append_lines = None
             if conf_file.endswith("postgresql.auto.conf"):
                 append_lines = recovery_info.get("auto_conf_append_lines")
@@ -1762,7 +1760,6 @@ def recovery_executor_factory(backup_manager, command, backup_info):
 
 
 class ConfigurationFileMangeler:
-
     # List of options that, if present, need to be forced to a specific value
     # during recovery, to avoid data losses
     OPTIONS_TO_MANGLE = {

--- a/barman/server.py
+++ b/barman/server.py
@@ -2014,7 +2014,6 @@ class Server(RemoteStatusMixin):
         wal_paths = self.get_wal_possible_paths(wal_name, partial)
 
         for wal_file in wal_paths:
-
             # Check for file existence
             if not os.path.exists(wal_file):
                 continue
@@ -2729,7 +2728,6 @@ class Server(RemoteStatusMixin):
                     mode = "a%s" % mode[1:]
 
             with open(xlogdb, mode) as f:
-
                 # execute the block nested in the with statement
                 try:
                     yield f

--- a/barman/utils.py
+++ b/barman/utils.py
@@ -511,6 +511,7 @@ def with_metaclass(meta, *bases):
 
     :param type meta: Metaclass to add to base class
     """
+
     # This requires a bit of explanation: the basic idea is to make a
     # dummy metaclass for one level of class instantiation that replaces
     # itself with the actual metaclass.
@@ -527,6 +528,7 @@ def timeout(timeout_duration):
     ContextManager responsible for timing out the contained
     block of code after a defined time interval.
     """
+
     # Define the handler for the alarm signal
     def handler(signum, frame):
         raise TimeoutError()

--- a/barman/wal_archiver.py
+++ b/barman/wal_archiver.py
@@ -478,7 +478,6 @@ class FileWalArchiver(WalArchiver):
     """
 
     def __init__(self, backup_manager):
-
         super(FileWalArchiver, self).__init__(backup_manager, "file archival")
 
     def fetch_remote_status(self):

--- a/scripts/prepare_snapshot_recovery.py
+++ b/scripts/prepare_snapshot_recovery.py
@@ -356,7 +356,6 @@ def main():
     gcp_compute = GcpComputeFacade(args.project_id)
     snapshots = []
     for snapshot_info in backup_info.snapshots_info.snapshots:
-
         snapshot = gcp_compute.get_snapshot(
             snapshot_info.snapshot_project,
             snapshot_info.snapshot_name,

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -742,13 +742,12 @@ class TestBackup(object):
         )
 
     @pytest.mark.parametrize("should_fail", (True, False))
-    @patch("barman.backup.LocalBackupInfo")
-    def test_backup_with_name(self, mock_backup_info, should_fail):
+    @patch("barman.backup.LocalBackupInfo.save")
+    @patch("barman.backup.output")
+    def test_backup_with_name(self, _mock_output, _mock_backup_info_save, should_fail):
         """Verify that backup name is written to backup info during the backup."""
         # GIVEN a backup manager
         backup_manager = build_backup_manager()
-        backup_info = mock_backup_info.return_value
-        backup_info.size = 0
         backup_manager.executor.backup = Mock()
         backup_manager.executor.copy_start_time = datetime.now()
 
@@ -758,19 +757,20 @@ class TestBackup(object):
 
         # WHEN a backup is taken with a given name
         backup_name = "arire tbaan tvir lbh hc"
-        backup_manager.backup(name=backup_name)
+        backup_info = backup_manager.backup(name=backup_name)
 
         # THEN the backup name is set on the backup_info
         assert backup_info.backup_name == backup_name
 
     @pytest.mark.parametrize("should_fail", (True, False))
-    @patch("barman.backup.LocalBackupInfo")
-    def test_backup_without_name(self, mock_backup_info, should_fail):
+    @patch("barman.backup.LocalBackupInfo.save")
+    @patch("barman.backup.output")
+    def test_backup_without_name(
+        self, _mock_output, _mock_backup_info_save, should_fail
+    ):
         """Verify that backup name is not written to backup info if name not used."""
         # GIVEN a backup manager
         backup_manager = build_backup_manager()
-        backup_info = mock_backup_info.return_value
-        backup_info.size = 0
         backup_manager.executor.backup = Mock()
         backup_manager.executor.copy_start_time = datetime.now()
 
@@ -779,7 +779,7 @@ class TestBackup(object):
             backup_manager.executor.backup.side_effect = Exception("failed!")
 
         # WHEN a backup is taken with no name
-        backup_manager.backup()
+        backup_info = backup_manager.backup()
 
         # THEN backup name is None in the backup_info
         assert backup_info.backup_name is None

--- a/tests/test_barman_wal_archive.py
+++ b/tests/test_barman_wal_archive.py
@@ -139,7 +139,6 @@ class TestMain(object):
 
     @mock.patch("barman.clients.walarchive.RemotePutWal")
     def test_error_dir(self, rpw_mock, tmpdir, capsys):
-
         with pytest.raises(SystemExit) as exc:
             walarchive.main(["a.host", "a-server", tmpdir.strpath])
 
@@ -199,7 +198,6 @@ class TestMain(object):
 
     @mock.patch("barman.clients.walarchive.subprocess.Popen")
     def test_connectivity_test_returns_subprocess_output(self, popen_mock, capsys):
-
         popen_mock.return_value.communicate.return_value = (
             b"Tested subprocess return code percolation",
             b"",
@@ -216,7 +214,6 @@ class TestMain(object):
 
     @mock.patch("barman.clients.walarchive.subprocess.Popen")
     def test_connectivity_test_error(self, popen_mock, capsys):
-
         popen_mock.return_value.communicate.side_effect = subprocess.CalledProcessError(
             255, "remote barman"
         )

--- a/tests/test_barman_wal_restore.py
+++ b/tests/test_barman_wal_restore.py
@@ -47,7 +47,6 @@ class TestRemoteGetWal(object):
 
     @mock.patch("barman.clients.walrestore.subprocess.Popen")
     def test_connectivity_test_ok(self, popen_mock, capsys):
-
         popen_mock.return_value.communicate.return_value = ("Good test!", "")
         popen_mock.return_value.returncode = 0
 
@@ -61,7 +60,6 @@ class TestRemoteGetWal(object):
 
     @mock.patch("barman.clients.walrestore.subprocess.Popen")
     def test_connectivity_test_error(self, popen_mock, capsys):
-
         popen_mock.return_value.communicate.side_effect = subprocess.CalledProcessError(
             255, "remote barman"
         )

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -2628,7 +2628,6 @@ end_time=2014-12-22 09:25:27.410470+01:00
         ],
     )
     def test_can_list_wals(self, expected_wal, wal_path, suffix):
-
         """Test the various different WAL files are listed correctly"""
         self._verify_wal_is_in_catalog(
             expected_wal,

--- a/tests/test_compressor.py
+++ b/tests/test_compressor.py
@@ -265,7 +265,6 @@ class TestCommandCompressors(object):
         )
 
     def test_gzip(self, tmpdir):
-
         config_mock = mock.Mock()
 
         compression_manager = CompressionManager(config_mock, tmpdir.strpath)
@@ -291,7 +290,6 @@ class TestCommandCompressors(object):
         assert f == "content"
 
     def test_bzip2(self, tmpdir):
-
         config_mock = mock.Mock()
 
         compression_manager = CompressionManager(config_mock, tmpdir.strpath)
@@ -320,7 +318,6 @@ class TestCommandCompressors(object):
 # noinspection PyMethodMayBeStatic
 class TestInternalCompressors(object):
     def test_gzip(self, tmpdir):
-
         config_mock = mock.Mock()
 
         compression_manager = CompressionManager(config_mock, tmpdir.strpath)
@@ -346,7 +343,6 @@ class TestInternalCompressors(object):
         assert f == "content"
 
     def test_bzip2(self, tmpdir):
-
         config_mock = mock.Mock()
 
         compression_manager = CompressionManager(config_mock, tmpdir.strpath)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -80,7 +80,6 @@ class TestOutputAPI(object):
     # noinspection PyProtectedMember,PyUnresolvedReferences
     @mock.patch.dict(output.AVAILABLE_WRITERS, mock=mock.Mock())
     def test_set_output_writer_close(self):
-
         old_writer = mock.Mock()
         output.set_output_writer(old_writer)
 

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -1291,7 +1291,6 @@ class TestRecoveryExecutor(object):
         unix_command_factory,
         tmpdir,
     ):
-
         # This backup is waiting for WALs and it remains in that status
         # even after having copied the data files
         backup_info_mock.WAITING_FOR_WALS = "WAITING_FOR_WALS"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1096,7 +1096,6 @@ class TestServer(object):
 
     @patch("barman.server.ProcessManager")
     def test_kill(self, pm_mock, capsys):
-
         server = build_real_server()
 
         # Empty process list, the process is not running

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -379,7 +379,6 @@ class TestPrettySize(object):
         assert barman.utils.pretty_size(val, base) == "-10240.0 YiB"
 
     def test_float(self):
-
         assert barman.utils.pretty_size(1234, 1000) == barman.utils.pretty_size(
             1234.0, 1000
         )

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -145,7 +145,6 @@ def mock_backup_ext_info(
     copy_stats={},
     **kwargs
 ):
-
     # make a dictionary with all the arguments
     ext_info = dict(locals())
     del ext_info["backup_info"]


### PR DESCRIPTION
Changes the point at which the backup_name is stored in the backup_info to the creation of the backup_info rather than the `finally` block in `BackupManager.backup`. Because the backup_name will not change during the backup there is no good reason for deferring the assignment.

This fixes an issue where backup_name was not saved in the `backup.info` file when the `--wait` option was used. This was because the backup_name was assigned so late in the process that it relied on the final check of the backup to save the backup info. When `--wait` is used, this check actually happens *before* the `finally` block executes which means the backup metadata is saved before `backup_name` is assigned. This meant that the `--name` option was effectively ignored if the `--wait` option was used.

Closes #748.