### PR TITLE
Add support for GCP kms_key_name to barman cloud

### DIFF
--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -360,6 +360,11 @@ def parse_arguments(args=None):
         "--snapshot-gcp-project",
         help="GCP project under which disk snapshots should be stored",
     )
+    gcs_arguments.add_argument(
+        "--kms-key-name",
+        help="The name of the GCP KMS key which should be used for encrypting the "
+        "uploaded data in GCS.",
+    )
     add_tag_argument(
         parser,
         name="tags",

--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -165,6 +165,14 @@ def parse_arguments(args=None):
         name="history-tags",
         help="Tags to be added to archived history files in cloud storage",
     )
+    gcs_arguments = parser.add_argument_group(
+        "Extra options for google-cloud-storage cloud provider"
+    )
+    gcs_arguments.add_argument(
+        "--kms-key-name",
+        help="The name of the GCP KMS key which should be used for encrypting the "
+        "uploaded data in GCS.",
+    )
     s3_arguments.add_argument(
         "-e",
         "--encryption",

--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -112,6 +112,16 @@ def _make_google_cloud_interface(config, cloud_interface_kwargs):
     from barman.cloud_providers.google_cloud_storage import GoogleCloudInterface
 
     cloud_interface_kwargs["jobs"] = 1
+    if "kms_key_name" in config:
+        if (
+            config.kms_key_name is not None
+            and "snapshot_instance" in config
+            and config.snapshot_instance is not None
+        ):
+            raise CloudProviderOptionUnsupported(
+                "KMS key cannot be specified for snapshot backups"
+            )
+        cloud_interface_kwargs["kms_key_name"] = config.kms_key_name
     return GoogleCloudInterface(**cloud_interface_kwargs)
 
 

--- a/doc/barman-cloud-backup.1
+++ b/doc/barman-cloud-backup.1
@@ -55,6 +55,7 @@ usage:\ barman\-cloud\-backup\ [\-V]\ [\-\-help]\ [\-v\ |\ \-q]\ [\-t]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-snapshot\-disk\ NAME]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-snapshot\-zone\ SNAPSHOT_ZONE]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-snapshot\-gcp\-project\ SNAPSHOT_GCP_PROJECT]
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-kms\-key\-name\ KMS_KEY_NAME]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-tags\ [TAGS\ [TAGS\ ...]]]\ [\-e\ {AES256,aws:kms}]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-sse\-kms\-key\-id\ SSE_KMS_KEY_ID]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-encryption\-scope\ ENCRYPTION_SCOPE]
@@ -147,6 +148,9 @@ Extra\ options\ for\ the\ azure\-blob\-storage\ cloud\ provider:
 Extra\ options\ for\ google\-cloud\-storage\ cloud\ provider:
 \ \ \-\-snapshot\-gcp\-project\ SNAPSHOT_GCP_PROJECT
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ GCP\ project\ under\ which\ disk\ snapshots\ should\ be\ stored
+\ \ \-\-kms\-key\-name\ KMS_KEY_NAME
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ The\ name\ of\ the\ GCP\ KMS\ key\ which\ should\ be\ used\ for
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ encrypting\ the\ uploaded\ data\ in\ GCS.
 \f[]
 .fi
 .SH REFERENCES

--- a/doc/barman-cloud-backup.1.md
+++ b/doc/barman-cloud-backup.1.md
@@ -52,6 +52,7 @@ usage: barman-cloud-backup [-V] [--help] [-v | -q] [-t]
                            [--snapshot-disk NAME]
                            [--snapshot-zone SNAPSHOT_ZONE]
                            [--snapshot-gcp-project SNAPSHOT_GCP_PROJECT]
+                           [--kms-key-name KMS_KEY_NAME]
                            [--tags [TAGS [TAGS ...]]] [-e {AES256,aws:kms}]
                            [--sse-kms-key-id SSE_KMS_KEY_ID]
                            [--encryption-scope ENCRYPTION_SCOPE]
@@ -144,6 +145,9 @@ Extra options for the azure-blob-storage cloud provider:
 Extra options for google-cloud-storage cloud provider:
   --snapshot-gcp-project SNAPSHOT_GCP_PROJECT
                         GCP project under which disk snapshots should be stored
+  --kms-key-name KMS_KEY_NAME
+                        The name of the GCP KMS key which should be used for
+                        encrypting the uploaded data in GCS.
 ```
 # REFERENCES
 

--- a/doc/barman-cloud-wal-archive.1
+++ b/doc/barman-cloud-wal-archive.1
@@ -37,7 +37,7 @@ usage:\ barman\-cloud\-wal\-archive\ [\-V]\ [\-\-help]\ [\-v\ |\ \-q]\ [\-t]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-z\ |\ \-j\ |\ \-\-snappy]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-tags\ [TAGS\ [TAGS\ ...]]]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-history\-tags\ [HISTORY_TAGS\ [HISTORY_TAGS\ ...]]]
-\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-e\ ENCRYPTION]
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-kms\-key\-name\ KMS_KEY_NAME]\ [\-e\ ENCRYPTION]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-sse\-kms\-key\-id\ SSE_KMS_KEY_ID]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-encryption\-scope\ ENCRYPTION_SCOPE]
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [\-\-max\-block\-size\ MAX_BLOCK_SIZE]
@@ -121,6 +121,12 @@ Extra\ options\ for\ the\ azure\-blob\-storage\ cloud\ provider:
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ set\ lower\ than\ the\ PostgreSQL\ WAL\ segment\ size\ after
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ any\ applied\ compression\ then\ the\ concurrent\ chunk
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ upload\ method\ for\ WAL\ archiving\ will\ be\ used.
+
+
+Extra\ options\ for\ google\-cloud\-storage\ cloud\ provider:
+\ \ \-\-kms\-key\-name\ KMS_KEY_NAME
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ The\ name\ of\ the\ GCP\ KMS\ key\ which\ should\ be\ used\ for
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ encrypting\ the\ uploaded\ data\ in\ GCS.
 \f[]
 .fi
 .SH REFERENCES

--- a/doc/barman-cloud-wal-archive.1.md
+++ b/doc/barman-cloud-wal-archive.1.md
@@ -37,7 +37,7 @@ usage: barman-cloud-wal-archive [-V] [--help] [-v | -q] [-t]
                                 [-z | -j | --snappy]
                                 [--tags [TAGS [TAGS ...]]]
                                 [--history-tags [HISTORY_TAGS [HISTORY_TAGS ...]]]
-                                [-e ENCRYPTION]
+                                [--kms-key-name KMS_KEY_NAME] [-e ENCRYPTION]
                                 [--sse-kms-key-id SSE_KMS_KEY_ID]
                                 [--encryption-scope ENCRYPTION_SCOPE]
                                 [--max-block-size MAX_BLOCK_SIZE]
@@ -121,6 +121,12 @@ Extra options for the azure-blob-storage cloud provider:
                         set lower than the PostgreSQL WAL segment size after
                         any applied compression then the concurrent chunk
                         upload method for WAL archiving will be used.
+
+
+Extra options for google-cloud-storage cloud provider:
+  --kms-key-name KMS_KEY_NAME
+                        The name of the GCP KMS key which should be used for
+                        encrypting the uploaded data in GCS.
 ```
 # REFERENCES
 

--- a/tests/test_barman_cloud_backup.py
+++ b/tests/test_barman_cloud_backup.py
@@ -323,6 +323,58 @@ class TestCloudBackup(object):
             **expected_cloud_interface_kwargs
         )
 
+    @pytest.mark.parametrize(
+        ("gcp_cli_args", "expected_cloud_interface_kwargs"),
+        [
+            # Defaults should result in None values being passed
+            (
+                [],
+                {
+                    "kms_key_name": None,
+                },
+            ),
+            # If values are provided then they should be passed to the cloud interface
+            (
+                ["--kms-key-name", "somekeyname"],
+                {
+                    "kms_key_name": "somekeyname",
+                },
+            ),
+        ],
+    )
+    @mock.patch("barman.clients.cloud_backup.PostgreSQLConnection")
+    @mock.patch("barman.cloud_providers.google_cloud_storage.GoogleCloudInterface")
+    @mock.patch("barman.clients.cloud_backup.CloudBackupUploader")
+    def test_gcp_encryption_args(
+        self,
+        _uploader_mock,
+        cloud_interface_mock,
+        _mock_postgres_conn,
+        _rmtree_mock,
+        _tempfile_mock,
+        gcp_cli_args,
+        expected_cloud_interface_kwargs,
+    ):
+        """Verify that GCP encryption arguments are passed to the cloud interface."""
+        # WHEN barman-cloud-backup is run with the provided arguments
+        cloud_backup.main(
+            [
+                "cloud_storage_url",
+                "test_server",
+                "--cloud-provider",
+                "google-cloud-storage",
+            ]
+            + gcp_cli_args
+        )
+
+        # THEN they are passed to the cloud interface
+        cloud_interface_mock.assert_called_once_with(
+            url="cloud_storage_url",
+            jobs=1,
+            tags=None,
+            **expected_cloud_interface_kwargs
+        )
+
 
 @mock.patch("barman.clients.cloud_backup.tempfile")
 @mock.patch("barman.clients.cloud_backup.rmtree")


### PR DESCRIPTION
Allows the kms_key_name to be specified in `barman-cloud-backup` and `barman-cloud-wal-archive`.

Based on #757 