### PR TITLE
Clarify archiver and streaming_archiver defaults

### DIFF
--- a/doc/barman.5
+++ b/doc/barman.5
@@ -73,12 +73,17 @@ setup.
 .B archiver
 This option allows you to activate log file shipping through
 PostgreSQL\[aq]s \f[C]archive_command\f[] for a server.
-If set to \f[C]true\f[] (default), Barman expects that continuous
-archiving for a server is in place and will activate checks as well as
-management (including compression) of WAL files that Postgres deposits
-in the \f[I]incoming\f[] directory.
-Setting it to \f[C]false\f[], will disable standard continuous archiving
-for a server.
+If set to \f[C]true\f[], Barman expects that continuous archiving for a
+server is in place and will activate checks as well as management
+(including compression) of WAL files that Postgres deposits in the
+\f[I]incoming\f[] directory.
+Setting it to \f[C]false\f[] (default), will disable standard continuous
+archiving for a server.
+Note: If neither \f[C]archiver\f[] nor \f[C]streaming_archiver\f[] are
+set, Barman will automatically set this option to \f[C]true\f[].
+This is in order to maintain parity with deprecated behaviour where
+\f[C]archiver\f[] would be enabled by default.
+This behaviour will be removed from the next major Barman version.
 Global/Server.
 .RS
 .RE
@@ -886,6 +891,11 @@ compression) of WAL files.
 If set to \f[C]off\f[] (default) barman will rely only on continuous
 archiving for a server WAL archive operations, eventually terminating
 any running \f[C]pg_receivexlog\f[] for the server.
+Note: If neither \f[C]streaming_archiver\f[] nor \f[C]archiver\f[] are
+set, Barman will automatically set \f[C]archiver\f[] to \f[C]true\f[].
+This is in order to maintain parity with deprecated behaviour where
+\f[C]archiver\f[] would be enabled by default.
+This behaviour will be removed from the next major Barman version.
 Global/Server.
 .RS
 .RE

--- a/doc/barman.5.d/50-archiver.md
+++ b/doc/barman.5.d/50-archiver.md
@@ -1,7 +1,12 @@
 archiver
 :   This option allows you to activate log file shipping through PostgreSQL's
-    `archive_command` for a server. If set to `true` (default), Barman expects
-    that continuous archiving for a server is in place and will activate
-    checks as well as management (including compression) of WAL files that
-    Postgres deposits in the *incoming* directory. Setting it to `false`,
-    will disable standard continuous archiving for a server. Global/Server.
+    `archive_command` for a server. If set to `true`, Barman expects that
+    continuous archiving for a server is in place and will activate checks as
+    well as management (including compression) of WAL files that Postgres
+    deposits in the *incoming* directory. Setting it to `false` (default),
+    will disable standard continuous archiving for a server. Note: If neither
+    `archiver` nor `streaming_archiver` are set, Barman will automatically set
+    this option to `true`. This is in order to maintain parity with deprecated
+    behaviour where `archiver` would be enabled by default. This behaviour will
+    be removed from the next major Barman version.
+    Global/Server.

--- a/doc/barman.5.d/50-streaming_archiver.md
+++ b/doc/barman.5.d/50-streaming_archiver.md
@@ -7,4 +7,9 @@ streaming_archiver
     checks as well as management (including compression) of WAL files.
     If set to `off` (default) barman will rely only on continuous archiving
     for a server WAL archive operations, eventually terminating any running
-    `pg_receivexlog` for the server. Global/Server.
+    `pg_receivexlog` for the server.  Note: If neither `streaming_archiver`
+    nor `archiver` are set, Barman will automatically set `archiver` to
+    `true`. This is in order to maintain parity with deprecated behaviour
+    where `archiver` would be enabled by default. This behaviour will be
+    removed from the next major Barman version.
+    Global/Server.

--- a/doc/barman.d/streaming-server.conf-template
+++ b/doc/barman.d/streaming-server.conf-template
@@ -36,5 +36,9 @@ slot_name = barman
 ;streaming_archiver_name = barman_receive_wal
 ;streaming_archiver_batch_size = 50
 
+; Uncomment the following line if you are also using archive_command
+; otherwise the "empty incoming directory" check will fail
+;archiver = on
+
 ; PATH setting for this server
 ;path_prefix = "/usr/pgsql-12/bin"


### PR DESCRIPTION
Updates the default value of the `archiver` config option in the docs with its real default and adds a note explaining:

- That it will default to `true` only if `streaming_archiver` is `off`.
- That this behaviour is deprecated and will be removed.

The docs for `streaming_archiver` are updated with a similar explanatory note.

The streaming server configuration template is also updated so that it instructs users to set `archiver = on` if archive_command is used in addition to pg_receivewal.

Closes #280.