### PR TITLE
Add links to referenced manual sections

### DIFF
--- a/doc/manual/00-head.en.md
+++ b/doc/manual/00-head.en.md
@@ -9,4 +9,5 @@
 > **IMPORTANT:** \newline
 > This manual assumes that you are familiar with theoretical disaster
 > recovery concepts, and that you have a grasp of PostgreSQL fundamentals in
-> terms of physical backup and disaster recovery. See section _"Before you start"_ below for details.
+> terms of physical backup and disaster recovery. See section _["Before you start"](#before-you-start)_
+> below for details.

--- a/doc/manual/10-design.en.md
+++ b/doc/manual/10-design.en.md
@@ -46,7 +46,7 @@ Remember that no decision is forever. You can start this way and adapt over time
 
 Another relevant feature that was first introduced by Barman is support for multiple servers. Barman can store backup data coming from multiple PostgreSQL instances, even with different versions, in a centralised way. [^recver]
 
-  [^recver]: The same [requirements for PostgreSQL's PITR][requirements_recovery] apply for recovery, as detailed in the section _"Requirements for recovery"_.
+  [^recver]: The same [requirements for PostgreSQL's PITR][requirements_recovery] apply for recovery, as detailed in the section _["Requirements for recovery"](#requirements-for-recovery)_.
 
 As a result, you can model complex disaster recovery architectures, forming a "star schema", where PostgreSQL servers rotate around a central Barman server.
 
@@ -70,7 +70,7 @@ Backup using `rsync`/SSH is recommended in all cases where `pg_basebackup` limit
 
 The reason why we recommend streaming backup is that, based on our experience, it is easier to setup than the traditional one. Also, streaming backup allows you to backup a PostgreSQL server on Windows[^windows], and makes life easier when working with Docker.
 
-  [^windows]: Backup of a PostgreSQL server on Windows is possible, but it is still experimental because it is not yet part of our continuous integration system. See section _"How to setup a Windows based server"_ for details.
+  [^windows]: Backup of a PostgreSQL server on Windows is possible, but it is still experimental because it is not yet part of our continuous integration system. See section _["How to setup a Windows based server"](#how-to-setup-a-windows-based-server)_ for details.
 
 ## The Barman WAL archive
 

--- a/doc/manual/20-server_setup.en.md
+++ b/doc/manual/20-server_setup.en.md
@@ -2,8 +2,8 @@
 
 # Setup of a new server in Barman
 
-As mentioned in the _"Design and architecture"_ section, we will use the
-following conventions:
+As mentioned in the _["Design and architecture"](#design-and-architecture)_
+section, we will use the following conventions:
 
 - `pg` as server ID and host name where PostgreSQL is installed
 - `backup` as host name where Barman is located

--- a/doc/manual/21-preliminary_steps.en.md
+++ b/doc/manual/21-preliminary_steps.en.md
@@ -6,9 +6,9 @@ undertake before setting up your PostgreSQL server in Barman.
 > **IMPORTANT:**
 > Before you proceed, it is important that you have made your decision
 > in terms of WAL archiving and backup strategies, as outlined in the
-> _"Design and architecture"_ section. In particular, you should
-> decide which WAL archiving methods to use, as well as the backup
-> method.
+> _["Design and architecture"](#design-and-architecture)_ section.
+> In particular, you should decide which WAL archiving methods to use,
+> as well as the backup method.
 
 ### PostgreSQL connection
 
@@ -170,8 +170,8 @@ max_replication_slots = 2
 ```
 
   [^replslot94]: Replication slots have been introduced in PostgreSQL 9.4.
-                 See section _"WAL Streaming / Replication slots"_ for
-                 details.
+                 See section _["WAL Streaming / Replication slots"](#replication-slots)_
+                 for details.
 
 The values proposed for `max_replication_slots` and `max_wal_senders`
 must be considered as examples, and the values you will use in your
@@ -248,7 +248,7 @@ postgres@pg$ ssh barman@backup -C true
 ```
 
 The value of the `archive_command` configuration parameter will be
-discussed in the _"WAL archiving via archive_command section"_.
+discussed in the _["WAL archiving via archive_command section"](#wal-archiving-via-archive_command)_.
 
 
 #### From Barman to PostgreSQL

--- a/doc/manual/22-config_file.en.md
+++ b/doc/manual/22-config_file.en.md
@@ -10,8 +10,8 @@ backup_method = postgres
 # backup_method = rsync
 ```
 
-The `conninfo` option is set accordingly to the section _"Preliminary
-steps: PostgreSQL connection"_.
+The `conninfo` option is set accordingly to the section _["Preliminary
+steps: PostgreSQL connection"](#postgresql-connection)_.
 
 The meaning of the `backup_method` option will be covered in the
 backup section of this guide.
@@ -25,4 +25,4 @@ streaming_conninfo = host=pg user=streaming_barman dbname=postgres
 ```
 
 This value must be chosen accordingly as described in the section
-_"Preliminary steps: PostgreSQL connection"_.
+_["Preliminary steps: PostgreSQL connection"](#postgresql-connection)_.

--- a/doc/manual/26-rsync_backup.en.md
+++ b/doc/manual/26-rsync_backup.en.md
@@ -2,8 +2,8 @@
 
 The backup over `rsync` was the only available method before 2.0, and
 is currently the only backup method that supports the incremental
-backup feature. Please consult the _"Features in detail"_ section for
-more information.
+backup feature. Please consult the _["Features in detail"](#features-in-detail)_
+section for more information.
 
 To take a backup using `rsync` you need to put these parameters inside
 the Barman server configuration file:

--- a/doc/manual/43-backup-commands.en.md
+++ b/doc/manual/43-backup-commands.en.md
@@ -262,7 +262,8 @@ in the WAL archive) and `current` (to recover to the timeline which was current
 when the backup was taken). If this option is omitted then PostgreSQL versions 12
 and above will recover to the `latest` timeline and PostgreSQL versions below 12
 will recover to the `current` timeline. You can find more details about timelines
-in the PostgreSQL documentation as mentioned in the _"Before you start"_ section.
+in the PostgreSQL documentation as mentioned in the _["Before you start"](#before-you-start)_
+section.
 
 Barman 2.4 introduces support for `--target-action` option, accepting
 the following values:


### PR DESCRIPTION
Improve the manual by linking to referenced sections instead of just referencing section names and have readers search the text.

The links work in HTML and PDF when building with `doc/build/build`. But I had to change `doc/Dockerfile` to use base image `debian:buster` as Stretch is EOL, causing `apt-get update` to fail. Also need to install package `texlive-fonts-recommended` and remove `latex-xcolor` and `texlive-math-extra`. The Dockerfile change is not included in this PR because I don't know if there are already plans to fix the doc build.

Unfortunately, Pandoc does not warn or fail on unknown anchors. This is prone to typos, as are references to section names.