### PR TITLE
Fix help strings for barman-cloud-backup compression

### DIFF
--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -257,7 +257,7 @@ def parse_arguments(args=None):
     compression.add_argument(
         "-z",
         "--gzip",
-        help="gzip-compress the WAL while uploading to the cloud",
+        help="gzip-compress the backup while uploading to the cloud",
         action="store_const",
         const="gz",
         dest="compression",
@@ -265,14 +265,14 @@ def parse_arguments(args=None):
     compression.add_argument(
         "-j",
         "--bzip2",
-        help="bzip2-compress the WAL while uploading to the cloud",
+        help="bzip2-compress the backup while uploading to the cloud",
         action="store_const",
         const="bz2",
         dest="compression",
     )
     compression.add_argument(
         "--snappy",
-        help="snappy-compress the WAL while uploading to the cloud ",
+        help="snappy-compress the backup while uploading to the cloud ",
         action="store_const",
         const="snappy",
         dest="compression",

--- a/barman/postgres.py
+++ b/barman/postgres.py
@@ -651,7 +651,9 @@ class PostgreSQLConnection(PostgreSQL):
         if self.is_superuser:
             return True
         else:
-            role_check_query = "select pg_has_role(CURRENT_USER ,'pg_checkpoint', 'MEMBER');"
+            role_check_query = (
+                "select pg_has_role(CURRENT_USER ,'pg_checkpoint', 'MEMBER');"
+            )
             try:
                 cur = self._cursor()
                 cur.execute(role_check_query)

--- a/barman/server.py
+++ b/barman/server.py
@@ -2913,8 +2913,10 @@ class Server(RemoteStatusMixin):
             )
         except PostgresCheckpointPrivilegesRequired:
             # Superuser rights are required to perform the switch_wal
-            output.error("Barman switch-wal --force requires superuser rights or "
-                         "the 'pg_checkpoint' role")
+            output.error(
+                "Barman switch-wal --force requires superuser rights or "
+                "the 'pg_checkpoint' role"
+            )
             return
 
         # If the user has asked to wait for a WAL file to be archived,

--- a/doc/barman-cloud-backup.1
+++ b/doc/barman-cloud-backup.1
@@ -82,9 +82,9 @@ optional\ arguments:
 \ \ \-t,\ \-\-test\ \ \ \ \ \ \ \ \ \ \ \ Test\ cloud\ connectivity\ and\ exit
 \ \ \-\-cloud\-provider\ {aws\-s3,azure\-blob\-storage,google\-cloud\-storage}
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ The\ cloud\ provider\ to\ use\ as\ a\ storage\ backend
-\ \ \-z,\ \-\-gzip\ \ \ \ \ \ \ \ \ \ \ \ gzip\-compress\ the\ WAL\ while\ uploading\ to\ the\ cloud
-\ \ \-j,\ \-\-bzip2\ \ \ \ \ \ \ \ \ \ \ bzip2\-compress\ the\ WAL\ while\ uploading\ to\ the\ cloud
-\ \ \-\-snappy\ \ \ \ \ \ \ \ \ \ \ \ \ \ snappy\-compress\ the\ WAL\ while\ uploading\ to\ the\ cloud
+\ \ \-z,\ \-\-gzip\ \ \ \ \ \ \ \ \ \ \ \ gzip\-compress\ the\ backup\ while\ uploading\ to\ the\ cloud
+\ \ \-j,\ \-\-bzip2\ \ \ \ \ \ \ \ \ \ \ bzip2\-compress\ the\ backup\ while\ uploading\ to\ the\ cloud
+\ \ \-\-snappy\ \ \ \ \ \ \ \ \ \ \ \ \ \ snappy\-compress\ the\ backup\ while\ uploading\ to\ the\ cloud
 \ \ \-h\ HOST,\ \-\-host\ HOST\ \ host\ or\ Unix\ socket\ for\ PostgreSQL\ connection
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (default:\ libpq\ settings)
 \ \ \-p\ PORT,\ \-\-port\ PORT\ \ port\ for\ PostgreSQL\ connection\ (default:\ libpq

--- a/doc/barman-cloud-backup.1.md
+++ b/doc/barman-cloud-backup.1.md
@@ -79,9 +79,9 @@ optional arguments:
   -t, --test            Test cloud connectivity and exit
   --cloud-provider {aws-s3,azure-blob-storage,google-cloud-storage}
                         The cloud provider to use as a storage backend
-  -z, --gzip            gzip-compress the WAL while uploading to the cloud
-  -j, --bzip2           bzip2-compress the WAL while uploading to the cloud
-  --snappy              snappy-compress the WAL while uploading to the cloud
+  -z, --gzip            gzip-compress the backup while uploading to the cloud
+  -j, --bzip2           bzip2-compress the backup while uploading to the cloud
+  --snappy              snappy-compress the backup while uploading to the cloud
   -h HOST, --host HOST  host or Unix socket for PostgreSQL connection
                         (default: libpq settings)
   -p PORT, --port PORT  port for PostgreSQL connection (default: libpq

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1065,10 +1065,7 @@ class TestPostgres(object):
         "barman.postgres.PostgreSQLConnection.server_version", new_callable=PropertyMock
     )
     def test_has_checkpoint_privileges(
-            self,
-            server_version_mock,
-            is_su_mock,
-            conn_mock
+        self, server_version_mock, is_su_mock, conn_mock
     ):
         server = build_real_server()
         cursor_mock = conn_mock.return_value.cursor.return_value
@@ -1087,14 +1084,18 @@ class TestPostgres(object):
         is_su_mock.return_value = False
         cursor_mock.fetchone.side_effect = [(False,)]
         assert not server.postgres.has_checkpoint_privileges
-        cursor_mock.execute.assert_called_with("select pg_has_role(CURRENT_USER ,'pg_checkpoint', 'MEMBER');")
+        cursor_mock.execute.assert_called_with(
+            "select pg_has_role(CURRENT_USER ,'pg_checkpoint', 'MEMBER');"
+        )
 
         # no superuser, pg_checkpoint -> True
         cursor_mock.reset_mock()
         is_su_mock.return_value = False
         cursor_mock.fetchone.side_effect = [(True,)]
         assert server.postgres.has_checkpoint_privileges
-        cursor_mock.execute.assert_called_with("select pg_has_role(CURRENT_USER ,'pg_checkpoint', 'MEMBER');")
+        cursor_mock.execute.assert_called_with(
+            "select pg_has_role(CURRENT_USER ,'pg_checkpoint', 'MEMBER');"
+        )
 
         # superuser, no pg_checkpoint -> True
         cursor_mock.reset_mock()
@@ -1114,7 +1115,7 @@ class TestPostgres(object):
     )
     @patch(
         "barman.postgres.PostgreSQLConnection.has_checkpoint_privileges",
-        new_callable=PropertyMock
+        new_callable=PropertyMock,
     )
     def test_checkpoint(self, has_cp_priv_mock, is_in_recovery_mock, conn_mock):
         """


### PR DESCRIPTION
Updates the help strings for the `barman-cloud-backup` compression options so that they refer to backups not WALs.

Closes #115.