### PR TITLE
Specify utf-8 encoding when parsing `version.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ install_requires = [
 ]
 
 barman = {}
-with open("barman/version.py", "r") as fversion:
+with open("barman/version.py", "r", encoding="utf-8") as fversion:
     exec(fversion.read(), barman)
 
 setup(


### PR DESCRIPTION
Updates `setup.py` so that it specifies utf-8 encoding when opening the `version.py` file to read the version string.

This resolves a packaging error on certain Python 3.6 distributions (e.g. EL7) where the file is decoded using ascii encoding, resulting in the following error when running `python3 setup.py build`:

    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 26: ordinal not in range(128)

By specifying `encoding="utf-8"` we correctly decode the file and can build for Python 3.6 on EL7.

Note: This change is not compatible with Python 2.7 so should not be backported to any branch where Python 2.7 compatibility is required.