### PR TITLE
Update backup compression options that call `pg_basebackup`.

### DIFF
--- a/barman/command_wrappers.py
+++ b/barman/command_wrappers.py
@@ -1019,9 +1019,16 @@ class PgBaseBackup(PostgreSQLClient):
                 compression_args.append(compress_arg)
             # For clients < 15 we use the old style argument format
             else:
-                compression_args.append("--%s" % compression.config.type)
-                if compression.config.level:
-                    compression_args.append("--compress=%d" % compression.config.level)
+                if compression.config.type == "none":
+                    compression_args.append("--compress=0")
+                else:
+                    if compression.config.level is not None:
+                        compression_args.append(
+                            "--compress=%d" % compression.config.level
+                        )
+                    # --gzip must be positioned after --compress when compression level=0
+                    # so `base.tar.gz` can be created. Otherwise `.gz` won't be added.
+                    compression_args.append("--%s" % compression.config.type)
         return compression_args
 
 

--- a/barman/config.py
+++ b/barman/config.py
@@ -71,7 +71,7 @@ BACKUP_METHOD_VALUES = ["rsync", "postgres", "local-rsync", "snapshot"]
 CREATE_SLOT_VALUES = ["manual", "auto"]
 
 # Config values relating to pg_basebackup compression
-BASEBACKUP_COMPRESSIONS = ["gzip", "lz4", "zstd"]
+BASEBACKUP_COMPRESSIONS = ["gzip", "lz4", "zstd", "none"]
 
 
 class CsvOption(set):
@@ -294,8 +294,6 @@ def parse_backup_compression(value):
     """
     Parse a string to a valid backup_compression value.
 
-    Valid values are contained in compression.basebackup_compressions list
-
     :param str value: backup_compression value
     :raises ValueError: if the value is invalid
     """
@@ -304,7 +302,7 @@ def parse_backup_compression(value):
     if value.lower() in BASEBACKUP_COMPRESSIONS:
         return value.lower()
     raise ValueError(
-        "Invalid value (must be one in: '%s')" % ("', '".join(BASEBACKUP_COMPRESSIONS))
+        "Invalid value '%s'(must be one in: %s)" % (value, BASEBACKUP_COMPRESSIONS)
     )
 
 
@@ -862,7 +860,7 @@ class Config(object):
             return None
         try:
             value = self._config.get(section, option, raw=False, vars=defaults)
-            if value.lower() == "none":
+            if value == "None":
                 value = none_value
             if value is not None:
                 value = self._QUOTE_RE.sub(lambda m: m.group(2), value)

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -52,7 +52,12 @@ from barman.exceptions import (
     RecoveryPreconditionException,
     SnapshotBackupException,
 )
-from barman.compression import GZipCompression, LZ4Compression, ZSTDCompression
+from barman.compression import (
+    GZipCompression,
+    LZ4Compression,
+    ZSTDCompression,
+    NoneCompression,
+)
 import barman.fs as fs
 from barman.infofile import BackupInfo, LocalBackupInfo
 from barman.utils import force_str, mkpath
@@ -1803,7 +1808,8 @@ def recovery_executor_factory(backup_manager, command, backup_info):
         return TarballRecoveryExecutor(backup_manager, LZ4Compression(command))
     if compression == ZSTDCompression.name:
         return TarballRecoveryExecutor(backup_manager, ZSTDCompression(command))
-
+    if compression == NoneCompression.name:
+        return TarballRecoveryExecutor(backup_manager, NoneCompression(command))
     raise AttributeError("Unexpected compression format: %s" % compression)
 
 

--- a/doc/barman.5
+++ b/doc/barman.5
@@ -157,7 +157,8 @@ Required when the \f[C]snapshot\f[] value is specified for
 .B backup_compression
 The compression to be used during the backup process.
 Only supported when \f[C]backup_method\ =\ postgres\f[].
-Can either be unset or \f[C]gzip\f[],\f[C]lz4\f[] or \f[C]zstd\f[].
+Can either be unset or \f[C]gzip\f[],\f[C]lz4\f[], \f[C]zstd\f[] or
+\f[C]none\f[].
 If unset then no compression will be used during the backup.
 Use of this option requires that the CLI application for the specified
 compression algorithm is available on the Barman server (at backup time)
@@ -165,6 +166,8 @@ and the PostgreSQL server (at recovery time).
 Note that the \f[C]lz4\f[] and \f[C]zstd\f[] algorithms require
 PostgreSQL 15 (beta) or later.
 Global/Server.
+Note that \f[C]none\f[] compression will create an archive not
+compressed.
 .RS
 .RE
 .TP

--- a/doc/barman.5.d/50-backup_compression.md
+++ b/doc/barman.5.d/50-backup_compression.md
@@ -1,7 +1,8 @@
 backup_compression
 :   The compression to be used during the backup process. Only supported when
-    `backup_method = postgres`. Can either be unset or `gzip`,`lz4` or `zstd`. If unset then
+    `backup_method = postgres`. Can either be unset or `gzip`,`lz4`, `zstd` or `none`. If unset then
     no compression will be used during the backup. Use of this option requires that the
     CLI application for the specified compression algorithm is available on the Barman
     server (at backup time) and the PostgreSQL server (at recovery time). Note that
     the `lz4` and `zstd` algorithms require PostgreSQL 15 (beta) or later. Global/Server.
+    Note that `none` compression will create an archive not compressed.

--- a/doc/manual/50-feature-details.en.md
+++ b/doc/manual/50-feature-details.en.md
@@ -131,10 +131,11 @@ using the `backup_compression` config option (global/per server):
 
 Setting this option will cause pg_basebackup to compress the backup
 using the specified compression algorithm. Currently, supported
-algorithm in Barman are: `gzip` `lz4` and `zstd`.
+algorithm in Barman are: `gzip`, `lz4`,`zstd` and `none`. `none` compression
+algorithm will create an uncompressed archive.
 
 ``` ini
-backup_compression = gzip|lz4|zstd
+backup_compression = gzip|lz4|zstd|none
 ```
 
 Barman requires the CLI utility for the selected compression algorithm
@@ -178,6 +179,15 @@ The compression level can be specified using the
 `backup_compression_level` option. This should be set to an integer
 value supported by the compression algorithm specified in
 `backup_compression`.
+If not defined, compression algorithm default value will be used.
+
+`none` compression only supports `backup_compression_level=0`.
+
+> **Note:** `backup_compression_level` available and default values depends on the compression algorithm used. 
+> Please check the compression algorithm documentation for more details.
+
+> **Note:** On PostgreSQL version prior to 15, `gzip` support `backup_compression_level=0`.
+> It results using default compression level
 
 #### Compression location
 
@@ -228,6 +238,7 @@ documentation][pg_basebackup-documentation].
 | lz4 |  tar  | **tar, lz4** | **tar, lz4** |
 | zstd | plain | **tar, zstd** | None |
 | zstd |  tar  | **tar, zstd** | **tar, zstd** |
+| none |  tar  | **tar** | **tar** |
 
 ### Concurrent backup
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -77,6 +77,7 @@ backup_directory =  /some/barman/home/main
 basebackups_directory = /some/barman/home/main/base
 wals_directory = wals
 incoming_wals_directory = /some/barman/home/main/incoming
+backup_compression = "none"
 custom_compression_filter = bzip2 -c -9
 custom_compression_magic = 0x425a68
 custom_decompression_filter = bzip2 -c -d
@@ -156,7 +157,7 @@ class TestConfig(object):
             {
                 "config": main.config,
                 "autogenerate_manifest": False,
-                "backup_compression": None,
+                "backup_compression": "none",
                 "backup_compression_format": None,
                 "backup_compression_level": None,
                 "backup_compression_location": None,
@@ -518,6 +519,7 @@ class TestConfig(object):
             ("gzip", True),
             ("lz4", True),
             ("zstd", True),
+            ("none", True),
             ("lizard", False),
             ("1", False),
         ),


### PR DESCRIPTION
add `backup_compression=none` to create an uncompressed archive that only supports `backup_compression_level=0`.
for pg >= 15:
update `zstd` compression level range from `-131072` to `22` update `lz4` compression level range from `0` to `12`

For PG < 15:
Allow using `backup_compression_level=0` with `backup_compression=gzip` algorithm.

In configuration 'none' can be used as value and not identified as None value.