### PR TITLE
allow set-version to build doc with docker image

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,3 +1,7 @@
+ifndef DIMAGE
+override DIMAGE =  barman-pandoc
+endif
+
 MANPAGES=barman.1 barman.5 \
 		barman-wal-archive.1 barman-wal-restore.1 \
     barman-cloud-backup.1 \
@@ -68,6 +72,12 @@ clean:
 	for dir in $(SUBDIRS); do \
 		$(MAKE) -C $$dir clean; \
 	done
+
+build-image:
+	docker build . -t $(DIMAGE)
+
+create-all:
+	docker run --rm --volume "`pwd`:/data" -w="/data" --user `id -u`:`id -g` $(DIMAGE) make clean all
 
 help:
 	@echo "Usage:"


### PR DESCRIPTION
Changed set-version.sh behavior.

Instead of positional argument it uses flags.
before:
`set-version.sh 3.5.0 20231206`
now:
* `set-version.sh -r 3.5.0 -d 20231206` (identical)
* `set-version.sh -r 3.5.0 -d 20231206 -D` (using docker image)
* `set-version.sh -r 3.5.0 -D` (uses docker image and current date)

Updated release process documentation in [Source code changes](https://enterprisedb.atlassian.net/wiki/spaces/PD/pages/3407282177/release+process+with+foundation#2--Source-code-changes) section.