### PR TITLE
Include wal_name in list_bucket prefix to improve performance of download_wal

### DIFF
--- a/barman/clients/cloud_walrestore.py
+++ b/barman/clients/cloud_walrestore.py
@@ -143,6 +143,7 @@ class CloudWalDownloader(object):
             # perfect match (uncompressed file)
             if item == wal_path:
                 remote_name = item
+                continue
             # look for compressed files or .partial files
 
             # Detect compression

--- a/barman/clients/cloud_walrestore.py
+++ b/barman/clients/cloud_walrestore.py
@@ -139,39 +139,39 @@ class CloudWalDownloader(object):
         remote_name = None
         # Automatically detect compression based on the file extension
         compression = None
-        for item in self.cloud_interface.list_bucket(source_dir):
+        for item in self.cloud_interface.list_bucket(wal_path):
             # perfect match (uncompressed file)
             if item == wal_path:
                 remote_name = item
             # look for compressed files or .partial files
-            elif item.startswith(wal_path):
-                # Detect compression
-                basename = item
-                for e, c in ALLOWED_COMPRESSIONS.items():
-                    if item[-len(e) :] == e:
-                        # Strip extension
-                        basename = basename[: -len(e)]
-                        compression = c
-                        break
 
-                # Check basename is a known xlog file (.partial?)
-                if not is_any_xlog_file(basename):
-                    logging.warning("Unknown WAL file: %s", item)
-                    continue
-                # Exclude backup informative files (not needed in recovery)
-                elif is_backup_file(basename):
-                    logging.info("Skipping backup file: %s", item)
-                    continue
+            # Detect compression
+            basename = item
+            for e, c in ALLOWED_COMPRESSIONS.items():
+                if item[-len(e) :] == e:
+                    # Strip extension
+                    basename = basename[: -len(e)]
+                    compression = c
+                    break
 
-                # Found candidate
-                remote_name = item
-                logging.info(
-                    "Found WAL %s for server %s as %s",
-                    wal_name,
-                    self.server_name,
-                    remote_name,
-                )
-                break
+            # Check basename is a known xlog file (.partial?)
+            if not is_any_xlog_file(basename):
+                logging.warning("Unknown WAL file: %s", item)
+                continue
+            # Exclude backup informative files (not needed in recovery)
+            elif is_backup_file(basename):
+                logging.info("Skipping backup file: %s", item)
+                continue
+
+            # Found candidate
+            remote_name = item
+            logging.info(
+                "Found WAL %s for server %s as %s",
+                wal_name,
+                self.server_name,
+                remote_name,
+            )
+            break
 
         if not remote_name:
             logging.info(

--- a/tests/test_barman_cloud_wal_restore.py
+++ b/tests/test_barman_cloud_wal_restore.py
@@ -70,9 +70,7 @@ class TestMain(object):
         """If the WAL cannot be found we exit with status 1."""
         cloud_interface_mock = get_cloud_interface_mock.return_value
         cloud_interface_mock.path = "testfolder/"
-        cloud_interface_mock.list_bucket.return_value = [
-            "testfolder/test-server/wals/000000080000ABFF/000000080000ABFF000000C1"
-        ]
+        cloud_interface_mock.list_bucket.return_value = []
         caplog.set_level(logging.INFO)
         with pytest.raises(SystemExit) as exc:
             cloud_walrestore.main(


### PR DESCRIPTION
The current implementation of [download_wal](https://github.com/sjuls/barman/blob/0bab1921352ea352950a062a1ab51fcb278e5250/barman/clients/cloud_walrestore.py#L121) lists all files in the wal directory and filters client-side for the actual wal being requested. However since we're querying blob storage which filters by prefix we can include the wal_name in the prefix to execute this filtering on the cloud provider while still retrieving both compressed and non-compressed files. 

The `list_bucket` api in the `cloud_interface` currently specifies prefix for filtering without any restrictions on the prefix pointing to a `folder`, and I believe all cloud providers supported by barman support filtering by any prefix as well.

This change should provide a noticeable performance improvement on wal directories containing a large amount of archived wal segments.