### PR TITLE
Remove full-depth traversal - only list items in the requested 'directory'

### DIFF
--- a/barman/cloud_providers/azure_blob_storage.py
+++ b/barman/cloud_providers/azure_blob_storage.py
@@ -44,7 +44,6 @@ except ImportError:
 
 try:
     from azure.storage.blob import (
-        BlobPrefix,
         ContainerClient,
         PartialBatchErrorException,
     )

--- a/barman/cloud_providers/azure_blob_storage.py
+++ b/barman/cloud_providers/azure_blob_storage.py
@@ -290,26 +290,6 @@ class AzureCloudInterface(CloudInterface):
         # the storage account level in Azure)
         self.container_client.create_container()
 
-    def _walk_blob_tree(self, obj, ignore=None):
-        """
-        Walk a blob tree in a directory manner and return a list of directories
-        and files.
-
-        :param ItemPaged[BlobProperties] obj: Iterable response of BlobProperties
-          obtained from ContainerClient.walk_blobs
-        :param str|None ignore: An entry to be excluded from the returned list,
-          typically the top level prefix
-        :return: List of objects and directories in the tree
-        :rtype: List[str]
-        """
-        if obj.name != ignore:
-            yield obj.name
-        if isinstance(obj, BlobPrefix):
-            # We are a prefix and not a leaf so iterate children
-            for child in obj:
-                for v in self._walk_blob_tree(child):
-                    yield v
-
     def list_bucket(self, prefix="", delimiter=DEFAULT_DELIMITER):
         """
         List bucket content in a directory manner
@@ -322,7 +302,9 @@ class AzureCloudInterface(CloudInterface):
         res = self.container_client.walk_blobs(
             name_starts_with=prefix, delimiter=delimiter
         )
-        return self._walk_blob_tree(res, ignore=prefix)
+
+        for item in res:
+            yield item.name
 
     def download_file(self, key, dest_path, decompress=None):
         """


### PR DESCRIPTION
Currently the azure container storage implementation of list_bucket does a depth-first traversal of the blob directory while the aws s3 implementation only lists the items in the target directory. Since doing the full traversal can be _VERY_ time-consuming when a lot of wal segments are archived in the bucket this degrades recovery operations.

We are currently experiencing 10 minute download times for a 300 byte .history file because the tree walk lists all wal segments on all timelines.

This PR removes the recursive calls and only returns first-level content similar to aws s3 implementation.