### PR TITLE
Delete backup_label for barman cloud snapshot backups

### DIFF
--- a/barman/clients/cloud_backup_delete.py
+++ b/barman/clients/cloud_backup_delete.py
@@ -185,6 +185,14 @@ def _delete_backup(
                 backup_info, config
             )
             snapshot_interface.delete_snapshot_backup(backup_info)
+        # Delete the backup_label for snapshots backups as this is not stored in the
+        # same format used by the non-snapshot backups.
+        backup_label_path = os.path.join(
+            catalog.prefix, backup_info.backup_id, "backup_label"
+        )
+        if not config.dry_run:
+            cloud_interface.delete_objects([backup_label_path])
+
     objects_to_delete = _get_files_for_backup(catalog, backup_info)
     backup_info_path = os.path.join(
         catalog.prefix, backup_info.backup_id, "backup.info"

--- a/barman/clients/cloud_backup_delete.py
+++ b/barman/clients/cloud_backup_delete.py
@@ -185,6 +185,8 @@ def _delete_backup(
                 backup_info, config
             )
             snapshot_interface.delete_snapshot_backup(backup_info)
+        else:
+            print("Skipping deletion of snapshots due to --dry-run option")
         # Delete the backup_label for snapshots backups as this is not stored in the
         # same format used by the non-snapshot backups.
         backup_label_path = os.path.join(
@@ -192,6 +194,8 @@ def _delete_backup(
         )
         if not config.dry_run:
             cloud_interface.delete_objects([backup_label_path])
+        else:
+            print("Skipping deletion of %s due to --dry-run option" % backup_label_path)
 
     objects_to_delete = _get_files_for_backup(catalog, backup_info)
     backup_info_path = os.path.join(


### PR DESCRIPTION
Deletes the backup_label from the object store when snapshot backups are deleted. This is necessary because the existing deletion logic only deleted the `backup.info` files and the tarballs containing the backup data (which included the backup label). With snapshot backups, tarballs are not used and the backup label is stored as a unique object. It must therefore be deleted as a special case.

Closes BAR-13.