### PR TITLE
Dev/bar 120 attempt 2

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -609,9 +609,10 @@ def status(args):
             choices=("backup-host", "wal-host"),
             default="backup-host",
             help="""
-                        Possible values are: 'backup-host' (only show replications
-                        running on the backup host) or 'wal-host' (only show replications
-                        running on the wal host). Defaults to %(default)s""",
+                        Possible values are: 'backup-host' (list clients using the
+                        backup conninfo for a server) or `wal-host` (list clients using
+                        the WAL streaming conninfo for a server). Defaults to
+                        %(default)s""",
         ),
     ]
 )

--- a/barman/config.py
+++ b/barman/config.py
@@ -572,7 +572,9 @@ class ServerConfig(BaseConfig):
         "streaming_conninfo",
         "streaming_wals_directory",
         "tablespace_bandwidth_limit",
+        "wal_conninfo",
         "wal_retention_policy",
+        "wal_streaming_conninfo",
         "wals_directory",
     ]
 
@@ -920,6 +922,34 @@ class ServerConfig(BaseConfig):
 
         self.msg_list.extend(msg_list)
         self.disabled = True
+
+    def get_wal_conninfo(self):
+        """
+        Return WAL-specific conninfo strings for this server.
+
+        Returns the value of ``wal_streaming_conninfo`` and ``wal_conninfo`` if they
+        are set in the configuration. If ``wal_conninfo`` is unset then it will
+        be given the value of ``wal_streaming_conninfo``. If ``wal_streaming_conninfo``
+        is unset then fall back to ``streaming_conninfo`` and ``conninfo``.
+
+        :rtype: (str,str)
+        :return: Tuple consisting of the ``wal_streaming_conninfo`` and
+            ``wal_conninfo`` defined in the configuration if ``wal_streaming_conninfo``
+            is set, a tuple of ``streaming_conninfo`` and ``conninfo`` otherwise.
+        """
+        wal_streaming_conninfo, wal_conninfo = None, None
+        if self.wal_streaming_conninfo is not None:
+            wal_streaming_conninfo = self.wal_streaming_conninfo
+            if self.wal_conninfo is not None:
+                wal_conninfo = self.wal_conninfo
+            else:
+                wal_conninfo = self.wal_streaming_conninfo
+        else:
+            # If wal_streaming_conninfo is not set then return the original
+            # streaming_conninfo and conninfo parameters
+            wal_streaming_conninfo = self.streaming_conninfo
+            wal_conninfo = self.conninfo
+        return wal_streaming_conninfo, wal_conninfo
 
 
 class ModelConfig(BaseConfig):

--- a/doc/barman.1.d/50-replication-status.md
+++ b/doc/barman.1.d/50-replication-status.md
@@ -13,3 +13,11 @@ replication-status *\[OPTIONS\]* *SERVER_NAME*
          - *wal-streamer*: lists only WAL streaming clients, such as
                           pg_receivewal
          - *all*: any streaming client (default)
+
+    --source *SOURCE_TYPE*
+    :    Possible values for SOURCE_TYPE are:
+
+         - *backup-host*: list clients using the backup conninfo for
+                          a server (default)
+         - *wal-host*: list clients using the WAL streaming conninfo
+                       for a server

--- a/doc/barman.5.d/50-wal_conninfo.md
+++ b/doc/barman.5.d/50-wal_conninfo.md
@@ -1,0 +1,8 @@
+wal_conninfo
+:   A connection string which, if set, will be used by Barman to connect to the
+    Postgres server when checking the status of the replication slot used for
+    receiving WALs. If left unset then Barman will use the connection string
+    defined by `wal_streaming_conninfo`. If `wal_conninfo` is set but
+    `wal_streaming_conninfo` is unset then `wal_conninfo` will be ignored.
+
+    Scope: Server/Model.

--- a/doc/barman.5.d/50-wal_streaming_conninfo.md
+++ b/doc/barman.5.d/50-wal_streaming_conninfo.md
@@ -1,0 +1,7 @@
+wal_streaming_conninfo
+:   A connection string which, if set, will be used by Barman to connect to
+    the Postgres server when receiving WAL segments via the streaming
+    replication protocol. If left unset then Barman will use the connection
+    string defined by `streaming_conninfo` for receiving WAL segments.
+
+    Scope: Server/Model.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1391,7 +1391,9 @@ class TestModelConfig:
             "streaming_backup_name": None,
             "streaming_conninfo": "SOME_STREAMING_CONNINFO",
             "tablespace_bandwidth_limit": None,
+            "wal_conninfo": None,
             "wal_retention_policy": None,
+            "wal_streaming_conninfo": None,
         }
         assert model_config.to_json() == expected
 
@@ -1484,7 +1486,9 @@ class TestModelConfig:
                 "value": "SOME_STREAMING_CONNINFO",
             },
             "tablespace_bandwidth_limit": {"source": "SOME_SOURCE", "value": None},
+            "wal_conninfo": {"source": "SOME_SOURCE", "value": None},
             "wal_retention_policy": {"source": "SOME_SOURCE", "value": None},
+            "wal_streaming_conninfo": {"source": "SOME_SOURCE", "value": None},
         }
         assert model_config.to_json(True) == expected
 

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -963,6 +963,7 @@ class TestPostgres(object):
             "wal_compression": "a wal_compression value",
             "xlog_segment_size": 8388608,
             "postgres_systemid": 6721602258895701769,
+            "has_monitoring_privileges": True,
         }
 
         # Test PostgreSQL 9.6
@@ -994,6 +995,7 @@ class TestPostgres(object):
             "wal_compression": "a wal_compression value",
             "xlog_segment_size": 8388608,
             "postgres_systemid": 6721602258895701769,
+            "has_monitoring_privileges": True,
         }
 
         # Test PostgreSQL 13
@@ -1025,6 +1027,7 @@ class TestPostgres(object):
             "wal_compression": "a wal_compression value",
             "xlog_segment_size": 8388608,
             "postgres_systemid": 6721602258895701769,
+            "has_monitoring_privileges": True,
         }
 
         # Test error management
@@ -1229,11 +1232,11 @@ class TestPostgres(object):
         "barman.postgres.PostgreSQLConnection.server_version", new_callable=PropertyMock
     )
     @patch(
-        "barman.postgres.PostgreSQLConnection.has_backup_privileges",
+        "barman.postgres.PostgreSQLConnection.has_monitoring_privileges",
         new_callable=PropertyMock,
     )
     def test_get_replication_stats(
-        self, has_backup_privileges_mock, server_version_mock, conn_mock
+        self, has_monitoring_privileges_mock, server_version_mock, conn_mock
     ):
         """
         Simple test for the execution of get_replication_stats on a server
@@ -1241,7 +1244,7 @@ class TestPostgres(object):
         # Build a server
         server = build_real_server()
         cursor_mock = conn_mock.return_value.cursor.return_value
-        has_backup_privileges_mock.return_value = True
+        has_monitoring_privileges_mock.return_value = True
 
         # 10 ALL
         cursor_mock.reset_mock()
@@ -1334,7 +1337,7 @@ class TestPostgres(object):
 
         cursor_mock.reset_mock()
         # Missing required permissions
-        has_backup_privileges_mock.return_value = False
+        has_monitoring_privileges_mock.return_value = False
         with pytest.raises(BackupFunctionsAccessRequired):
             server.postgres.get_replication_stats(
                 PostgreSQLConnection.ANY_STREAMING_CLIENT

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -355,6 +355,8 @@ def build_config_dictionary(config_keys=None):
         "snapshot_provider": None,
         "snapshot_zone": None,
         "snapshot_gcp_project": None,
+        "wal_conninfo": None,
+        "wal_streaming_conninfo": None,
     }
     # Check for overriding keys
     if config_keys is not None:


### PR DESCRIPTION
This is functionally-equivalent to #867 however the different conninfo strings for WAL streaming are managed before creating the server.

The general idea is that:
1. `barman backup` and most other barman commands create `barman.server.Server` objects using the `conninfo` and `streaming_conninfo` in the configuration as usual.
2. `barman receive-wal` and `barman cron` create `barman.server.Server` objects using `wal_conninfo` and `wal_streaming_conninfo` if they are set but use`conninfo` and `streaming_conninfo` otherwise.
3. `barman replication-status` will use either, depending on the value of its `--source` option (which defaults to the backup conninfo, to preserve existing behaviour).

This works quite nicely however:
1. We need to be sure this is a safe thing to do. Might `barman cron` need to use the backup-host conninfo strings for some reason? Are there other barman commands which should have the WAL conninfo?
2. `barman check` still needs work because it is checking the complete configuration of the Barman server.

Point 2 is addressed by the second commit in this PR where we make `barman check` get the WAL streaming status and carry out the relevant checks using that.

For point 1 we can do some careful review.

Overall this seems cleaner than #867 and does not require the scattergun changes to `barman.server.Server` which are present in that PR.

Related: [Integration tests](https://github.com/EnterpriseDB/barman-testing/pull/142).