### PR TITLE
State PostgreSQL version required for --recovery-conf-filename

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -743,9 +743,8 @@ def rebuild_xlogdb(args):
             "--recovery-conf-filename",
             dest="recovery_conf_filename",
             help=(
-                "Name of the file to which recovery configuration will be added "
-                "(default: postgresql.auto.conf for PostgreSQL 12 and newer, "
-                "recovery.conf for earlier versions)."
+                "Name of the file to which recovery configuration options will be "
+                "added for PostgreSQL 12 and later (default: postgresql.auto.conf)."
             ),
         ),
         argument(

--- a/doc/barman.1
+++ b/doc/barman.1
@@ -572,11 +572,10 @@ and has no effect otherwise.
 .TP
 .B \-\-recovery\-conf\-filename \f[I]RECOVERY_CONF_FILENAME\f[]
 The name of the file where Barman should write the PostgreSQL recovery
-options.
-This defaults to postgresql.auto.conf (or recovery.conf for PostgreSQL
-versions earlier than 12) however if \-\-recovery\-conf\-filename is
-used then recovery options will be written to RECOVERY_CONF_FILENAME
-instead.
+options when recovering backups for PostgreSQL versions 12 and later.
+This defaults to postgresql.auto.conf however if
+\-\-recovery\-conf\-filename is used then recovery options will be
+written to RECOVERY_CONF_FILENAME instead.
 The default value is correct for a typical PostgreSQL installation
 however if PostgreSQL is being managed by tooling which modifies the
 configuration mechanism (for example postgresql.auto.conf could be

--- a/doc/barman.1.d/50-recover.md
+++ b/doc/barman.1.d/50-recover.md
@@ -98,14 +98,14 @@ recover *\[OPTIONS\]* *SERVER_NAME* *BACKUP_ID* *DESTINATION_DIRECTORY*
 
     --recovery-conf-filename *RECOVERY_CONF_FILENAME*
     :   The name of the file where Barman should write the PostgreSQL recovery
-        options. This defaults to postgresql.auto.conf (or recovery.conf for
-        PostgreSQL versions earlier than 12) however if --recovery-conf-filename
-        is used then recovery options will be written to RECOVERY_CONF_FILENAME
-        instead. The default value is correct for a typical PostgreSQL
-        installation however if PostgreSQL is being managed by tooling which
-        modifies the configuration mechanism (for example postgresql.auto.conf
-        could be symlinked to /dev/null) then this option can be used to write
-        the recovery options to an alternative location.
+        options when recovering backups for PostgreSQL versions 12 and later.
+        This defaults to postgresql.auto.conf however if
+        --recovery-conf-filename is used then recovery options will be written
+        to RECOVERY_CONF_FILENAME instead. The default value is correct for a
+        typical PostgreSQL installation however if PostgreSQL is being managed
+        by tooling which modifies the configuration mechanism (for example
+        postgresql.auto.conf could be symlinked to /dev/null) then this option
+        can be used to write the recovery options to an alternative location.
 
     --snapshot-recovery-instance *INSTANCE_NAME*
     :   Name of the instance where the disks recovered from the snapshots are


### PR DESCRIPTION
Updates the docs for the `--recovery-conf-filename` option so it is clear that the option only affects recovery of backups from PostgreSQL 12 or later.