### PR TITLE
Add support for AWS SSEKMSKeyId to barman cloud

### DIFF
--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -372,6 +372,12 @@ def parse_arguments(args=None):
         "Allowed values: 'AES256'|'aws:kms'.",
         choices=["AES256", "aws:kms"],
     )
+    s3_arguments.add_argument(
+        "--sse-kms-key-id",
+        help="The AWS KMS key ID that should be used for encrypting the uploaded data "
+        "in S3. Can be specified using the key ID on its own or using the full ARN for "
+        "the key. Only allowed if `-e/--encryption` is set to `aws:kms`.",
+    )
     azure_arguments.add_argument(
         "--encryption-scope",
         help="The name of an encryption scope defined in the Azure Blob Storage "

--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -173,6 +173,12 @@ def parse_arguments(args=None):
         choices=["AES256", "aws:kms"],
         metavar="ENCRYPTION",
     )
+    s3_arguments.add_argument(
+        "--sse-kms-key-id",
+        help="The AWS KMS key ID that should be used for encrypting the uploaded data "
+        "in S3. Can be specified using the key ID on its own or using the full ARN for "
+        "the key. Only allowed if `-e/--encryption` is set to `aws:kms`.",
+    )
     azure_arguments.add_argument(
         "--encryption-scope",
         help="The name of an encryption scope defined in the Azure Blob Storage "

--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -54,6 +54,16 @@ def _make_s3_cloud_interface(config, cloud_interface_kwargs):
     )
     if "encryption" in config:
         cloud_interface_kwargs["encryption"] = config.encryption
+    if "sse_kms_key_id" in config:
+        if (
+            config.sse_kms_key_id is not None
+            and "encryption" in config
+            and config.encryption != "aws:kms"
+        ):
+            raise CloudProviderOptionUnsupported(
+                'Encryption type must be "aws:kms" if SSE KMS Key ID is specified'
+            )
+        cloud_interface_kwargs["sse_kms_key_id"] = config.sse_kms_key_id
     return S3CloudInterface(**cloud_interface_kwargs)
 
 

--- a/barman/cloud_providers/aws_s3.py
+++ b/barman/cloud_providers/aws_s3.py
@@ -98,6 +98,7 @@ class S3CloudInterface(CloudInterface):
         tags=None,
         delete_batch_size=None,
         read_timeout=None,
+        sse_kms_key_id=None,
     ):
         """
         Create a new S3 interface given the S3 destination url and the profile
@@ -114,6 +115,8 @@ class S3CloudInterface(CloudInterface):
           deleted in a single request
         :param int|None read_timeout: the time in seconds until a timeout is
           raised when waiting to read from a connection
+        :param str|None sse_kms_key_id: the AWS KMS key ID that should be used
+          for encrypting uploaded data in S3
         """
         super(S3CloudInterface, self).__init__(
             url=url,
@@ -125,6 +128,7 @@ class S3CloudInterface(CloudInterface):
         self.encryption = encryption
         self.endpoint_url = endpoint_url
         self.read_timeout = read_timeout
+        self.sse_kms_key_id = sse_kms_key_id
 
         # Extract information from the destination URL
         parsed_url = urlparse(url)
@@ -161,6 +165,8 @@ class S3CloudInterface(CloudInterface):
         additional_args = {}
         if self.encryption:
             additional_args["ServerSideEncryption"] = self.encryption
+        if self.sse_kms_key_id:
+            additional_args["SSEKMSKeyId"] = self.sse_kms_key_id
         return additional_args
 
     def test_connectivity(self):

--- a/doc/barman-cloud-backup.1
+++ b/doc/barman-cloud-backup.1
@@ -56,6 +56,7 @@ usage:\ barman\-cloud\-backup\ [\-V]\ [\-\-help]\ [\-v\ |\ \-q]\ [\-t]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-snapshot\-zone\ SNAPSHOT_ZONE]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-snapshot\-gcp\-project\ SNAPSHOT_GCP_PROJECT]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-tags\ [TAGS\ [TAGS\ ...]]]\ [\-e\ {AES256,aws:kms}]
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-sse\-kms\-key\-id\ SSE_KMS_KEY_ID]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-encryption\-scope\ ENCRYPTION_SCOPE]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ destination_url\ server_name
 
@@ -124,6 +125,11 @@ Extra\ options\ for\ the\ aws\-s3\ cloud\ provider:
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ The\ encryption\ algorithm\ used\ when\ storing\ the
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ uploaded\ data\ in\ S3.\ Allowed\ values:
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \[aq]AES256\[aq]|\[aq]aws:kms\[aq].
+\ \ \-\-sse\-kms\-key\-id\ SSE_KMS_KEY_ID
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ The\ AWS\ KMS\ key\ ID\ that\ should\ be\ used\ for\ encrypting
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ the\ uploaded\ data\ in\ S3.\ Can\ be\ specified\ using\ the
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ key\ ID\ on\ its\ own\ or\ using\ the\ full\ ARN\ for\ the\ key.
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ Only\ allowed\ if\ `\-e/\-\-encryption`\ is\ set\ to\ `aws:kms`.
 
 Extra\ options\ for\ the\ azure\-blob\-storage\ cloud\ provider:
 \ \ \-\-credential\ {azure\-cli,managed\-identity}

--- a/doc/barman-cloud-backup.1.md
+++ b/doc/barman-cloud-backup.1.md
@@ -53,6 +53,7 @@ usage: barman-cloud-backup [-V] [--help] [-v | -q] [-t]
                            [--snapshot-zone SNAPSHOT_ZONE]
                            [--snapshot-gcp-project SNAPSHOT_GCP_PROJECT]
                            [--tags [TAGS [TAGS ...]]] [-e {AES256,aws:kms}]
+                           [--sse-kms-key-id SSE_KMS_KEY_ID]
                            [--encryption-scope ENCRYPTION_SCOPE]
                            destination_url server_name
 
@@ -121,6 +122,11 @@ Extra options for the aws-s3 cloud provider:
                         The encryption algorithm used when storing the
                         uploaded data in S3. Allowed values:
                         'AES256'|'aws:kms'.
+  --sse-kms-key-id SSE_KMS_KEY_ID
+                        The AWS KMS key ID that should be used for encrypting
+                        the uploaded data in S3. Can be specified using the
+                        key ID on its own or using the full ARN for the key.
+                        Only allowed if `-e/--encryption` is set to `aws:kms`.
 
 Extra options for the azure-blob-storage cloud provider:
   --credential {azure-cli,managed-identity}

--- a/doc/barman-cloud-wal-archive.1
+++ b/doc/barman-cloud-wal-archive.1
@@ -38,6 +38,7 @@ usage:\ barman\-cloud\-wal\-archive\ [\-V]\ [\-\-help]\ [\-v\ |\ \-q]\ [\-t]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-tags\ [TAGS\ [TAGS\ ...]]]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-history\-tags\ [HISTORY_TAGS\ [HISTORY_TAGS\ ...]]]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-e\ ENCRYPTION]
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-sse\-kms\-key\-id\ SSE_KMS_KEY_ID]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-encryption\-scope\ ENCRYPTION_SCOPE]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-max\-block\-size\ MAX_BLOCK_SIZE]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-max\-concurrency\ MAX_CONCURRENCY]
@@ -90,6 +91,11 @@ Extra\ options\ for\ the\ aws\-s3\ cloud\ provider:
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ The\ encryption\ algorithm\ used\ when\ storing\ the
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ uploaded\ data\ in\ S3.\ Allowed\ values:
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \[aq]AES256\[aq]|\[aq]aws:kms\[aq].
+\ \ \-\-sse\-kms\-key\-id\ SSE_KMS_KEY_ID
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ The\ AWS\ KMS\ key\ ID\ that\ should\ be\ used\ for\ encrypting
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ the\ uploaded\ data\ in\ S3.\ Can\ be\ specified\ using\ the
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ key\ ID\ on\ its\ own\ or\ using\ the\ full\ ARN\ for\ the\ key.
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ Only\ allowed\ if\ `\-e/\-\-encryption`\ is\ set\ to\ `aws:kms`.
 
 Extra\ options\ for\ the\ azure\-blob\-storage\ cloud\ provider:
 \ \ \-\-credential\ {azure\-cli,managed\-identity}

--- a/doc/barman-cloud-wal-archive.1.md
+++ b/doc/barman-cloud-wal-archive.1.md
@@ -38,6 +38,7 @@ usage: barman-cloud-wal-archive [-V] [--help] [-v | -q] [-t]
                                 [--tags [TAGS [TAGS ...]]]
                                 [--history-tags [HISTORY_TAGS [HISTORY_TAGS ...]]]
                                 [-e ENCRYPTION]
+                                [--sse-kms-key-id SSE_KMS_KEY_ID]
                                 [--encryption-scope ENCRYPTION_SCOPE]
                                 [--max-block-size MAX_BLOCK_SIZE]
                                 [--max-concurrency MAX_CONCURRENCY]
@@ -90,6 +91,11 @@ Extra options for the aws-s3 cloud provider:
                         The encryption algorithm used when storing the
                         uploaded data in S3. Allowed values:
                         'AES256'|'aws:kms'.
+  --sse-kms-key-id SSE_KMS_KEY_ID
+                        The AWS KMS key ID that should be used for encrypting
+                        the uploaded data in S3. Can be specified using the
+                        key ID on its own or using the full ARN for the key.
+                        Only allowed if `-e/--encryption` is set to `aws:kms`.
 
 Extra options for the azure-blob-storage cloud provider:
   --credential {azure-cli,managed-identity}


### PR DESCRIPTION
Allows the AWS KMS key ID to be specified in `barman-cloud-backup` and `barman-cloud-wal-archive` commands.