### PR TITLE
[WIP] Allow WAL streaming from a different host to the backup source

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -602,6 +602,15 @@ def status(args):
                         'wal-streamer' (only WAL streaming clients, such as pg_receivewal),
                         'all' (any of them). Defaults to %(default)s""",
         ),
+        argument(
+            "--source",
+            choices=("backup-host", "wal-host"),
+            default="backup-host",
+            help="""
+                        Possible values are: 'backup-host' (only show replications
+                        running on the backup host) or 'wal-host' (only show repliations
+                        running on the wal host). Defaults to %(default)s""",
+        ),
     ]
 )
 def replication_status(args):
@@ -618,7 +627,7 @@ def replication_status(args):
 
         with closing(server):
             output.init("replication_status", name, minimal=args.minimal)
-            server.replication_status(args.target)
+            server.replication_status(args.target, source=args.source)
     output.close_and_exit()
 
 

--- a/barman/config.py
+++ b/barman/config.py
@@ -513,7 +513,9 @@ class ServerConfig(object):
         "streaming_conninfo",
         "streaming_wals_directory",
         "tablespace_bandwidth_limit",
+        "wal_conninfo",
         "wal_retention_policy",
+        "wal_streaming_conninfo",
         "wals_directory",
     ]
 
@@ -625,7 +627,9 @@ class ServerConfig(object):
         "streaming_backup_name": "barman_streaming_backup",
         "streaming_conninfo": "%(conninfo)s",
         "streaming_wals_directory": "%(backup_directory)s/streaming",
+        "wal_conninfo": "%(conninfo)s",
         "wal_retention_policy": "main",
+        "wal_streaming_conninfo": "%(wal_conninfo)s",
         "wals_directory": "%(backup_directory)s/wals",
     }
 

--- a/barman/config.py
+++ b/barman/config.py
@@ -627,9 +627,7 @@ class ServerConfig(object):
         "streaming_backup_name": "barman_streaming_backup",
         "streaming_conninfo": "%(conninfo)s",
         "streaming_wals_directory": "%(backup_directory)s/streaming",
-        "wal_conninfo": "%(conninfo)s",
         "wal_retention_policy": "main",
-        "wal_streaming_conninfo": "%(wal_conninfo)s",
         "wals_directory": "%(backup_directory)s/wals",
     }
 

--- a/barman/postgres.py
+++ b/barman/postgres.py
@@ -666,6 +666,43 @@ class PostgreSQLConnection(PostgreSQL):
                 return None
 
     @property
+    def has_monitoring_privileges(self):
+        """
+        Returns true if the current user is a superuser or if the user has the
+        necessary privileges to monitor system status.
+        """
+        if self.is_superuser:
+            return True
+        else:
+            monitoring_check_query = """
+            SELECT
+            (
+                pg_has_role(CURRENT_USER, 'pg_monitor', 'MEMBER')
+                OR
+                (
+                    pg_has_role(CURRENT_USER, 'pg_read_all_settings', 'MEMBER')
+                    AND pg_has_role(CURRENT_USER, 'pg_read_all_stats', 'MEMBER')
+                )
+            )
+            FROM
+            pg_user
+            WHERE
+            usename = CURRENT_USER
+            """.format(
+                **self.name_map
+            )
+            try:
+                cur = self._cursor()
+                cur.execute(monitoring_check_query)
+                return cur.fetchone()[0]
+            except (PostgresConnectionError, psycopg2.Error) as e:
+                _logger.debug(
+                    "Error checking privileges for functions needed for monitoring: %s",
+                    force_str(e).strip(),
+                )
+                return None
+
+    @property
     def current_xlog_info(self):
         """
         Get detailed information about the current WAL position in PostgreSQL.
@@ -938,6 +975,7 @@ class PostgreSQLConnection(PostgreSQL):
 
             result["is_superuser"] = self.is_superuser
             result["has_backup_privileges"] = self.has_backup_privileges
+            result["has_monitoring_privileges"] = self.has_monitoring_privileges
             result["is_in_recovery"] = self.is_in_recovery
             result["server_txt_version"] = self.server_txt_version
             result["version_supported"] = self.is_minimal_postgres_version()

--- a/barman/postgres.py
+++ b/barman/postgres.py
@@ -1431,7 +1431,7 @@ class PostgreSQLConnection(PostgreSQL):
         try:
             cur = self._cursor(cursor_factory=NamedTupleCursor)
 
-            if not self.has_backup_privileges:
+            if not self.has_monitoring_privileges:
                 raise BackupFunctionsAccessRequired(
                     "Postgres user '%s' is missing required privileges "
                     '(see "Preliminary steps" in the Barman manual)'

--- a/barman/server.py
+++ b/barman/server.py
@@ -2577,7 +2577,7 @@ class Server(RemoteStatusMixin):
         """
         Create a physical replication slot using the streaming connection
         """
-        if not self.streaming:
+        if not self.wal_streaming:
             output.error(
                 "Unable to create a physical replication slot: "
                 "streaming connection not configured"
@@ -2586,11 +2586,12 @@ class Server(RemoteStatusMixin):
 
         # Replication slots are not supported by PostgreSQL < 9.4
         try:
-            if self.streaming.server_version < 90400:
+            if self.wal_streaming.server_version < 90400:
                 output.error(
                     "Unable to create a physical replication slot: "
                     "not supported by '%s' "
-                    "(9.4 or higher is required)" % self.streaming.server_major_version
+                    "(9.4 or higher is required)"
+                    % self.wal_streaming.server_major_version
                 )
                 return
         except PostgresException as exc:
@@ -2613,7 +2614,7 @@ class Server(RemoteStatusMixin):
         )
 
         try:
-            self.streaming.create_physical_repslot(self.config.slot_name)
+            self.wal_streaming.create_physical_repslot(self.config.slot_name)
             output.info("Replication slot '%s' created", self.config.slot_name)
         except PostgresDuplicateReplicationSlot:
             output.error("Replication slot '%s' already exists", self.config.slot_name)
@@ -2636,7 +2637,7 @@ class Server(RemoteStatusMixin):
         """
         Drop a replication slot using the streaming connection
         """
-        if not self.streaming:
+        if not self.wal_streaming:
             output.error(
                 "Unable to drop a physical replication slot: "
                 "streaming connection not configured"
@@ -2645,11 +2646,11 @@ class Server(RemoteStatusMixin):
 
         # Replication slots are not supported by PostgreSQL < 9.4
         try:
-            if self.streaming.server_version < 90400:
+            if self.wal_streaming.server_version < 90400:
                 output.error(
                     "Unable to drop a physical replication slot: "
                     "not supported by '%s' (9.4 or higher is "
-                    "required)" % self.streaming.server_major_version
+                    "required)" % self.wal_streaming.server_major_version
                 )
                 return
         except PostgresException as exc:
@@ -2672,7 +2673,7 @@ class Server(RemoteStatusMixin):
         )
 
         try:
-            self.streaming.drop_repslot(self.config.slot_name)
+            self.wal_streaming.drop_repslot(self.config.slot_name)
             output.info("Replication slot '%s' dropped", self.config.slot_name)
         except PostgresInvalidReplicationSlot:
             output.error("Replication slot '%s' does not exist", self.config.slot_name)

--- a/barman/server.py
+++ b/barman/server.py
@@ -639,6 +639,10 @@ class Server(RemoteStatusMixin):
             self.postgres.close()
         if self.streaming:
             self.streaming.close()
+        if self.wal_postgres != self.postgres:
+            self.wal_postgres.close()
+        if self.wal_streaming != self.streaming:
+            self.streaming.close()
 
     def check(self, check_strategy=__default_check_strategy):
         """
@@ -1543,6 +1547,8 @@ class Server(RemoteStatusMixin):
         # connection that may have been opened by the self.check() call
         if self.streaming:
             self.streaming.close()
+            if self.wal_streaming != self.streaming:
+                self.wal_streaming.close()
 
         try:
             # lock acquisition and backup execution

--- a/barman/server.py
+++ b/barman/server.py
@@ -3120,7 +3120,7 @@ class Server(RemoteStatusMixin):
                     "A WAL file has not been received in %s seconds", archive_timeout
                 )
 
-    def replication_status(self, target="all"):
+    def replication_status(self, target="all", source="backup-host"):
         """
         Implements the 'replication-status' command.
         """
@@ -3130,8 +3130,13 @@ class Server(RemoteStatusMixin):
             client_type = PostgreSQLConnection.WALSTREAMER
         else:
             client_type = PostgreSQLConnection.ANY_STREAMING_CLIENT
+        if source == "wal-host":
+            postgres = self.wal_postgres
+        else:
+            postgres = self.postgres
         try:
-            standby_info = self.postgres.get_replication_stats(client_type)
+            standby_info = postgres.get_replication_stats(client_type)
+
             if standby_info is None:
                 output.error("Unable to connect to server %s" % self.config.name)
             else:
@@ -3139,7 +3144,7 @@ class Server(RemoteStatusMixin):
                     "replication_status",
                     self.config.name,
                     target,
-                    self.postgres.current_xlog_location,
+                    postgres.current_xlog_location,
                     standby_info,
                 )
         except PostgresUnsupportedFeature as e:

--- a/barman/server.py
+++ b/barman/server.py
@@ -838,6 +838,22 @@ class Server(RemoteStatusMixin):
                     check="no access to backup functions",
                 )
 
+        # If there is a separate WAL connection, check it has monitoring privileges
+        if remote_status.get("wal_server"):
+            check_strategy.init_check(
+                "Connection to WAL server has monitoring privileges"
+            )
+            if remote_status["wal_server"].get("has_monitoring_privileges"):
+                check_strategy.result(self.config.name, True)
+            else:
+                check_strategy.result(
+                    self.config.name,
+                    False,
+                    hint="privileges for PostgreSQL monitoring functions are "
+                    "required (see documentation)",
+                    check="no access to monitoring functions",
+                )
+
         if "streaming_supported" in remote_status:
             check_strategy.init_check("PostgreSQL streaming")
             hint = None

--- a/barman/wal_archiver.py
+++ b/barman/wal_archiver.py
@@ -683,8 +683,8 @@ class StreamingWalArchiver(WalArchiver):
 
         # Retrieve the PostgreSQL version
         pg_version = None
-        if self.server.streaming is not None:
-            pg_version = self.server.streaming.server_major_version
+        if self.server.wal_streaming is not None:
+            pg_version = self.server.wal_streaming.server_major_version
 
         # If one of the version is unknown we cannot compare them
         if pgreceivexlog_version is None or pg_version is None:
@@ -735,7 +735,7 @@ class StreamingWalArchiver(WalArchiver):
         mkpath(self.config.streaming_wals_directory)
 
         # Execute basic sanity checks on PostgreSQL connection
-        streaming_status = self.server.streaming.get_remote_status()
+        streaming_status = self.server.wal_streaming.get_remote_status()
         if streaming_status["streaming_supported"] is None:
             raise ArchiverFailure(
                 "failed opening the PostgreSQL streaming connection "
@@ -744,11 +744,11 @@ class StreamingWalArchiver(WalArchiver):
         elif not streaming_status["streaming_supported"]:
             raise ArchiverFailure(
                 "PostgreSQL version too old (%s < 9.2)"
-                % self.server.streaming.server_txt_version
+                % self.server.wal_streaming.server_txt_version
             )
         # Execute basic sanity checks on pg_receivexlog
         command = "pg_receivewal"
-        if self.server.streaming.server_version < 100000:
+        if self.server.wal_streaming.server_version < 100000:
             command = "pg_receivexlog"
         remote_status = self.get_remote_status()
         if not remote_status["pg_receivexlog_installed"]:
@@ -759,14 +759,14 @@ class StreamingWalArchiver(WalArchiver):
             )
 
         # Execute sanity check on replication slot usage
-        postgres_status = self.server.postgres.get_remote_status()
+        postgres_status = self.server.wal_postgres.get_remote_status()
         if self.config.slot_name:
             # Check if slots are supported
             if not remote_status["pg_receivexlog_supports_slots"]:
                 raise ArchiverFailure(
                     "Physical replication slot not supported by %s "
                     "(9.4 or higher is required)"
-                    % self.server.streaming.server_txt_version
+                    % self.server.wal_streaming.server_txt_version
                 )
             # Check if the required slot exists
             if postgres_status["replication_slot"] is None:
@@ -804,7 +804,7 @@ class StreamingWalArchiver(WalArchiver):
         try:
             output_handler = PgReceiveXlog.make_output_handler(self.config.name + ": ")
             receive = PgReceiveXlog(
-                connection=self.server.streaming,
+                connection=self.server.wal_streaming,
                 destination=self.config.streaming_wals_directory,
                 command=remote_status["pg_receivexlog_path"],
                 version=remote_status["pg_receivexlog_version"],
@@ -1006,8 +1006,8 @@ class StreamingWalArchiver(WalArchiver):
         check_strategy.init_check("pg_receivexlog compatible")
         if not remote_status["pg_receivexlog_compatible"]:
             pg_version = "Unknown"
-            if self.server.streaming is not None:
-                pg_version = self.server.streaming.server_txt_version
+            if self.server.wal_streaming is not None:
+                pg_version = self.server.wal_streaming.server_txt_version
             hint = "PostgreSQL version: %s, pg_receivexlog version: %s" % (
                 pg_version,
                 remote_status["pg_receivexlog_version"],
@@ -1041,7 +1041,7 @@ class StreamingWalArchiver(WalArchiver):
         :rtype: bool
         """
         # Nothing to do if postgres connection is not working
-        postgres = self.server.postgres
+        postgres = self.server.wal_postgres
         if postgres is None or postgres.server_txt_version is None:
             return None
 


### PR DESCRIPTION
This is a work-in-progress for BAR-120 where we add the ability for users to define conninfo strings to be used for streaming WALs. This allows WALs to be streamed from a different host than the host from which backups are streamed.

The implementation is a lot more complicated than I'd like and I feel like there are opportunities for simplifying things which I'm not seeing, so suggestions along these lines are particularly welcome.