### PR TITLE
clean file created during test_ssh_port at the end of the test

### DIFF
--- a/tests/test_barman_wal_restore.py
+++ b/tests/test_barman_wal_restore.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
+import os
 import subprocess
 
 import mock
@@ -105,6 +106,8 @@ class TestRemoteGetWal(object):
             ],
             stdout=mock.ANY,
         )
+        # Clean created file
+        os.remove("test_wal_dest")
 
     @mock.patch("barman.clients.walrestore.RemoteGetWal")
     def test_ssh_connectivity_error(self, remote_get_wal_mock, capsys, tmpdir):


### PR DESCRIPTION
Minor test correction: When running `test_ssh_port` a file  named `test_wal_dest` remains.

This will clean the test so the file is deleted when the test is done