### PR TITLE
BAR-18: Make snapshots implementation more portable

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -930,8 +930,6 @@ def recover(args):
         missing_args = []
         if not args.snapshot_recovery_instance:
             missing_args.append("--snapshot-recovery-instance")
-        if not args.snapshot_recovery_zone:
-            missing_args.append("--snapshot-recovery-zone")
         if len(missing_args) > 0:
             output.error(
                 "Backup %s is a snapshot backup and the following required arguments "
@@ -947,16 +945,18 @@ def recover(args):
                 backup_id.backup_id,
             )
             output.close_and_exit()
+        snapshot_provider_args = {}
+        for arg in vars(args):
+            if arg.startswith("snapshot_") and arg != "snapshot_recovery_instance":
+                snapshot_provider_args[arg] = getattr(args, arg)
         snapshot_kwargs = {
+            "provider_args": snapshot_provider_args,
             "recovery_instance": args.snapshot_recovery_instance,
-            "recovery_zone": args.snapshot_recovery_zone,
         }
     else:
         unexpected_args = []
         if args.snapshot_recovery_instance:
             unexpected_args.append("--snapshot-recovery-instance")
-        if args.snapshot_recovery_zone:
-            unexpected_args.append("--snapshot-recovery-zone")
         if len(unexpected_args) > 0:
             output.error(
                 "Backup %s is not a snapshot backup but the following snapshot "

--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -30,7 +30,6 @@ from barman.clients.cloud_cli import (
     NetworkErrorExit,
     OperationErrorExit,
     UrlArgumentType,
-    get_missing_attrs,
 )
 from barman.cloud import (
     CloudBackupSnapshot,
@@ -121,13 +120,6 @@ def _validate_config(config):
         [getattr(config, var) for var in required_snapshot_variables]
     )
     if is_snapshot_backup:
-        missing_options = get_missing_attrs(config, required_snapshot_variables)
-        if len(missing_options) > 0:
-            raise ConfigurationException(
-                "Incomplete options for snapshot backup - missing: %s"
-                % ", ".join(missing_options)
-            )
-
         if getattr(config, "compression"):
             raise ConfigurationException(
                 "Compression options cannot be used with snapshot backups"
@@ -208,8 +200,9 @@ def main(args=None):
 
                 with closing(postgres):
                     # Take snapshot backups if snapshot backups were specified
-                    if config.snapshot_instance:
+                    if config.snapshot_disks or config.snapshot_instance:
                         snapshot_interface = get_snapshot_interface(config)
+                        snapshot_interface.validate_backup_config(config)
                         snapshot_backup = CloudBackupSnapshot(
                             config.server_name,
                             cloud_interface,

--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -116,7 +116,6 @@ def _validate_config(config):
     required_snapshot_variables = (
         "snapshot_disks",
         "snapshot_instance",
-        "snapshot_zone",
     )
     is_snapshot_backup = any(
         [getattr(config, var) for var in required_snapshot_variables]
@@ -217,7 +216,6 @@ def main(args=None):
                             snapshot_interface,
                             postgres,
                             config.snapshot_instance,
-                            config.snapshot_zone,
                             config.snapshot_disks,
                             config.backup_name,
                         )

--- a/barman/clients/cloud_restore.py
+++ b/barman/clients/cloud_restore.py
@@ -336,15 +336,13 @@ class CloudBackupDownloaderSnapshot(CloudBackupDownloader):
         :param dict[str,str] provider_args: A dict of keyword arguments to be
             passed to the cloud provider
         """
-        attached_snapshots = SnapshotRecoveryExecutor.get_attached_snapshots_for_backup(
+        attached_volumes = SnapshotRecoveryExecutor.get_attached_volumes_for_backup(
             self.snapshot_interface,
             backup_info,
             recovery_instance,
         )
         cmd = UnixLocalCommand()
-        SnapshotRecoveryExecutor.check_mount_points(
-            backup_info, attached_snapshots, cmd
-        )
+        SnapshotRecoveryExecutor.check_mount_points(backup_info, attached_volumes, cmd)
         SnapshotRecoveryExecutor.check_recovery_dir_exists(destination_dir, cmd)
 
         # If the target directory does not exist then we will fail here because

--- a/barman/clients/cloud_restore.py
+++ b/barman/clients/cloud_restore.py
@@ -26,7 +26,6 @@ from barman.clients.cloud_cli import (
     GeneralErrorExit,
     NetworkErrorExit,
     OperationErrorExit,
-    get_missing_attrs,
 )
 from barman.cloud import CloudBackupCatalog, configure_logging
 from barman.cloud_providers import (
@@ -49,12 +48,6 @@ def _validate_config(config, backup_info):
     :param BackupInfo backup_info: The backup info for the backup to restore
     """
     if backup_info.snapshots_info:
-        missing_options = get_missing_attrs(config, ("snapshot_recovery_instance",))
-        if len(missing_options) > 0:
-            raise ConfigurationException(
-                "Incomplete options for snapshot restore - missing: %s"
-                % ", ".join(missing_options)
-            )
         if config.tablespace != []:
             raise ConfigurationException(
                 "Backup %s is a snapshot backup therefore tablespace relocation rules "
@@ -101,7 +94,6 @@ def main(args=None):
             _validate_config(config, backup_info)
 
             if backup_info.snapshots_info:
-                downloader = CloudBackupDownloaderSnapshot(cloud_interface, catalog)
                 provider_args = {}
                 for arg in vars(config):
                     if (
@@ -109,11 +101,17 @@ def main(args=None):
                         and arg != "snapshot_recovery_instance"
                     ):
                         provider_args[arg] = getattr(config, arg)
+                snapshot_interface = get_snapshot_interface_from_backup_info(
+                    backup_info, provider_args
+                )
+                snapshot_interface.validate_restore_config(config)
+                downloader = CloudBackupDownloaderSnapshot(
+                    cloud_interface, catalog, snapshot_interface
+                )
                 downloader.download_backup(
                     backup_info,
                     config.recovery_dir,
                     config.snapshot_recovery_instance,
-                    provider_args,
                 )
             else:
                 downloader = CloudBackupDownloaderObjectStore(cloud_interface, catalog)
@@ -308,8 +306,25 @@ class CloudBackupDownloaderObjectStore(CloudBackupDownloader):
 class CloudBackupDownloaderSnapshot(CloudBackupDownloader):
     """A minimal downloader for cloud backups which just retrieves the backup label."""
 
+    def __init__(self, cloud_interface, catalog, snapshot_interface):
+        """
+        Object responsible for handling interactions with cloud storage
+
+        :param CloudInterface cloud_interface: The interface to use to
+          upload the backup
+        :param str server_name: The name of the server as configured in Barman
+        :param CloudBackupCatalog catalog: The cloud backup catalog
+        :param CloudSnapshotInterface snapshot_interface: Interface for managing
+            snapshots via a cloud provider API.
+        """
+        super(CloudBackupDownloaderSnapshot, self).__init__(cloud_interface, catalog)
+        self.snapshot_interface = snapshot_interface
+
     def download_backup(
-        self, backup_info, destination_dir, recovery_instance, provider_args
+        self,
+        backup_info,
+        destination_dir,
+        recovery_instance,
     ):
         """
         Download a backup from cloud storage
@@ -321,11 +336,8 @@ class CloudBackupDownloaderSnapshot(CloudBackupDownloader):
         :param dict[str,str] provider_args: A dict of keyword arguments to be
             passed to the cloud provider
         """
-        snapshot_interface = get_snapshot_interface_from_backup_info(
-            backup_info, provider_args
-        )
         attached_snapshots = SnapshotRecoveryExecutor.get_attached_snapshots_for_backup(
-            snapshot_interface,
+            self.snapshot_interface,
             backup_info,
             recovery_instance,
         )

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -2216,18 +2216,6 @@ class CloudSnapshotInterface(with_metaclass(ABCMeta)):
     """Defines a common interface for handling cloud snapshots."""
 
     @abstractmethod
-    def take_snapshot(self, backup_info, disk_zone, disk_name):
-        """
-        Take a snapshot of a disk in the cloud.
-
-        :param barman.infofile.LocalBackupInfo backup_info: Backup information.
-        :param str disk_zone: The zone in which the disk resides.
-        :param str disk_name: The name of the source disk for the snapshot.
-        :rtype: str
-        :return: The name used to reference the snapshot with the cloud provider.
-        """
-
-    @abstractmethod
     def take_snapshot_backup(self, backup_info, instance_name, zone, disks):
         """
         Take a snapshot backup for the named instance.

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -2236,15 +2236,6 @@ class CloudSnapshotInterface(with_metaclass(ABCMeta)):
         """
 
     @abstractmethod
-    def delete_snapshot(self, snapshot_identifier):
-        """
-        Delete the specified snapshot.
-
-        :param str snapshot_identifier: An identifier used to reference this snapshot
-            within the cloud provider API.
-        """
-
-    @abstractmethod
     def delete_snapshot_backup(self, backup_info):
         """
         Delete all snapshots for the supplied backup.

--- a/barman/cloud_providers/google_cloud_storage.py
+++ b/barman/cloud_providers/google_cloud_storage.py
@@ -431,7 +431,7 @@ class GcpCloudSnapshotInterface(CloudSnapshotInterface):
                 % (disk_name, zone, self.project)
             )
 
-    def take_snapshot(self, backup_info, disk_zone, disk_name):
+    def _take_snapshot(self, backup_info, disk_zone, disk_name):
         """
         Take a snapshot of a persistent disk in GCP.
 
@@ -513,7 +513,7 @@ class GcpCloudSnapshotInterface(CloudSnapshotInterface):
             # We should always have exactly one attached disk matching the name
             assert len(attached_disks) == 1
 
-            snapshot_name = self.take_snapshot(backup_info, zone, disk_name)
+            snapshot_name = self._take_snapshot(backup_info, zone, disk_name)
             snapshots.append(
                 GcpSnapshotMetadata(
                     device_name=attached_disks[0].device_name,

--- a/barman/cloud_providers/google_cloud_storage.py
+++ b/barman/cloud_providers/google_cloud_storage.py
@@ -371,6 +371,15 @@ class GcpCloudSnapshotInterface(CloudSnapshotInterface):
         https://cloud.google.com/compute/docs/disks/create-snapshots
     """
 
+    _required_config_for_backup = CloudSnapshotInterface._required_config_for_backup + (
+        "snapshot_zone",
+    )
+
+    _required_config_for_restore = (
+        CloudSnapshotInterface._required_config_for_restore
+        + ("snapshot_recovery_zone",)
+    )
+
     DEVICE_PREFIX = "/dev/disk/by-id/google-"
 
     def __init__(self, project, zone=None):

--- a/barman/cloud_providers/google_cloud_storage.py
+++ b/barman/cloud_providers/google_cloud_storage.py
@@ -527,7 +527,7 @@ class GcpCloudSnapshotInterface(CloudSnapshotInterface):
             project=self.project, snapshots=snapshots
         )
 
-    def delete_snapshot(self, snapshot_name):
+    def _delete_snapshot(self, snapshot_name):
         """
         Delete the specified snapshot.
 
@@ -575,7 +575,7 @@ class GcpCloudSnapshotInterface(CloudSnapshotInterface):
                 snapshot.identifier,
                 backup_info.backup_id,
             )
-            self.delete_snapshot(snapshot.identifier)
+            self._delete_snapshot(snapshot.identifier)
 
     def get_attached_devices(self, instance_name, zone):
         """

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -43,7 +43,6 @@ from barman.config import RecoveryOptions
 from barman.copy_controller import RsyncCopyController
 from barman.exceptions import (
     BadXlogSegmentName,
-    CommandException,
     CommandFailedException,
     DataTransferFailure,
     FsOperationFailed,
@@ -51,6 +50,7 @@ from barman.exceptions import (
     RecoveryStandbyModeException,
     RecoveryTargetActionException,
     RecoveryPreconditionException,
+    SnapshotBackupException,
 )
 from barman.compression import GZipCompression, LZ4Compression, ZSTDCompression
 import barman.fs as fs
@@ -1543,9 +1543,7 @@ class SnapshotRecoveryExecutor(RemoteConfigRecoveryExecutor):
             raise RecoveryPreconditionException(message)
 
     @staticmethod
-    def get_attached_snapshots_for_backup(
-        snapshot_interface, backup_info, instance_name
-    ):
+    def get_attached_volumes_for_backup(snapshot_interface, backup_info, instance_name):
         """
         Verifies that disks cloned from the snapshots specified in the supplied
         backup_info are attached to the named instance and returns them as a dict
@@ -1569,15 +1567,19 @@ class SnapshotRecoveryExecutor(RemoteConfigRecoveryExecutor):
         """
         if backup_info.snapshots_info is None:
             return {}
-        attached_snapshots = snapshot_interface.get_attached_snapshots(instance_name)
-        attached_snapshots_for_backup = {}
+        attached_volumes = snapshot_interface.get_attached_volumes(instance_name)
+        attached_volumes_for_backup = {}
         missing_snapshots = []
         for source_snapshot in backup_info.snapshots_info.snapshots:
             try:
-                attached_snapshots_for_backup[
-                    source_snapshot.identifier
-                ] = attached_snapshots[source_snapshot.identifier]
-            except KeyError:
+                disk, attached_volume = [
+                    (k, v)
+                    for k, v in attached_volumes.items()
+                    if v.source_snapshot == source_snapshot.identifier
+                ][0]
+
+                attached_volumes_for_backup[disk] = attached_volume
+            except IndexError:
                 missing_snapshots.append(source_snapshot.identifier)
 
         if len(missing_snapshots) > 0:
@@ -1586,10 +1588,10 @@ class SnapshotRecoveryExecutor(RemoteConfigRecoveryExecutor):
                 % (instance_name, ", ".join(missing_snapshots))
             )
         else:
-            return attached_snapshots_for_backup
+            return attached_volumes_for_backup
 
     @staticmethod
-    def check_mount_points(backup_info, attached_snapshots, cmd):
+    def check_mount_points(backup_info, attached_volumes, cmd):
         """
         Check that each disk cloned from a snapshot is mounted at the same mount point
         as the original disk and with the same mount options.
@@ -1600,44 +1602,51 @@ class SnapshotRecoveryExecutor(RemoteConfigRecoveryExecutor):
 
         :param BackupInfo backup_info: Backup information for the backup being
             recovered.
-        :param dict[str,str] attached_snapshots: A dict of snapshot_name:device_path
-            mappings where the device_path is the path at which the disk cloned from
-            that snapshot is attached to the recovery instance.
+        :param dict[str,barman.cloud.VolumeMetadata] attached_volumes: Metadata for the
+            volumes attached to the recovery instance.
         :param UnixLocalCommand cmd: The command wrapper for running commands on the
             recovery instance.
         """
         mount_point_errors = []
         mount_options_errors = []
-        for snapshot, device in sorted(attached_snapshots.items()):
+        for disk, volume in sorted(attached_volumes.items()):
             try:
-                mount_point, mount_options = cmd.findmnt(device)
-            except CommandException as e:
+                volume.resolve_mounted_volume(cmd)
+                mount_point = volume.mount_point
+                mount_options = volume.mount_options
+            except SnapshotBackupException as e:
                 mount_point_errors.append(
-                    "Error finding mount point for device %s: %s" % (device, e)
+                    "Error finding mount point for disk %s: %s" % (disk, e)
                 )
                 continue
             if mount_point is None:
                 mount_point_errors.append(
-                    "Could not find device %s at any mount point" % device
+                    "Could not find disk %s at any mount point" % disk
                 )
                 continue
             snapshot_metadata = next(
                 metadata
                 for metadata in backup_info.snapshots_info.snapshots
-                if metadata.identifier == snapshot
+                if metadata.identifier == volume.source_snapshot
             )
             expected_mount_point = snapshot_metadata.mount_point
             expected_mount_options = snapshot_metadata.mount_options
             if mount_point != expected_mount_point:
                 mount_point_errors.append(
-                    "Device %s cloned from snapshot %s is mounted at %s but %s was "
-                    "expected." % (device, snapshot, mount_point, expected_mount_point)
+                    "Disk %s cloned from snapshot %s is mounted at %s but %s was "
+                    "expected."
+                    % (disk, volume.source_snapshot, mount_point, expected_mount_point)
                 )
             if mount_options != expected_mount_options:
                 mount_options_errors.append(
-                    "Device %s cloned from snapshot %s is mounted with %s but %s was "
+                    "Disk %s cloned from snapshot %s is mounted with %s but %s was "
                     "expected."
-                    % (device, snapshot, mount_options, expected_mount_options)
+                    % (
+                        disk,
+                        volume.source_snapshot,
+                        mount_options,
+                        expected_mount_options,
+                    )
                 )
         if len(mount_point_errors) > 0:
             raise RecoveryPreconditionException(
@@ -1699,13 +1708,11 @@ class SnapshotRecoveryExecutor(RemoteConfigRecoveryExecutor):
         snapshot_interface = get_snapshot_interface_from_backup_info(
             backup_info, provider_args
         )
-        attached_snapshots = self.get_attached_snapshots_for_backup(
+        attached_volumes = self.get_attached_volumes_for_backup(
             snapshot_interface, backup_info, recovery_instance
         )
         cmd = fs.unix_command_factory(remote_command, self.server.path)
-        SnapshotRecoveryExecutor.check_mount_points(
-            backup_info, attached_snapshots, cmd
-        )
+        SnapshotRecoveryExecutor.check_mount_points(backup_info, attached_volumes, cmd)
         self.check_recovery_dir_exists(dest, cmd)
 
         return super(SnapshotRecoveryExecutor, self).recover(

--- a/tests/test_barman_cloud_backup.py
+++ b/tests/test_barman_cloud_backup.py
@@ -126,6 +126,23 @@ class TestCloudBackup(object):
         (
             [
                 [
+                    "--cloud-provider",
+                    "google-cloud-storage",
+                    "--snapshot-gcp-project",
+                    "test-project",
+                    "--snapshot-disk",
+                    "disk0",
+                    "--snapshot-instance",
+                    "test_instance",
+                ],
+                "Incomplete options for snapshot backup - missing: snapshot_zone",
+            ],
+            [
+                [
+                    "--cloud-provider",
+                    "google-cloud-storage",
+                    "--snapshot-gcp-project",
+                    "test-project",
                     "--snapshot-zone",
                     "test_zone",
                     "--snapshot-instance",
@@ -134,11 +151,24 @@ class TestCloudBackup(object):
                 "Incomplete options for snapshot backup - missing: snapshot_disks",
             ],
             [
-                ["--snapshot-disk", "disk0", "--snapshot-zone", "test_zone"],
+                [
+                    "--cloud-provider",
+                    "google-cloud-storage",
+                    "--snapshot-gcp-project",
+                    "snapshot_gcp_project",
+                    "--snapshot-disk",
+                    "disk0",
+                    "--snapshot-zone",
+                    "test_zone",
+                ],
                 "Incomplete options for snapshot backup - missing: snapshot_instance",
             ],
             [
                 [
+                    "--cloud-provider",
+                    "google-cloud-storage",
+                    "--snapshot-gcp-project",
+                    "snapshot_gcp_project",
                     "--snapshot-disk",
                     "disk0",
                     "--snapshot-instance",
@@ -194,8 +224,12 @@ class TestCloudBackup(object):
     @mock.patch("barman.clients.cloud_backup.PostgreSQLConnection")
     @mock.patch("barman.clients.cloud_backup.get_cloud_interface")
     @mock.patch("barman.clients.cloud_backup.CloudBackupUploader")
+    @mock.patch(
+        "barman.cloud_providers.google_cloud_storage.import_google_cloud_compute"
+    )
     def test_unsupported_snapshot_args(
         self,
+        _mock_google_cloud_compute,
         uploader_mock,
         _cloud_interface_mock,
         _postgres_connection,

--- a/tests/test_barman_cloud_backup.py
+++ b/tests/test_barman_cloud_backup.py
@@ -125,10 +125,6 @@ class TestCloudBackup(object):
         ("snapshot_args", "expected_error"),
         (
             [
-                ["--snapshot-disk", "disk0", "--snapshot-instance", "test_instance"],
-                "Incomplete options for snapshot backup - missing: snapshot_zone",
-            ],
-            [
                 [
                     "--snapshot-zone",
                     "test_zone",
@@ -266,7 +262,6 @@ class TestCloudBackup(object):
             mock_get_snapshot_interface.return_value,
             postgres_connection.return_value,
             "test_instance",
-            "test_zone",
             [
                 "disk0",
             ],

--- a/tests/test_barman_cloud_restore.py
+++ b/tests/test_barman_cloud_restore.py
@@ -141,8 +141,12 @@ class TestCloudRestore(object):
     )
     @mock.patch("barman.clients.cloud_restore.CloudBackupCatalog")
     @mock.patch("barman.clients.cloud_restore.get_cloud_interface")
+    @mock.patch(
+        "barman.cloud_providers.google_cloud_storage.import_google_cloud_compute"
+    )
     def test_unsupported_snapshot_args(
         self,
+        _mock_google_cloud_compute,
         _mock_cloud_interface_factory,
         mock_catalog,
         snapshot_args,
@@ -158,7 +162,9 @@ class TestCloudRestore(object):
         backup_id = "20380119T031408"
         mock_catalog.return_value.parse_backup_id.return_value = backup_id
         # AND the catalog returns a mock backup_info with a snapshots_info field
-        mock_backup_info = mock.Mock(backup_id=backup_id, snapshots_info=mock.Mock())
+        mock_backup_info = mock.Mock(
+            backup_id=backup_id, snapshots_info=mock.Mock(provider="gcp")
+        )
         mock_catalog.return_value.get_backup_info.return_value = mock_backup_info
 
         # WHEN barman-cloud-restore is run with a subset of snapshot arguments

--- a/tests/test_barman_cloud_restore.py
+++ b/tests/test_barman_cloud_restore.py
@@ -172,6 +172,7 @@ class TestCloudRestore(object):
         # AND the expected error message occurs
         assert expected_error.format(**{"backup_id": backup_id}) in caplog.text
 
+    @mock.patch("barman.clients.cloud_restore.get_snapshot_interface_from_backup_info")
     @mock.patch("barman.clients.cloud_restore.CloudBackupDownloaderSnapshot")
     @mock.patch("barman.clients.cloud_restore.CloudBackupCatalog")
     @mock.patch("barman.clients.cloud_restore.get_cloud_interface")
@@ -180,6 +181,7 @@ class TestCloudRestore(object):
         mock_cloud_interface_factory,
         mock_catalog,
         mock_backup_downloader_snapshot,
+        mock_get_snapshot_interface,
     ):
         """
         Verify that restoring a snapshots backup uses CloudBackupDownloaderSnapshot
@@ -190,7 +192,9 @@ class TestCloudRestore(object):
         backup_id = "20380119T031408"
         mock_catalog.return_value.parse_backup_id.return_value = backup_id
         # AND the catalog returns a mock backup_info with a snapshots_info field
-        mock_backup_info = mock.Mock(backup_id=backup_id, snapshots_info=mock.Mock())
+        mock_backup_info = mock.Mock(
+            backup_id=backup_id, snapshots_info=mock.Mock(provider="gcp")
+        )
         mock_catalog.return_value.get_backup_info.return_value = mock_backup_info
 
         # WHEN barman-cloud-restore is run with the required arguments for a snapshots
@@ -213,12 +217,16 @@ class TestCloudRestore(object):
 
         # THEN a CloudBackupDownloaderSnapshot is created
         mock_backup_downloader_snapshot.assert_called_once_with(
-            mock_cloud_interface_factory.return_value, mock_catalog.return_value
+            mock_cloud_interface_factory.return_value,
+            mock_catalog.return_value,
+            mock_get_snapshot_interface.return_value,
         )
         # AND download_backup is called with the expected arguments
         backup_downloader = mock_backup_downloader_snapshot.return_value
         backup_downloader.download_backup.assert_called_once_with(
-            mock_backup_info, recovery_dir, recovery_instance, recovery_zone
+            mock_backup_info,
+            recovery_dir,
+            recovery_instance,
         )
 
 
@@ -339,36 +347,34 @@ class TestCloudBackupDownloaderSnapshot(TestCloudBackupDownloader):
     def backup_info(self, snapshots_info):
         yield mock.Mock(backup_id=self.backup_id, snapshots_info=snapshots_info)
 
-    @mock.patch("barman.clients.cloud_restore.get_snapshot_interface_from_backup_info")
     @mock.patch("barman.clients.cloud_restore.UnixLocalCommand")
     def test_download_backup(
         self,
         mock_cmd,
-        mock_get_snapshot_interface,
         backup_info,
         mock_cloud_interface,
         mock_catalog,
     ):
         """Verify that the backup label is downloaded if all preconditions are met."""
-        # GIVEN a CloudBackupDownloaderSnapshot
-        downloader = CloudBackupDownloaderSnapshot(mock_cloud_interface, mock_catalog)
-        # AND the specified snapshots are returned by the snapshot interface
-        mock_get_snapshot_interface.return_value.get_attached_snapshots.return_value = {
+        # GIVEN a snapshot interface which returns the specified snapshots
+        mock_snapshots_interface = mock.Mock()
+        mock_snapshots_interface.get_attached_snapshots.return_value = {
             "snapshot0": "/dev/dev0"
         }
+        # AND a CloudBackupDownloaderSnapshot
+        downloader = CloudBackupDownloaderSnapshot(
+            mock_cloud_interface, mock_catalog, mock_snapshots_interface
+        )
         # AND the following recovery args
         recovery_dir = "/path/to/restore_dir"
         recovery_instance = "test_instance"
-        recovery_zone = "test_zone"
         # AND a mock findmnt command which returns a successful response
         mock_cmd.return_value.findmnt.return_value = ["/opt/disk0", "rw,noatime"]
         # AND a mock check_directory_exists command which returns True
         mock_cmd.return_value.check_directory_exists.return_value = True
 
         # WHEN download_backup is called
-        downloader.download_backup(
-            backup_info, recovery_dir, recovery_instance, recovery_zone
-        )
+        downloader.download_backup(backup_info, recovery_dir, recovery_instance)
         # THEN the backup label is downloaded to the recovery destination
         mock_cloud_interface.download_file.assert_called_once_with(
             "{}/base/{}/backup_label".format(
@@ -421,12 +427,10 @@ class TestCloudBackupDownloaderSnapshot(TestCloudBackupDownloader):
             ],
         ),
     )
-    @mock.patch("barman.clients.cloud_restore.get_snapshot_interface_from_backup_info")
     @mock.patch("barman.clients.cloud_restore.UnixLocalCommand")
     def test_download_backup_preconditions_failed(
         self,
         mock_cmd,
-        mock_get_snapshot_interface,
         backup_info,
         mock_cloud_interface,
         mock_catalog,
@@ -436,16 +440,18 @@ class TestCloudBackupDownloaderSnapshot(TestCloudBackupDownloader):
         expected_error_msg,
     ):
         """Verify that backup download fails when preconditions are not met."""
-        # GIVEN a CloudBackupDownloaderSnapshot
-        downloader = CloudBackupDownloaderSnapshot(mock_cloud_interface, mock_catalog)
-        # AND the specified snapshots are returned by the snapshot interface
-        mock_get_snapshot_interface.return_value.get_attached_snapshots.return_value = (
+        # GIVEN a snapshot interface which returns the specified snapshots
+        mock_snapshots_interface = mock.Mock()
+        mock_snapshots_interface.get_attached_snapshots.return_value = (
             attached_snapshots
+        )
+        # AND a CloudBackupDownloaderSnapshot
+        downloader = CloudBackupDownloaderSnapshot(
+            mock_cloud_interface, mock_catalog, mock_snapshots_interface
         )
         # AND the following recovery args
         recovery_dir = "/path/to/restore_dir"
         recovery_instance = "test_instance"
-        recovery_zone = "test_zone"
         # AND a mock findmnt command which returns the specified response
         mock_cmd.return_value.findmnt.return_value = findmnt_output
         # AND a mock check_directory_exists command which returns the specified respone
@@ -456,9 +462,7 @@ class TestCloudBackupDownloaderSnapshot(TestCloudBackupDownloader):
         # WHEN download_backup is called
         # THEN a RecoveryPreconditionException is raised
         with pytest.raises(RecoveryPreconditionException) as exc:
-            downloader.download_backup(
-                backup_info, recovery_dir, recovery_instance, recovery_zone
-            )
+            downloader.download_backup(backup_info, recovery_dir, recovery_instance)
         # AND the exception has the expected message
         assert str(exc.value) == expected_error_msg.format(
             device_path=self.device_path,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -637,30 +637,6 @@ class TestCli(object):
                     "snapshot arguments have been used: --snapshot-recovery-instance"
                 ),
             ),
-            (
-                None,
-                {
-                    "snapshot_recovery_zone": "test_zone",
-                },
-                {},
-                (
-                    "Backup backup_id is not a snapshot backup but the following "
-                    "snapshot arguments have been used: --snapshot-recovery-zone"
-                ),
-            ),
-            (
-                None,
-                {
-                    "snapshot_recovery_instance": "test_instance",
-                    "snapshot_recovery_zone": "test_zone",
-                },
-                {},
-                (
-                    "Backup backup_id is not a snapshot backup but the following "
-                    "snapshot arguments have been used: --snapshot-recovery-instance, "
-                    "--snapshot-recovery-zone"
-                ),
-            ),
             # If there is snapshot_info but no snapshot args then there should be an
             # error
             (
@@ -669,8 +645,7 @@ class TestCli(object):
                 {},
                 (
                     "Backup backup_id is a snapshot backup and the following required "
-                    "arguments have not been provided: --snapshot-recovery-instance, "
-                    "--snapshot-recovery-zone"
+                    "arguments have not been provided: --snapshot-recovery-instance"
                 ),
             ),
             # If there is snapshot_info, snapshot args and also tablespace mappings
@@ -679,7 +654,6 @@ class TestCli(object):
                 Mock(snapshots=[]),
                 {
                     "snapshot_recovery_instance": "test_instance",
-                    "snapshot_recovery_zone": "test_zone",
                 },
                 {"tablespace": ("tbs1:/path/to/tbs1",)},
                 (
@@ -693,7 +667,6 @@ class TestCli(object):
                 Mock(snapshots=[]),
                 {
                     "snapshot_recovery_instance": "test_instance",
-                    "snapshot_recovery_zone": "test_zone",
                 },
                 {},
                 None,
@@ -745,10 +718,6 @@ class TestCli(object):
             assert (
                 server.recover.call_args_list[0][1]["recovery_instance"]
                 == snapshot_recovery_args["snapshot_recovery_instance"]
-            )
-            assert (
-                server.recover.call_args_list[0][1]["recovery_zone"]
-                == snapshot_recovery_args["snapshot_recovery_zone"]
             )
 
     def test_check_target_action(self):

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -3381,7 +3381,7 @@ class TestCloudBackupSnapshot(object):
                 False,
                 [],
                 [],
-                "Cannot find compute instance {snapshot_instance} in zone {snapshot_zone}",
+                "Cannot find compute instance {snapshot_instance}",
             ),
             (
                 True,
@@ -3417,7 +3417,6 @@ class TestCloudBackupSnapshot(object):
             snapshot_interface,
             mock_postgres,
             self.instance_name,
-            self.zone,
             self.disks,
         )
         # AND the compute instance has the specified state
@@ -3435,7 +3434,7 @@ class TestCloudBackupSnapshot(object):
 
         # AND the exception has the expected message
         assert str(exc.value) == expected_error_msg.format(
-            **{"snapshot_instance": self.instance_name, "snapshot_zone": self.zone}
+            **{"snapshot_instance": self.instance_name}
         )
 
     @mock.patch("barman.cloud.CloudBackup._get_backup_info")
@@ -3458,7 +3457,6 @@ class TestCloudBackupSnapshot(object):
             snapshot_interface,
             mock_postgres,
             self.instance_name,
-            self.zone,
             self.disks[:1],
         )
         # AND the instance exists
@@ -3494,7 +3492,7 @@ class TestCloudBackupSnapshot(object):
         )
 
         # AND a mock take_snapshot_backup function which sets snapshot_info
-        def mock_take_snapshot_backup(backup_info, _instance_name, _zone, _disks):
+        def mock_take_snapshot_backup(backup_info, _instance_name, _disks):
             backup_info.snapshots_info = mock.Mock(
                 snapshots=[mock.Mock(identifier="snapshot0", device="/dev/dev0")]
             )
@@ -3508,7 +3506,6 @@ class TestCloudBackupSnapshot(object):
         snapshot_interface.take_snapshot_backup.assert_called_once_with(
             backup_info,
             self.instance_name,
-            self.zone,
             self.disks[:1],
         )
         # AND the backup label was uploaded

--- a/tests/test_cloud_snapshot_interface.py
+++ b/tests/test_cloud_snapshot_interface.py
@@ -271,7 +271,7 @@ class TestGcpCloudSnapshotInterface(object):
 
     def test_take_snapshot(self, mock_google_cloud_compute, caplog):
         """
-        Verify that take_snapshot calls the GCP library and waits for the result.
+        Verify that _take_snapshot calls the GCP library and waits for the result.
         """
         # GIVEN a new GcpCloudSnapshotInterface
         snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
@@ -286,8 +286,8 @@ class TestGcpCloudSnapshotInterface(object):
         # AND log level is INFO
         caplog.set_level(logging.INFO)
 
-        # WHEN take_snapshot is called
-        snapshot_name = snapshot_interface.take_snapshot(
+        # WHEN _take_snapshot is called
+        snapshot_name = snapshot_interface._take_snapshot(
             backup_info,
             self.gcp_zone,
             self.gcp_disks[0]["name"],
@@ -343,8 +343,8 @@ class TestGcpCloudSnapshotInterface(object):
         # AND the response has warnings
         mock_resp.warnings = [mock.Mock(code="123", message="warning message")]
 
-        # WHEN take_snapshot is called
-        snapshot_name = snapshot_interface.take_snapshot(
+        # WHEN _take_snapshot is called
+        snapshot_name = snapshot_interface._take_snapshot(
             backup_info,
             self.gcp_zone,
             self.gcp_disks[0]["name"],
@@ -360,7 +360,7 @@ class TestGcpCloudSnapshotInterface(object):
 
     def test_take_snapshot_failed(self, mock_google_cloud_compute):
         """
-        Verify that take_snapshot raises an exception on failure.
+        Verify that _take_snapshot raises an exception on failure.
         """
         # GIVEN a new GcpCloudSnapshotInterface
         snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
@@ -373,10 +373,10 @@ class TestGcpCloudSnapshotInterface(object):
         mock_resp.error_code = "503"
         mock_resp.error_message = "test error message"
 
-        # WHEN take_snapshot is called
+        # WHEN _take_snapshot is called
         # THEN a CloudProviderError is raised
         with pytest.raises(CloudProviderError) as exc:
-            snapshot_interface.take_snapshot(
+            snapshot_interface._take_snapshot(
                 backup_info,
                 self.gcp_zone,
                 self.gcp_disks[0]["name"],

--- a/tests/test_cloud_snapshot_interface.py
+++ b/tests/test_cloud_snapshot_interface.py
@@ -673,7 +673,7 @@ class TestGcpCloudSnapshotInterface(object):
 
         # WHEN a snapshot is deleted
         snapshot_name = self._get_snapshot_name(self.gcp_disks[0])
-        snapshot_interface.delete_snapshot(snapshot_name)
+        snapshot_interface._delete_snapshot(snapshot_name)
 
         # THEN delete was called on the SnapshotsClient for that project/snapshot
         mock_snapshots_client = mock_google_cloud_compute.SnapshotsClient.return_value
@@ -699,7 +699,7 @@ class TestGcpCloudSnapshotInterface(object):
 
         # WHEN a snapshot is deleted
         snapshot_name = self._get_snapshot_name(self.gcp_disks[0])
-        snapshot_interface.delete_snapshot(snapshot_name)
+        snapshot_interface._delete_snapshot(snapshot_name)
 
         # THEN delete was called on the SnapshotsClient for that project/snapshot
         mock_snapshots_client = mock_google_cloud_compute.SnapshotsClient.return_value
@@ -724,7 +724,7 @@ class TestGcpCloudSnapshotInterface(object):
 
         # WHEN a snapshot is deleted
         snapshot_name = self._get_snapshot_name(self.gcp_disks[0])
-        snapshot_interface.delete_snapshot(snapshot_name)
+        snapshot_interface._delete_snapshot(snapshot_name)
 
         # THEN the warning is included in the log output
         assert (
@@ -749,7 +749,7 @@ class TestGcpCloudSnapshotInterface(object):
         # THEN a CloudProviderError is raised
         snapshot_name = self._get_snapshot_name(self.gcp_disks[0])
         with pytest.raises(CloudProviderError) as exc:
-            snapshot_interface.delete_snapshot(snapshot_name)
+            snapshot_interface._delete_snapshot(snapshot_name)
 
         # AND the exception message contains the snapshot name, error code and error
         # message

--- a/tests/test_cloud_snapshot_interface.py
+++ b/tests/test_cloud_snapshot_interface.py
@@ -30,9 +30,13 @@ from barman.cloud_providers import (
     get_snapshot_interface_from_backup_info,
     get_snapshot_interface_from_server_config,
 )
-from barman.cloud_providers.google_cloud_storage import GcpCloudSnapshotInterface
+from barman.cloud_providers.google_cloud_storage import (
+    GcpCloudSnapshotInterface,
+    GcpVolumeMetadata,
+)
 from barman.exceptions import (
     BarmanException,
+    CommandException,
     ConfigurationException,
     SnapshotBackupException,
 )
@@ -195,18 +199,24 @@ class TestGcpCloudSnapshotInterface(object):
             "device_name": "dev0",
             "physical_block_size": 1024,
             "size_gb": 1,
+            "mount_options": "rw,noatime",
+            "mount_point": "/opt/disk0",
         },
         {
             "name": "test_disk_1",
             "device_name": "dev1",
             "physical_block_size": 2048,
             "size_gb": 10,
+            "mount_options": "rw",
+            "mount_point": "/opt/disk0",
         },
         {
             "name": "test_disk_2",
             "device_name": "dev2",
             "physical_block_size": 4096,
             "size_gb": 100,
+            "mount_options": "rw,relatime",
+            "mount_point": "/opt/disk0",
         },
     )
     gcp_zone = "us-east1-b"
@@ -453,6 +463,17 @@ class TestGcpCloudSnapshotInterface(object):
         snapshots_client.delete.return_value = mock.Mock(error_code=None, warnings=None)
         return snapshots_client
 
+    def _get_mock_volumes(self, disks):
+        return dict(
+            (
+                disk["name"],
+                mock.Mock(
+                    mount_point=disk["mount_point"], mount_options=disk["mount_options"]
+                ),
+            )
+            for disk in disks
+        )
+
     @pytest.mark.parametrize("number_of_disks", (1, 2, 3))
     def test_take_snapshot_backup(
         self,
@@ -463,7 +484,7 @@ class TestGcpCloudSnapshotInterface(object):
         Verify that take_snapshot_backup takes the required snapshots and updates the
         backup_info when prerequisites are met.
         """
-        # GIVEN a set of disks
+        # GIVEN a set of disks, represented as VolumeMetadata
         disks = self.gcp_disks[:number_of_disks]
         # AND a backup_info for a given server name and backup ID
         backup_info = mock.Mock(backup_id=self.backup_id, server_name=self.server_name)
@@ -487,9 +508,7 @@ class TestGcpCloudSnapshotInterface(object):
 
         # WHEN take_snapshot_backup is called for multiple disks
         snapshot_interface.take_snapshot_backup(
-            backup_info,
-            self.gcp_instance_name,
-            (disk["name"] for disk in disks),
+            backup_info, self.gcp_instance_name, self._get_mock_volumes(disks)
         )
 
         # THEN the backup_info is updated with the expected snapshot metadata
@@ -505,10 +524,11 @@ class TestGcpCloudSnapshotInterface(object):
                 if snapshot.snapshot_name == snapshot_name
             )
             assert snapshot.identifier == snapshot_name
-            assert snapshot.device == self._get_device_path(disk["device_name"])
             assert snapshot.snapshot_name == snapshot_name
             assert snapshot.snapshot_project == self.gcp_project
             assert snapshot.device_name == disk["device_name"]
+            assert snapshot.mount_options == disk["mount_options"]
+            assert snapshot.mount_point == disk["mount_point"]
 
     def test_take_snapshot_backup_instance_not_found(self, mock_google_cloud_compute):
         """
@@ -525,7 +545,9 @@ class TestGcpCloudSnapshotInterface(object):
         # THEN a SnapshotBackupException is raised
         with pytest.raises(SnapshotBackupException) as exc:
             snapshot_interface.take_snapshot_backup(
-                mock.Mock(), self.gcp_instance_name, self.gcp_disks
+                mock.Mock(),
+                self.gcp_instance_name,
+                self._get_mock_volumes(self.gcp_disks),
             )
 
         # AND the exception contains the expected message
@@ -535,7 +557,7 @@ class TestGcpCloudSnapshotInterface(object):
             self.gcp_instance_name, self.gcp_zone, self.gcp_project
         )
 
-    def test_take_snapshot_backup_disk_not_found(
+    def test_get_attached_volumes_disk_not_found(
         self,
         mock_google_cloud_compute,
     ):
@@ -565,10 +587,8 @@ class TestGcpCloudSnapshotInterface(object):
         # WHEN take snapshot_backup is called
         # THEN a SnapshotBackupException is raised
         with pytest.raises(SnapshotBackupException) as exc:
-            snapshot_interface.take_snapshot_backup(
-                mock.Mock(),
-                self.gcp_instance_name,
-                (disk["name"] for disk in disks),
+            snapshot_interface.get_attached_volumes(
+                self.gcp_instance_name, [disk["name"] for disk in disks]
             )
 
         # AND the exception contains the expected message
@@ -578,7 +598,7 @@ class TestGcpCloudSnapshotInterface(object):
             disks[-1]["name"], self.gcp_zone, self.gcp_project
         )
 
-    def test_take_snapshot_backup_disk_not_attached(
+    def test_get_attached_volumes_disk_not_attached(
         self,
         mock_google_cloud_compute,
     ):
@@ -608,18 +628,16 @@ class TestGcpCloudSnapshotInterface(object):
         # WHEN take snapshot_backup is called
         # THEN a SnapshotBackupException is raised
         with pytest.raises(SnapshotBackupException) as exc:
-            snapshot_interface.take_snapshot_backup(
-                mock.Mock(),
-                self.gcp_instance_name,
-                (disk["name"] for disk in disks),
+            snapshot_interface.get_attached_volumes(
+                self.gcp_instance_name, [disk["name"] for disk in disks]
             )
 
         # AND the exception contains the expected message
-        assert str(exc.value) == "Disk {} not attached to instance {}".format(
-            disks[-1]["name"], self.gcp_instance_name
+        assert str(exc.value) == "Disks not attached to instance {}: {}".format(
+            self.gcp_instance_name, disks[-1]["name"]
         )
 
-    def test_take_snapshot_backup_disk_attached_multiple_times(
+    def test_get_attached_volumes_disk_attached_multiple_times(
         self,
         mock_google_cloud_compute,
     ):
@@ -650,10 +668,9 @@ class TestGcpCloudSnapshotInterface(object):
         # WHEN take snapshot_backup is called
         # THEN a SnapshotBackupException is raised
         with pytest.raises(AssertionError):
-            snapshot_interface.take_snapshot_backup(
-                mock.Mock(),
+            snapshot_interface.get_attached_volumes(
                 self.gcp_instance_name,
-                (disk["name"] for disk in disks),
+                [disk["name"] for disk in disks],
             )
 
     def test_delete_snapshot(self, mock_google_cloud_compute, caplog):
@@ -803,9 +820,15 @@ class TestGcpCloudSnapshotInterface(object):
             )
 
     @pytest.mark.parametrize(
-        ("mock_disks", "expected_disk_names", "expected_device_names"),
         (
-            ([], [], []),
+            "mock_disks",
+            "mock_disk_metadata",
+            "expected_disk_names",
+            "expected_device_names",
+            "expected_source_snapshots",
+        ),
+        (
+            ([], [], [], [], []),
             (
                 [
                     mock.Mock(
@@ -813,8 +836,30 @@ class TestGcpCloudSnapshotInterface(object):
                         device_name="dev0",
                     )
                 ],
+                [
+                    mock.Mock(
+                        source_snapshot=None,
+                    ),
+                ],
                 ["disk0"],
                 ["dev0"],
+                [None],
+            ),
+            (
+                [
+                    mock.Mock(
+                        source="projects/test_project/zones/us-east1-b/disks/disk0",
+                        device_name="dev0",
+                    )
+                ],
+                [
+                    mock.Mock(
+                        source_snapshot="snap0",
+                    ),
+                ],
+                ["disk0"],
+                ["dev0"],
+                ["snap0"],
             ),
             (
                 [
@@ -827,41 +872,60 @@ class TestGcpCloudSnapshotInterface(object):
                         device_name="dev1",
                     ),
                 ],
+                [
+                    mock.Mock(
+                        source_snapshot="snap0",
+                    ),
+                    mock.Mock(
+                        source_snapshot="snap1",
+                    ),
+                ],
                 ["disk0", "disk1"],
                 ["dev0", "dev1"],
+                ["snap0", "snap1"],
             ),
         ),
     )
-    def test_get_attached_devices(
+    def test_get_attached_volumes(
         self,
         mock_disks,
+        mock_disk_metadata,
         expected_disk_names,
         expected_device_names,
+        expected_source_snapshots,
         mock_google_cloud_compute,
     ):
-        """Verify that attached devices are returned as a dict keyed by disk name."""
+        """Verify that attached volumes are returned as a dict keyed by disk name."""
         # GIVEN a new GcpCloudSnapshotInterface
         snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
         # AND a mock InstancesClient which returns metadata listing the devices
         mock_instances_client = mock_google_cloud_compute.InstancesClient.return_value
         mock_instance_metadata = mock.Mock(disks=mock_disks)
         mock_instances_client.get.return_value = mock_instance_metadata
+        # AND a mock DisksClient which returns the specified source snapshots
+        mock_disks_client = mock_google_cloud_compute.DisksClient.return_value
+        mock_disks_client.get.side_effect = mock_disk_metadata
 
-        # WHEN get_attached_devices is called
-        attached_devices = snapshot_interface.get_attached_devices(
+        # WHEN get_attached_volumes is called
+        attached_volumes = snapshot_interface.get_attached_volumes(
             self.gcp_instance_name
         )
 
         # THEN a dict of devices returned by the instance metadata is returned, keyed
         # by disk name
-        assert len(attached_devices) == len(expected_disk_names)
-        for expected_disk_name, expected_device_name in zip(
-            expected_disk_names, expected_device_names
+        assert len(attached_volumes) == len(expected_disk_names)
+        for expected_disk_name, expected_device_name, expected_source_snapshot in zip(
+            expected_disk_names, expected_device_names, expected_source_snapshots
         ):
-            assert expected_disk_name in attached_devices
+            assert expected_disk_name in attached_volumes
             # AND the device name matches that returned by the instance metadata
-            assert attached_devices[expected_disk_name] == self._get_device_path(
-                expected_device_name
+            assert attached_volumes[
+                expected_disk_name
+            ]._device_path == self._get_device_path(expected_device_name)
+            # AND the source snapshot matches that returned by the disk metadata
+            assert (
+                attached_volumes[expected_disk_name].source_snapshot
+                == expected_source_snapshot
             )
 
     @pytest.mark.parametrize(
@@ -872,7 +936,7 @@ class TestGcpCloudSnapshotInterface(object):
             [mock.Mock(source="foo/", device_name="dev0")],
         ),
     )
-    def test_get_attached_devices_bad_disk_name(
+    def test_get_attached_volumes_bad_disk_name(
         self,
         mock_disks,
         mock_google_cloud_compute,
@@ -885,10 +949,10 @@ class TestGcpCloudSnapshotInterface(object):
         mock_instance_metadata = mock.Mock(disks=mock_disks)
         mock_instances_client.get.return_value = mock_instance_metadata
 
-        # WHEN get_attached_devices is called
+        # WHEN get_attached_volumes is called
         # THEN a SnapshotBackupException is raised
         with pytest.raises(SnapshotBackupException) as exc:
-            snapshot_interface.get_attached_devices(self.gcp_instance_name)
+            snapshot_interface.get_attached_volumes(self.gcp_instance_name)
         # AND the expected message is included
         assert str(
             exc.value
@@ -925,7 +989,7 @@ class TestGcpCloudSnapshotInterface(object):
             ],
         ),
     )
-    def test_get_attached_devices_multiple_names(
+    def test_get_attached_volumes_multiple_names(
         self,
         mock_disks,
         mock_google_cloud_compute,
@@ -940,20 +1004,16 @@ class TestGcpCloudSnapshotInterface(object):
         mock_instances_client = mock_google_cloud_compute.InstancesClient.return_value
         mock_instance_metadata = mock.Mock(disks=mock_disks)
         mock_instances_client.get.return_value = mock_instance_metadata
+        # AND a mock DisksClient which returns minimal information
+        mock_disks_client = mock_google_cloud_compute.DisksClient.return_value
+        mock_disks_client.get.return_value = mock.Mock(source_snapshot=None)
 
-        # WHEN get_attached_devices is called
-        # THEN a SnapshotBackupException is raised
-        with pytest.raises(SnapshotBackupException) as exc:
-            snapshot_interface.get_attached_devices(self.gcp_instance_name)
-        # AND the expected message is included
-        assert str(exc.value) == (
-            "Disk projects/test_project/zones/us-east1-b/disks/disk0 appears to be "
-            "attached with name disk0 as devices {} and {}".format(
-                self._get_device_path("dev1"), self._get_device_path("dev0")
-            )
-        )
+        # WHEN get_attached_volumes is called
+        # THEN an AssertionError is raised
+        with pytest.raises(AssertionError):
+            snapshot_interface.get_attached_volumes(self.gcp_instance_name)
 
-    def test_get_attached_devices_instance_not_found(self, mock_google_cloud_compute):
+    def test_get_attached_volumes_instance_not_found(self, mock_google_cloud_compute):
         """
         Verify that a SnapshotBackupException is raised if the instance cannot be
         found.
@@ -964,129 +1024,16 @@ class TestGcpCloudSnapshotInterface(object):
         mock_instances_client = mock_google_cloud_compute.InstancesClient.return_value
         mock_instances_client.get.side_effect = NotFound("instance not found")
 
-        # WHEN get_attached_devices is called
+        # WHEN get_attached_volumes is called
         # THEN a SnapshotBackupException is raised
         with pytest.raises(SnapshotBackupException) as exc:
-            snapshot_interface.get_attached_devices(self.gcp_instance_name)
+            snapshot_interface.get_attached_volumes(self.gcp_instance_name)
 
         # AND the exception contains the expected message
         assert str(
             exc.value
         ) == "Cannot find instance with name {} in zone {} for project {}".format(
             self.gcp_instance_name, self.gcp_zone, self.gcp_project
-        )
-
-    @pytest.mark.parametrize(
-        "attached_devices",
-        ({}, {"test_disk_0": "dev0"}, {"test_disk_0": "dev0", "test_disk_1": "dev1"}),
-    )
-    @mock.patch(
-        "barman.cloud_providers.google_cloud_storage.GcpCloudSnapshotInterface.get_attached_devices"
-    )
-    def test_get_attached_snapshots(
-        self, mock_get_attached_devices, attached_devices, mock_google_cloud_compute
-    ):
-        """Verify a dict of devices keyed by snapshot name is returned."""
-        # GIVEN a dict of attached devices
-        mock_get_attached_devices.return_value = attached_devices
-        # AND a disks client which returns metadata including the source snapshot
-        disks = []
-        for disk_metadata in self.gcp_disks:
-            updated_disk_metadata = disk_metadata.copy()
-            updated_disk_metadata["source_snapshot"] = self._get_snapshot_name(
-                disk_metadata["name"]
-            )
-            disks.append(updated_disk_metadata)
-        mock_disks_client = self._get_mock_disks_client(
-            self.gcp_project, self.gcp_zone, disks
-        )
-        mock_google_cloud_compute.DisksClient.return_value = mock_disks_client
-        # AND a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
-
-        # WHEN get_attached_snapshots is called
-        attached_snapshots = snapshot_interface.get_attached_snapshots(
-            self.gcp_instance_name
-        )
-
-        # THEN the correct device is returned for each disk
-        assert len(attached_snapshots) == len(attached_devices)
-        for disk, device in attached_devices.items():
-            assert attached_snapshots[self._get_snapshot_name(disk)] == device
-
-    @pytest.mark.parametrize(
-        "attached_devices",
-        (
-            {"test_disk_0": "dev0"},
-            {"test_disk_0": "dev0", "test_disk_1": "dev1"},
-            {"test_disk_0": "dev0", "test_disk_1": "dev1", "test_disk_2": "dev2"},
-        ),
-    )
-    @mock.patch(
-        "barman.cloud_providers.google_cloud_storage.GcpCloudSnapshotInterface.get_attached_devices"
-    )
-    def test_get_attached_snapshots_missing_snapshot(
-        self, mock_get_attached_devices, attached_devices, mock_google_cloud_compute
-    ):
-        """Verify a missing snapshot is simply not included in the return value."""
-        # GIVEN a dict of attached devices
-        mock_get_attached_devices.return_value = attached_devices
-        # AND a disks client which returns metadata including the source snapshot but
-        # only for one of the disks
-        disk_with_missing_snapshot = "test_disk_0"
-        disks = []
-        for disk_metadata in self.gcp_disks:
-            updated_disk_metadata = disk_metadata.copy()
-            if disk_metadata["name"] != disk_with_missing_snapshot:
-                updated_disk_metadata["source_snapshot"] = self._get_snapshot_name(
-                    disk_metadata["name"]
-                )
-            disks.append(updated_disk_metadata)
-        mock_disks_client = self._get_mock_disks_client(
-            self.gcp_project, self.gcp_zone, disks
-        )
-        mock_google_cloud_compute.DisksClient.return_value = mock_disks_client
-        # AND a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
-
-        # WHEN get_attached_snapshots is called
-        attached_snapshots = snapshot_interface.get_attached_snapshots(
-            self.gcp_instance_name
-        )
-
-        # THEN only the disk cloned from a snapshot is included in the response
-        assert len(attached_snapshots) == len(attached_devices) - 1
-        for disk, device in attached_devices.items():
-            if disk != disk_with_missing_snapshot:
-                assert attached_snapshots[self._get_snapshot_name(disk)] == device
-
-    @mock.patch(
-        "barman.cloud_providers.google_cloud_storage.GcpCloudSnapshotInterface.get_attached_devices"
-    )
-    def test_get_attached_snapshots_disk_not_found(
-        self, mock_get_attached_devices, mock_google_cloud_compute
-    ):
-        """
-        Verify that a SnapshotBackupException is raised if the disk cannot be found.
-        """
-        # GIVEN a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
-        # AND a set of attached devices
-        mock_get_attached_devices.return_value = {self.gcp_disks[0]["name"]: "dev0"}
-        # AND a mock DisksClient which cannot find a disk
-        mock_disks_client = mock_google_cloud_compute.DisksClient.return_value
-        mock_disks_client.get.side_effect = NotFound("instance not found")
-
-        # WHEN get_attached_snapshots is called
-        # THEN a SnapshotBackupException is raised
-        with pytest.raises(SnapshotBackupException) as exc:
-            snapshot_interface.get_attached_snapshots(self.gcp_instance_name)
-
-        # AND the exception contains the expected message
-        assert str(
-            exc.value
-        ) == "Cannot find disk with name {} in zone {} for project {}".format(
-            self.gcp_disks[0]["name"], self.gcp_zone, self.gcp_project
         )
 
     def test_instance_exists(self, mock_google_cloud_compute):
@@ -1113,3 +1060,106 @@ class TestGcpCloudSnapshotInterface(object):
 
         # THEN it returns False
         assert result is False
+
+
+class TestGcpVolumeMetadata(object):
+    """Verify behaviour of GcpVolumeMetadata."""
+
+    @pytest.mark.parametrize(
+        (
+            "attachment_metadata",
+            "disk_metadata",
+            "expected_device_path",
+            "expected_source_snapshot",
+        ),
+        (
+            (None, None, None, None),
+            (
+                mock.Mock(device_name="pgdata"),
+                None,
+                "/dev/disk/by-id/google-pgdata",
+                None,
+            ),
+            (None, mock.Mock(source_snapshot="prefix/snap0"), None, "snap0"),
+            (
+                mock.Mock(device_name="pgdata"),
+                mock.Mock(source_snapshot="prefix/snap0"),
+                "/dev/disk/by-id/google-pgdata",
+                "snap0",
+            ),
+        ),
+    )
+    def test_init(
+        self,
+        attachment_metadata,
+        disk_metadata,
+        expected_device_path,
+        expected_source_snapshot,
+    ):
+        """Verify GcpVolumeMetadata is created from supplied metadata."""
+        # WHEN volume metadata is created from the specified attachment_metadata and
+        # disk_metadata
+        volume = GcpVolumeMetadata(attachment_metadata, disk_metadata)
+
+        # THEN the metadata has the expected source snapshot
+        assert volume.source_snapshot == expected_source_snapshot
+        # AND the internal _device_path has the expected value
+        assert volume._device_path == expected_device_path
+
+    def test_resolve_mounted_volume(self):
+        """Verify resolve_mounted_volume sets mount info from findmnt output."""
+        # GIVEN a GcpVolumeMetadata for device `pgdata`
+        attachment_metadata = mock.Mock(device_name="pgdata")
+        volume = GcpVolumeMetadata(attachment_metadata)
+        # AND the specified findmnt response
+        mock_cmd = mock.Mock()
+        mock_cmd.findmnt.return_value = ("/opt/disk0", "rw,noatime")
+
+        # WHEN resolve_mounted_volume is called
+        volume.resolve_mounted_volume(mock_cmd)
+
+        # THEN findmnt was called with the expected arguments
+        mock_cmd.findmnt.assert_called_once_with("/dev/disk/by-id/google-pgdata")
+
+        # AND the expected mount point and options are set on the volume metadata
+        assert volume.mount_point == "/opt/disk0"
+        assert volume.mount_options == "rw,noatime"
+
+    @pytest.mark.parametrize(
+        ("findmnt_fun", "device_name", "expected_exception_msg"),
+        (
+            (
+                lambda x: (None, None),
+                "pgdata",
+                "Could not find device /dev/disk/by-id/google-pgdata at any mount point",
+            ),
+            (
+                CommandException("error doing findmnt"),
+                "pgdata",
+                "Error finding mount point for device /dev/disk/by-id/google-pgdata: error doing findmnt",
+            ),
+            (
+                lambda x: (None, None),
+                None,
+                "Cannot resolve mounted volume: Device path unknown",
+            ),
+        ),
+    )
+    def test_resolve_mounted_volume_failure(
+        self, findmnt_fun, device_name, expected_exception_msg
+    ):
+        """Verify the failure modes of resolve_mounted_volume."""
+        # GIVEN a GcpVolumeMetadata for device `pgdata`
+        attachment_metadata = mock.Mock(device_name=device_name)
+        volume = GcpVolumeMetadata(attachment_metadata)
+        # AND the specified findmnt response
+        mock_cmd = mock.Mock()
+        mock_cmd.findmnt.side_effect = findmnt_fun
+
+        # WHEN resolve_mounted_volume is called
+        # THEN the expected exception occurs
+        with pytest.raises(SnapshotBackupException) as exc:
+            volume.resolve_mounted_volume(mock_cmd)
+
+        # AND the exception has the expected error message
+        assert str(exc.value) == expected_exception_msg

--- a/tests/test_cloud_snapshot_interface.py
+++ b/tests/test_cloud_snapshot_interface.py
@@ -483,13 +483,12 @@ class TestGcpCloudSnapshotInterface(object):
             self._get_mock_snapshots_client()
         )
         # AND a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
 
         # WHEN take_snapshot_backup is called for multiple disks
         snapshot_interface.take_snapshot_backup(
             backup_info,
             self.gcp_instance_name,
-            self.gcp_zone,
             (disk["name"] for disk in disks),
         )
 
@@ -517,7 +516,7 @@ class TestGcpCloudSnapshotInterface(object):
         found.
         """
         # GIVEN a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
         # AND a mock InstancesClient which cannot find the instance
         mock_instances_client = mock_google_cloud_compute.InstancesClient.return_value
         mock_instances_client.get.side_effect = NotFound("instance not found")
@@ -526,7 +525,7 @@ class TestGcpCloudSnapshotInterface(object):
         # THEN a SnapshotBackupException is raised
         with pytest.raises(SnapshotBackupException) as exc:
             snapshot_interface.take_snapshot_backup(
-                mock.Mock(), self.gcp_instance_name, self.gcp_zone, self.gcp_disks
+                mock.Mock(), self.gcp_instance_name, self.gcp_disks
             )
 
         # AND the exception contains the expected message
@@ -561,7 +560,7 @@ class TestGcpCloudSnapshotInterface(object):
             self._get_mock_snapshots_client()
         )
         # AND a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
 
         # WHEN take snapshot_backup is called
         # THEN a SnapshotBackupException is raised
@@ -569,7 +568,6 @@ class TestGcpCloudSnapshotInterface(object):
             snapshot_interface.take_snapshot_backup(
                 mock.Mock(),
                 self.gcp_instance_name,
-                self.gcp_zone,
                 (disk["name"] for disk in disks),
             )
 
@@ -605,7 +603,7 @@ class TestGcpCloudSnapshotInterface(object):
             self._get_mock_snapshots_client()
         )
         # AND a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
 
         # WHEN take snapshot_backup is called
         # THEN a SnapshotBackupException is raised
@@ -613,7 +611,6 @@ class TestGcpCloudSnapshotInterface(object):
             snapshot_interface.take_snapshot_backup(
                 mock.Mock(),
                 self.gcp_instance_name,
-                self.gcp_zone,
                 (disk["name"] for disk in disks),
             )
 
@@ -648,7 +645,7 @@ class TestGcpCloudSnapshotInterface(object):
             self._get_mock_snapshots_client()
         )
         # AND a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
 
         # WHEN take snapshot_backup is called
         # THEN a SnapshotBackupException is raised
@@ -656,7 +653,6 @@ class TestGcpCloudSnapshotInterface(object):
             snapshot_interface.take_snapshot_backup(
                 mock.Mock(),
                 self.gcp_instance_name,
-                self.gcp_zone,
                 (disk["name"] for disk in disks),
             )
 
@@ -785,7 +781,7 @@ class TestGcpCloudSnapshotInterface(object):
             self._get_mock_snapshots_client()
         )
         # AND a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, zone=None)
 
         # WHEN delete_snapshot_backup is called
         snapshot_interface.delete_snapshot_backup(backup_info)
@@ -845,7 +841,7 @@ class TestGcpCloudSnapshotInterface(object):
     ):
         """Verify that attached devices are returned as a dict keyed by disk name."""
         # GIVEN a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
         # AND a mock InstancesClient which returns metadata listing the devices
         mock_instances_client = mock_google_cloud_compute.InstancesClient.return_value
         mock_instance_metadata = mock.Mock(disks=mock_disks)
@@ -853,7 +849,7 @@ class TestGcpCloudSnapshotInterface(object):
 
         # WHEN get_attached_devices is called
         attached_devices = snapshot_interface.get_attached_devices(
-            self.gcp_instance_name, self.gcp_zone
+            self.gcp_instance_name
         )
 
         # THEN a dict of devices returned by the instance metadata is returned, keyed
@@ -883,7 +879,7 @@ class TestGcpCloudSnapshotInterface(object):
     ):
         """Verify that unparseable disk names are handled."""
         # GIVEN a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
         # AND a mock InstancesClient which returns metadata listing the devices
         mock_instances_client = mock_google_cloud_compute.InstancesClient.return_value
         mock_instance_metadata = mock.Mock(disks=mock_disks)
@@ -892,9 +888,7 @@ class TestGcpCloudSnapshotInterface(object):
         # WHEN get_attached_devices is called
         # THEN a SnapshotBackupException is raised
         with pytest.raises(SnapshotBackupException) as exc:
-            snapshot_interface.get_attached_devices(
-                self.gcp_instance_name, self.gcp_zone
-            )
+            snapshot_interface.get_attached_devices(self.gcp_instance_name)
         # AND the expected message is included
         assert str(
             exc.value
@@ -941,7 +935,7 @@ class TestGcpCloudSnapshotInterface(object):
         once.
         """
         # GIVEN a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
         # AND a mock InstancesClient which returns metadata listing the devices
         mock_instances_client = mock_google_cloud_compute.InstancesClient.return_value
         mock_instance_metadata = mock.Mock(disks=mock_disks)
@@ -950,9 +944,7 @@ class TestGcpCloudSnapshotInterface(object):
         # WHEN get_attached_devices is called
         # THEN a SnapshotBackupException is raised
         with pytest.raises(SnapshotBackupException) as exc:
-            snapshot_interface.get_attached_devices(
-                self.gcp_instance_name, self.gcp_zone
-            )
+            snapshot_interface.get_attached_devices(self.gcp_instance_name)
         # AND the expected message is included
         assert str(exc.value) == (
             "Disk projects/test_project/zones/us-east1-b/disks/disk0 appears to be "
@@ -967,7 +959,7 @@ class TestGcpCloudSnapshotInterface(object):
         found.
         """
         # GIVEN a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
         # AND a mock InstancesClient which cannot find the instance
         mock_instances_client = mock_google_cloud_compute.InstancesClient.return_value
         mock_instances_client.get.side_effect = NotFound("instance not found")
@@ -975,9 +967,7 @@ class TestGcpCloudSnapshotInterface(object):
         # WHEN get_attached_devices is called
         # THEN a SnapshotBackupException is raised
         with pytest.raises(SnapshotBackupException) as exc:
-            snapshot_interface.get_attached_devices(
-                self.gcp_instance_name, self.gcp_zone
-            )
+            snapshot_interface.get_attached_devices(self.gcp_instance_name)
 
         # AND the exception contains the expected message
         assert str(
@@ -1012,11 +1002,11 @@ class TestGcpCloudSnapshotInterface(object):
         )
         mock_google_cloud_compute.DisksClient.return_value = mock_disks_client
         # AND a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
 
         # WHEN get_attached_snapshots is called
         attached_snapshots = snapshot_interface.get_attached_snapshots(
-            self.gcp_instance_name, self.gcp_zone
+            self.gcp_instance_name
         )
 
         # THEN the correct device is returned for each disk
@@ -1057,11 +1047,11 @@ class TestGcpCloudSnapshotInterface(object):
         )
         mock_google_cloud_compute.DisksClient.return_value = mock_disks_client
         # AND a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
 
         # WHEN get_attached_snapshots is called
         attached_snapshots = snapshot_interface.get_attached_snapshots(
-            self.gcp_instance_name, self.gcp_zone
+            self.gcp_instance_name
         )
 
         # THEN only the disk cloned from a snapshot is included in the response
@@ -1080,7 +1070,7 @@ class TestGcpCloudSnapshotInterface(object):
         Verify that a SnapshotBackupException is raised if the disk cannot be found.
         """
         # GIVEN a new GcpCloudSnapshotInterface
-        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
+        snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project, self.gcp_zone)
         # AND a set of attached devices
         mock_get_attached_devices.return_value = {self.gcp_disks[0]["name"]: "dev0"}
         # AND a mock DisksClient which cannot find a disk
@@ -1090,9 +1080,7 @@ class TestGcpCloudSnapshotInterface(object):
         # WHEN get_attached_snapshots is called
         # THEN a SnapshotBackupException is raised
         with pytest.raises(SnapshotBackupException) as exc:
-            snapshot_interface.get_attached_snapshots(
-                self.gcp_instance_name, self.gcp_zone
-            )
+            snapshot_interface.get_attached_snapshots(self.gcp_instance_name)
 
         # AND the exception contains the expected message
         assert str(
@@ -1107,11 +1095,9 @@ class TestGcpCloudSnapshotInterface(object):
         snapshot_interface = GcpCloudSnapshotInterface(self.gcp_project)
 
         # WHEN instance_exists is called for an instance which exists
-        result = snapshot_interface.instance_exists(
-            self.gcp_instance_name, self.gcp_zone
-        )
+        result = snapshot_interface.instance_exists(self.gcp_instance_name)
 
-        # THEN it returns False
+        # THEN it returns True
         assert result is True
 
     def test_instance_exists_not_found(self, mock_google_cloud_compute):
@@ -1123,9 +1109,7 @@ class TestGcpCloudSnapshotInterface(object):
         mock_instances_client.get.side_effect = NotFound("instance not found")
 
         # WHEN instance_exists is called
-        result = snapshot_interface.instance_exists(
-            self.gcp_instance_name, self.gcp_zone
-        )
+        result = snapshot_interface.instance_exists(self.gcp_instance_name)
 
         # THEN it returns False
         assert result is False

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1506,7 +1506,7 @@ class TestSnapshotBackupExecutor(object):
 
     @pytest.mark.parametrize(
         "missing_option",
-        ("snapshot_disks", "snapshot_instance", "snapshot_provider", "snapshot_zone"),
+        ("snapshot_disks", "snapshot_instance", "snapshot_provider"),
     )
     @patch("barman.backup_executor.get_snapshot_interface_from_server_config")
     def test_snapshot_backup_executor_init_missing_options(
@@ -1651,7 +1651,6 @@ class TestSnapshotBackupExecutor(object):
         mock_get_snapshot_interface.return_value.take_snapshot_backup.assert_called_once_with(
             backup_info,
             core_snapshot_options["snapshot_instance"],
-            core_snapshot_options["snapshot_zone"],
             [core_snapshot_options["snapshot_disks"]],
         )
         # AND add_mount_data_to_backup_info was called
@@ -1748,7 +1747,6 @@ class TestSnapshotBackupExecutor(object):
             cmd,
             mock_get_snapshot_interface.return_value,
             "instance1",
-            "zone1",
             expected_missing_disks + expected_unmounted_disks + expected_mounted_disks,
         )
 
@@ -1820,7 +1818,7 @@ class TestSnapshotBackupExecutor(object):
         assert len(check_strategy.check_result) == 3
         # AND each snapshot-specific check passes
         for check in (
-            "snapshot instance exists in zone",
+            "snapshot instance exists",
             "snapshot disks attached to instance",
             "snapshot disks mounted on instance",
         ):
@@ -1842,11 +1840,11 @@ class TestSnapshotBackupExecutor(object):
         ),
         [
             (
-                "snapshot instance exists in zone",
+                "snapshot instance exists",
                 False,
                 [],
                 [],
-                "cannot find compute instance {snapshot_instance} in zone {snapshot_zone}",
+                "cannot find compute instance {snapshot_instance}",
             ),
             (
                 "snapshot disks attached to instance",

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -17,6 +17,7 @@
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
+from functools import partial
 import logging
 import os
 
@@ -1537,87 +1538,46 @@ class TestSnapshotBackupExecutor(object):
         # AND the server is disabled
         assert server.config.disabled
 
-    def test_add_mount_data_to_backup_info(self):
-        """Verify that mount data is added to backup_info when it is returned."""
-        # GIVEN devices which are mounted
-        mock_remote_cmd = mock.Mock()
+    def test_add_mount_data_to_volume_metadata(self):
+        """Verify that mount data is added to volume metadata when it is returned."""
 
-        def mock_findmnt(device):
-            return {
-                "/dev/disk1": ("/opt/mount1", "rw,noatime"),
-                "/dev/disk2": ("/opt/mount2", "ro"),
-            }[device]
+        # GIVEN volumes which are mounted
+        def mock_resolve_mounted_volume(mock_volume, mount_point, mount_options, _cmd):
+            mock_volume.mount_point = mount_point
+            mock_volume.mount_options = mount_options
 
-        mock_remote_cmd.findmnt.side_effect = mock_findmnt
-        # AND a backup_info file with snapshots of these devices
-        backup_info = build_test_backup_info(
-            snapshots_info=mock.Mock(
-                snapshots=[
-                    mock.Mock(
-                        identifier="snapshot1",
-                        device="/dev/disk1",
-                    ),
-                    mock.Mock(
-                        identifier="snapshot2",
-                        device="/dev/disk2",
-                    ),
-                ]
-            )
+        mock_volumes = {
+            "disk1": mock.Mock(),
+            "disk2": mock.Mock(),
+        }
+        mock_volumes["disk1"].resolve_mounted_volume.side_effect = partial(
+            mock_resolve_mounted_volume,
+            mock_volumes["disk1"],
+            "/opt/mount1",
+            "rw,noatime",
+        )
+        mock_volumes["disk2"].resolve_mounted_volume.side_effect = partial(
+            mock_resolve_mounted_volume,
+            mock_volumes["disk2"],
+            "/opt/mount2",
+            "ro",
         )
 
-        # WHEN add_mount_data_to_backup_info is called
-        SnapshotBackupExecutor.add_mount_data_to_backup_info(
-            backup_info, mock_remote_cmd
-        )
+        mock_cmd = mock.Mock()
+
+        # WHEN add_mount_data_to_volume_metadata is called
+        SnapshotBackupExecutor.add_mount_data_to_volume_metadata(mock_volumes, mock_cmd)
 
         # THEN the backup_info is enhanced with the mount point and mount options
         # for each device
-        assert backup_info.snapshots_info.snapshots[0].mount_point == "/opt/mount1"
-        assert backup_info.snapshots_info.snapshots[0].mount_options == "rw,noatime"
-        assert backup_info.snapshots_info.snapshots[1].mount_point == "/opt/mount2"
-        assert backup_info.snapshots_info.snapshots[1].mount_options == "ro"
-
-    def test_add_mount_data_to_backup_info_not_mounted(self):
-        """Verify that an exception is raised when a device is not mounted."""
-        # GIVEN devices where one is not mounted
-        mock_remote_cmd = mock.Mock()
-
-        def mock_findmnt(device):
-            return {
-                "/dev/disk1": ("/opt/mount1", "rw,noatime"),
-                "/dev/disk2": (None, None),
-            }[device]
-
-        mock_remote_cmd.findmnt.side_effect = mock_findmnt
-        # AND a backup_info file with snapshots of these devices
-        backup_info = build_test_backup_info(
-            snapshots_info=mock.Mock(
-                snapshots=[
-                    mock.Mock(
-                        identifier="snapshot1",
-                        device="/dev/disk1",
-                    ),
-                    mock.Mock(
-                        identifier="snapshot2",
-                        device="/dev/disk2",
-                    ),
-                ]
-            )
-        )
-
-        # WHEN add_mount_data_to_backup_info is called
-        # THEN a BackupException is raised
-        with pytest.raises(BackupException) as e:
-            SnapshotBackupExecutor.add_mount_data_to_backup_info(
-                backup_info, mock_remote_cmd
-            )
-
-        # AND the exception message warns about the missing mount point
-        assert str(e.value) == "Could not find mount point for device /dev/disk2"
+        assert mock_volumes["disk1"].mount_point == "/opt/mount1"
+        assert mock_volumes["disk1"].mount_options == "rw,noatime"
+        assert mock_volumes["disk2"].mount_point == "/opt/mount2"
+        assert mock_volumes["disk2"].mount_options == "ro"
 
     @patch("barman.backup_executor.get_snapshot_interface_from_server_config")
     @patch(
-        "barman.backup_executor.SnapshotBackupExecutor.add_mount_data_to_backup_info"
+        "barman.backup_executor.SnapshotBackupExecutor.add_mount_data_to_volume_metadata"
     )
     @patch("barman.backup_executor.UnixRemoteCommand")
     @patch("barman.backup_executor.UnixLocalCommand")
@@ -1625,7 +1585,7 @@ class TestSnapshotBackupExecutor(object):
         self,
         mock_unix_local_command,
         mock_unix_remote_command,
-        mock_add_mount_data_to_backup_info,
+        mock_add_mount_data_to_volume_metadata,
         mock_get_snapshot_interface,
         core_snapshot_options,
     ):
@@ -1638,6 +1598,9 @@ class TestSnapshotBackupExecutor(object):
         executor = SnapshotBackupExecutor(server.backup_manager)
         # AND backup_info for a new backup
         backup_info = build_test_backup_info()
+        # AND a snapshot interface which returns mock volume metadata
+        mock_snapshot_interface = mock_get_snapshot_interface.return_value
+        mock_volume_metadata = mock_snapshot_interface.get_attached_volumes.return_value
 
         # WHEN backup_copy is called
         executor.backup_copy(backup_info)
@@ -1646,21 +1609,27 @@ class TestSnapshotBackupExecutor(object):
         mock_unix_local_command.return_value.create_dir_if_not_exists.assert_called_once_with(
             backup_info.get_data_directory()
         )
+        # AND the snapshot interface was asked for volume metadata from the
+        # expected disks
+        mock_snapshot_interface.get_attached_volumes.assert_called_once_with(
+            core_snapshot_options["snapshot_instance"],
+            [core_snapshot_options["snapshot_disks"]],
+        )
         # AND the snapshot interface is used to take a snapshot backup with the
         # expected args
         mock_get_snapshot_interface.return_value.take_snapshot_backup.assert_called_once_with(
             backup_info,
             core_snapshot_options["snapshot_instance"],
-            [core_snapshot_options["snapshot_disks"]],
+            mock_volume_metadata,
         )
-        # AND add_mount_data_to_backup_info was called
-        mock_add_mount_data_to_backup_info.assert_called_once_with(
-            backup_info, mock_unix_remote_command.return_value
+        # AND add_mount_data_to_volume_metadata was called
+        mock_add_mount_data_to_volume_metadata.assert_called_once_with(
+            mock_volume_metadata, mock_unix_remote_command.return_value
         )
 
     @patch("barman.backup_executor.get_snapshot_interface_from_server_config")
     @patch(
-        "barman.backup_executor.SnapshotBackupExecutor.add_mount_data_to_backup_info"
+        "barman.backup_executor.SnapshotBackupExecutor.add_mount_data_to_volume_metadata"
     )
     @patch("barman.backup_executor.UnixRemoteCommand")
     @patch("barman.backup_executor.UnixLocalCommand")
@@ -1668,7 +1637,7 @@ class TestSnapshotBackupExecutor(object):
         self,
         _mock_unix_local_command,
         _mock_unix_remote_command,
-        _mock_add_mount_data_to_backup_info,
+        _mock_add_mount_data_to_volume_metadata,
         _mock_get_snapshot_interface,
         core_snapshot_options,
     ):
@@ -1720,24 +1689,27 @@ class TestSnapshotBackupExecutor(object):
         and mounted devices.
         """
         # GIVEN the specified attached and mounted disks are all returned by the
-        # get_attached_devices function
-        mock_get_attached_devices = (
-            mock_get_snapshot_interface.return_value.get_attached_devices
+        # get_attached_volumes function
+        mock_get_attached_volumes = (
+            mock_get_snapshot_interface.return_value.get_attached_volumes
         )
-        mock_get_attached_devices.return_value = dict(
-            (disk, "/dev/" + disk)
+        mock_get_attached_volumes.return_value = dict(
+            (disk, mock.Mock(mount_point=None, mount_options=None))
             for disk in expected_unmounted_disks + expected_mounted_disks
         )
-        # AND the specified mounted disks are returned by findmnt while the attached
-        # (but not mounted) disks are not found
+        # AND the specified mounted disks are returned by resolve_mounted_volume
+        # while the attached(but not mounted) disks are not found
         cmd = mock.Mock()
-        findmnt_resp = dict(
-            ("/dev/" + disk, ("/opt/" + disk, "rw")) for disk in expected_mounted_disks
-        )
-        findmnt_resp.update(
-            dict(("/dev/" + disk, (None, None)) for disk in expected_unmounted_disks)
-        )
-        cmd.findmnt.side_effect = lambda x: findmnt_resp[x]
+
+        def mock_resolve_mounted_volume(mock_volume, disk_name, _cmd):
+            mock_volume.mount_point = "/opt/" + disk_name
+            mock_volume.mount_options = "rw"
+
+        for disk in expected_mounted_disks:
+            mock_volume = mock_get_attached_volumes.return_value[disk]
+            mock_volume.resolve_mounted_volume.side_effect = partial(
+                mock_resolve_mounted_volume, mock_volume, disk
+            )
 
         # WHEN find_missing_and_unmounted_disks is called for all expected disksts
         (

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -1753,10 +1753,9 @@ class TestSnapshotRecoveryExecutor(object):
                 ]
             )
         )
-        # AND a given recovery destination, instance and zone
+        # AND a given recovery destination and instance
         recovery_dest = "/path/to/dest"
         recovery_instance = "test_instance"
-        recovery_zone = "test_zone"
         # AND a mock findmnt command which always returns the correct response
         mock_fs.unix_command_factory.return_value.findmnt.return_value = (
             "/opt/disk0",
@@ -1769,7 +1768,6 @@ class TestSnapshotRecoveryExecutor(object):
             backup_info,
             recovery_dest,
             recovery_instance=recovery_instance,
-            recovery_zone=recovery_zone,
         )
 
         # AND the superclass recovery method was called with the expected args
@@ -1842,10 +1840,9 @@ class TestSnapshotRecoveryExecutor(object):
                 ]
             )
         )
-        # AND a given recovery destination, instance and zone
+        # AND a given recovery destination and instance
         recovery_dest = "/path/to/dest"
         recovery_instance = "test_instance"
-        recovery_zone = "test_zone"
         # AND a mock findmnt command which returns the specified response
         mock_cmd = mock_fs.unix_command_factory.return_value
         mock_cmd.findmnt.return_value = findmnt_output
@@ -1862,7 +1859,6 @@ class TestSnapshotRecoveryExecutor(object):
                     backup_info,
                     recovery_dest,
                     recovery_instance=recovery_instance,
-                    recovery_zone=recovery_zone,
                 )
         else:
             # WHEN recover is called AND no error is expected then there is no error
@@ -1870,7 +1866,6 @@ class TestSnapshotRecoveryExecutor(object):
                 backup_info,
                 recovery_dest,
                 recovery_instance=recovery_instance,
-                recovery_zone=recovery_zone,
             )
 
     @mock.patch("barman.recovery_executor.fs.unix_command_factory")
@@ -2042,9 +2037,8 @@ class TestSnapshotRecoveryExecutor(object):
         mock_snapshot_interface.get_attached_snapshots.return_value = attached_snapshots
         # AND a mock backup_info which contains the specified snapshots
         mock_backup_info = mock.Mock(snapshots_info=snapshots_info)
-        # AND a given instance and zone
+        # AND a given instance
         instance = "gcp_instance_name"
-        zone = "gcp_zone"
 
         # WHEN get_attached_snapshots_for_backup is called
         # THEN if we expect missing snapshots, a RecoveryPreconditionException is
@@ -2052,7 +2046,7 @@ class TestSnapshotRecoveryExecutor(object):
         if expected_missing:
             with pytest.raises(RecoveryPreconditionException) as exc:
                 SnapshotRecoveryExecutor.get_attached_snapshots_for_backup(
-                    mock_snapshot_interface, mock_backup_info, instance, zone
+                    mock_snapshot_interface, mock_backup_info, instance
                 )
             # AND the exception has the expected message
             message_part_1, message_part_2 = str(exc.value).split(": ")
@@ -2066,7 +2060,7 @@ class TestSnapshotRecoveryExecutor(object):
             # the expected snapshots are returned
             attached_snapshots_for_backup = (
                 SnapshotRecoveryExecutor.get_attached_snapshots_for_backup(
-                    mock_snapshot_interface, mock_backup_info, instance, zone
+                    mock_snapshot_interface, mock_backup_info, instance
                 )
             )
             for snapshot_metadata in snapshots_info.snapshots:
@@ -2085,7 +2079,7 @@ class TestSnapshotRecoveryExecutor(object):
         mock_backup_info = mock.Mock(snapshots_info=None)
         # WHEN get_attached_snapshots_for_backup is called
         snapshots = SnapshotRecoveryExecutor.get_attached_snapshots_for_backup(
-            mock.Mock(), mock_backup_info, "instance", "zone"
+            mock.Mock(), mock_backup_info, "instance"
         )
         # THEN we expect an empty list to be returned
         assert snapshots == {}


### PR DESCRIPTION
Refactors parts of the implementation of snapshot backups for GCP to make it easier to add different cloud providers.

Note: The [17 Code Smells](https://sonarqube.enterprisedb.com/project/issues?id=EnterpriseDB_barman&pullRequest=793&resolved=false&types=CODE_SMELL) reported by sonarqube relate to code untouched by this commit and are present because someone tweaked the quality profiles in sonarqube. I think it's best if they are addressed in a separate PR.