### PR TITLE
Avoid the execution of replication-status command on passive nodes

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -573,7 +573,7 @@ def replication_status(args):
     """
     Shows live information and status of any streaming client
     """
-    servers = get_server_list(args, skip_inactive=True)
+    servers = get_server_list(args, skip_inactive=True, skip_passive=True)
     for name in sorted(servers):
         server = servers[name]
 


### PR DESCRIPTION
As a passive nodes, by definition, are unable to connect to postgres in any way, we should avoid the execution of the replication-status command on them.