### PR TITLE
Fix attribute access on potential None type

### DIFF
--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -295,14 +295,17 @@ def get_snapshot_interface_from_backup_info(backup_info, config=None):
                 "backup_info has snapshot provider 'azure' but "
                 "subscription_id is not set"
             )
-        if config is not None and hasattr(config, "azure_resource_group"):
-            resource_group = config.azure_resource_group
-        else:
-            resource_group = None
+        resource_group = None
+        azure_credential = None
+        if config is not None:
+            if hasattr(config, "azure_resource_group"):
+                resource_group = config.azure_resource_group
+            if hasattr(config, "azure_credential"):
+                azure_credential = config.azure_credential
         return AzureCloudSnapshotInterface(
             backup_info.snapshots_info.subscription_id,
             resource_group=resource_group,
-            credential=_get_azure_credential(config.azure_credential),
+            credential=_get_azure_credential(azure_credential),
         )
     elif backup_info.snapshots_info.provider == "aws":
         from barman.cloud_providers.aws_s3 import AwsCloudSnapshotInterface


### PR DESCRIPTION
Replaces the direct reference to `config.azure_credential` with one which is guarded against `config` being `None`.

Because `resource_group` was set in a similar manner the code is combined with the existing code which accessed `config.resource_group`.

Closes BAR-102.