### PR TITLE
Avoid using internal functions/object with multiprocessing

### DIFF
--- a/barman/command_wrappers.py
+++ b/barman/command_wrappers.py
@@ -41,6 +41,22 @@ from barman.exceptions import CommandFailedException, CommandMaxRetryExceeded
 _logger = logging.getLogger(__name__)
 
 
+class Handler:
+    def __init__(self, logger, level, prefix=None):
+        self.class_logger = logger
+        self.level = level
+        self.prefix = prefix
+
+    def run(self, line):
+        if line:
+            if self.prefix:
+                self.class_logger.log(self.level, "%s%s", self.prefix, line)
+            else:
+                self.class_logger.log(self.level, "%s", line)
+
+    __call__ = run
+
+
 class StreamLineProcessor(object):
     """
     Class deputed to reading lines from a file object, using a buffered read.
@@ -526,7 +542,7 @@ class Command(object):
         """
         Build a handler function that logs every line it receives.
 
-        The resulting function logs its input at the specified level
+        The resulting callable object logs its input at the specified level
         with an optional prefix.
 
         :param level: The log level to use
@@ -535,14 +551,7 @@ class Command(object):
         """
         class_logger = logging.getLogger(cls.__name__)
 
-        def handler(line):
-            if line:
-                if prefix:
-                    class_logger.log(level, "%s%s", prefix, line)
-                else:
-                    class_logger.log(level, "%s", line)
-
-        return handler
+        return Handler(class_logger, level, prefix)
 
     @staticmethod
     def make_output_handler(prefix=None):


### PR DESCRIPTION
A Multiprocessing start method is the technique used by the Multiprocessing library to start child processes in Python.

There are three start methods:

* spawn: start a new Python process.
* fork: copy a Python process from an existing process.
* forkserver: new process from which future forked processes will be copied.

Each OS has a list of supported start methods:
* Windows (win32): spawn
* MacOS (darwin): spawn (default), fork, forkserver.
* Linux (unix): spawn, fork (default), forkserver.

Spawn not only is the most supported, but as per recent investigations of the devs of the Multiprocessing library, is the most secure on all the OS.

Spawn method makes use of the Pickle library for starting the new subprocesses and Pickle is unable to process internal objects and functions.

Get rid an internal function (handler inside the make_logging_handler method of the Command class) and use a callable object instead.

Consider substituting internal objects and functions with Pickle compliant options all around the code and eventually enforce the usage of the spawn method.