### PR TITLE
Add documentation for HA cluster support features

### DIFF
--- a/doc/barman.1.d/50-config-switch.md
+++ b/doc/barman.1.d/50-config-switch.md
@@ -1,0 +1,6 @@
+config-switch *SERVER_NAME* *MODEL_NAME*
+:   Apply a set of configuration overrides defined in the model ``MODEL_NAME``
+    to the Barman server ``SERVER_NAME``. The final configuration is composed
+    by the server configuration plus the overrides defined in the given model.
+    Note: there can only be at most one model active at a time for a given
+    server.

--- a/doc/barman.1.d/50-config-switch.md
+++ b/doc/barman.1.d/50-config-switch.md
@@ -1,6 +1,6 @@
 config-switch *SERVER_NAME* *MODEL_NAME*
 :   Apply a set of configuration overrides defined in the model ``MODEL_NAME``
     to the Barman server ``SERVER_NAME``. The final configuration is composed
-    by the server configuration plus the overrides defined in the given model.
+    of the server configuration plus the overrides defined in the given model.
     Note: there can only be at most one model active at a time for a given
     server.

--- a/doc/barman.5.d/50-active.md
+++ b/doc/barman.5.d/50-active.md
@@ -6,3 +6,5 @@ active
     setting active=false at first, making sure that barman check shows
     no problems, and only then activating the server. This will avoid
     spamming the Barman logs with errors during the initial setup.
+
+    Scope: Server/Model.

--- a/doc/barman.5.d/50-archiver.md
+++ b/doc/barman.5.d/50-archiver.md
@@ -9,4 +9,5 @@ archiver
     this option to `true`. This is in order to maintain parity with deprecated
     behaviour where `archiver` would be enabled by default. This behaviour will
     be removed from the next major Barman version.
-    Global/Server.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-archiver_batch_size.md
+++ b/doc/barman.5.d/50-archiver_batch_size.md
@@ -4,4 +4,6 @@ archiver_batch_size
     the traditional unlimited processing of the WAL queue is enabled.
     When batch processing is activated, the `archive-wal` process would
     limit itself to maximum `archiver_batch_size` WAL segments per single
-    run. Integer. Global/Server.
+    run. Integer.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-autogenerate_manifest.md
+++ b/doc/barman.5.d/50-autogenerate_manifest.md
@@ -1,7 +1,12 @@
 autogenerate_manifest
 :   This option enables the auto-generation of backup manifest files
     for rsync based backups and strategies.
-    The manifest file is a JSON file containing the list of files contained in the backup.
-    It is generated at the end of the backup process and stored in the backup directory.
-    The manifest file generated follows the format described in the postgesql documentation, and is compatible with the `pg_verifybackup` tool.
+    The manifest file is a JSON file containing the list of files contained in
+    the backup.
+    It is generated at the end of the backup process and stored in the backup
+    directory.
+    The manifest file generated follows the format described in the postgesql
+    documentation, and is compatible with the `pg_verifybackup` tool.
     The option is ignored if the backup method is not rsync.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-aws_profile.md
+++ b/doc/barman.5.d/50-aws_profile.md
@@ -1,3 +1,5 @@
 aws_profile
 :   The name of the AWS profile to use when authenticating with AWS
-    (e.g. INI section in AWS credentials file). Global/Server.
+    (e.g. INI section in AWS credentials file).
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-aws_region.md
+++ b/doc/barman.5.d/50-aws_region.md
@@ -1,3 +1,5 @@
 aws_region
 :   The name of the AWS region containing the EC2 VM and storage volumes
-    defined by `snapshot_instance` and `snapshot_disks`. Global/Server.
+    defined by `snapshot_instance` and `snapshot_disks`.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-azure_credential.md
+++ b/doc/barman.5.d/50-azure_credential.md
@@ -1,4 +1,6 @@
 azure_credential
 :   The credential type (either `azure-cli` or `managed-identity`) to use when
     authenticating with Azure. If this is omitted then the default Azure
-    authentication flow will be used. Global/Server.
+    authentication flow will be used.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-azure_resource_group.md
+++ b/doc/barman.5.d/50-azure_resource_group.md
@@ -1,5 +1,7 @@
 azure_resource_group
 :   The name of the Azure resource group to which the compute instance and
     disks defined by `snapshot_instance` and `snapshot_disks` belong.
-    Global/Server. Required when the `snapshot` value is specified for
-    `backup_method` and `snapshot_provider` is set to `azure`.
+    Required when the `snapshot` value is specified for `backup_method` and
+    `snapshot_provider` is set to `azure`.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-azure_subscription_id.md
+++ b/doc/barman.5.d/50-azure_subscription_id.md
@@ -1,5 +1,7 @@
 azure_subscription_id
 :   The ID of the Azure subscription which owns the instance and storage
-    volumes defined by `snapshot_instance` and `snapshot_disks`. Global/Server.
-    Required when the `snapshot` value is specified for `backup_method`
-    and `snapshot_provider` is set to `azure`.
+    volumes defined by `snapshot_instance` and `snapshot_disks`. Required when
+    the `snapshot` value is specified for `backup_method` and
+    `snapshot_provider` is set to `azure`.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-backup_compression.md
+++ b/doc/barman.5.d/50-backup_compression.md
@@ -1,8 +1,11 @@
 backup_compression
 :   The compression to be used during the backup process. Only supported when
-    `backup_method = postgres`. Can either be unset or `gzip`,`lz4`, `zstd` or `none`. If unset then
-    no compression will be used during the backup. Use of this option requires that the
-    CLI application for the specified compression algorithm is available on the Barman
-    server (at backup time) and the PostgreSQL server (at recovery time). Note that
-    the `lz4` and `zstd` algorithms require PostgreSQL 15 (beta) or later. Global/Server.
-    Note that `none` compression will create an archive not compressed.
+    `backup_method = postgres`. Can either be unset or `gzip`,`lz4`, `zstd` or
+    `none`. If unset then no compression will be used during the backup. Use of
+    this option requires that the CLI application for the specified compression
+    algorithm is available on the Barman server (at backup time) and the
+    PostgreSQL server (at recovery time). Note that the `lz4` and `zstd`
+    algorithms require PostgreSQL 15 (beta) or later. Note that `none`
+    compression will create an archive not compressed.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-backup_compression_format.md
+++ b/doc/barman.5.d/50-backup_compression_format.md
@@ -3,4 +3,6 @@ backup_compression_format
     disk. Can be set to either `plain` or `tar`. If unset then a default of
     `tar` is assumed. The value `plain` can only be used if the server is
     running PostgreSQL 15 or later *and* if `backup_compression_location` is
-    `server`. Only supported when `backup_method = postgres`. Global/Server.
+    `server`. Only supported when `backup_method = postgres`.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-backup_compression_level.md
+++ b/doc/barman.5.d/50-backup_compression_level.md
@@ -2,4 +2,5 @@ backup_compression_level
 :   An integer value representing the compression level to use when compressing
     backups. Allowed values depend on the compression algorithm specified by
     `backup_compression`. Only supported when `backup_method = postgres`.
-    Global/Server.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-backup_compression_location.md
+++ b/doc/barman.5.d/50-backup_compression_location.md
@@ -1,4 +1,6 @@
 backup_compression_location
 :   The location (either `client` or `server`) where compression should be
     performed during the backup. The value `server` is only allowed if the
-    server is running PostgreSQL 15 or later. Global/Server.
+    server is running PostgreSQL 15 or later.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-backup_compression_workers.md
+++ b/doc/barman.5.d/50-backup_compression_workers.md
@@ -1,4 +1,6 @@
 backup_compression_workers
-:   The number of compression threads to be used during the backup process. Only supported when
-    `backup_compression = zstd` is set. Default value is 0. In this case default compression 
-    behavior will be used.
+:   The number of compression threads to be used during the backup process. Only
+    supported when `backup_compression = zstd` is set. Default value is 0. In
+    this case default compression behavior will be used.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-backup_directory.md
+++ b/doc/barman.5.d/50-backup_directory.md
@@ -1,2 +1,4 @@
 backup_directory
-:   Directory where backup data for a server will be placed. Server.
+:   Directory where backup data for a server will be placed.
+
+    Scope: Server.

--- a/doc/barman.5.d/50-backup_method.md
+++ b/doc/barman.5.d/50-backup_method.md
@@ -2,12 +2,14 @@ backup_method
 :   Configure the method barman used for backup execution.
     If set to `rsync` (default), barman will execute backup using the `rsync`
     command over SSH (requires `ssh_command`).
-    If set to `postgres` barman will use the `pg_basebackup` command to execute the backup.
+    If set to `postgres` barman will use the `pg_basebackup` command to execute
+    the backup.
     If set to `local-rsync`, barman will assume to be running on the same server
-    as the PostgreSQL instance and with the same user, then execute `rsync` for the
-    file system copy.
-    If set to `snapshot`, barman will use the API for the cloud provider defined in
-    the `snapshot_provider` option to create snapshots of disks specified in the
-    `snapshot_disks` option and save only the backup label and metadata to its own
-    storage.
-    Global/Server.
+    as the PostgreSQL instance and with the same user, then execute `rsync` for
+    the file system copy.
+    If set to `snapshot`, barman will use the API for the cloud provider defined
+    in the `snapshot_provider` option to create snapshots of disks specified in
+    the `snapshot_disks` option and save only the backup label and metadata to
+    its own storage.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-backup_options.md
+++ b/doc/barman.5.d/50-backup_options.md
@@ -17,4 +17,6 @@ backup_options
       of a backup.
 
     Note that `exclusive_backup` and `concurrent_backup` are mutually
-    exclusive. Global/Server.
+    exclusive.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-bandwidth_limit.md
+++ b/doc/barman.5.d/50-bandwidth_limit.md
@@ -1,4 +1,5 @@
 bandwidth_limit
 :   This  option  allows  you  to specify a maximum transfer rate in
     kilobytes per second. A value of zero specifies no limit (default).
-    Global/Server.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-barman_home.md
+++ b/doc/barman.5.d/50-barman_home.md
@@ -1,2 +1,4 @@
 barman_home
-:   Main data directory for Barman. Global.
+:   Main data directory for Barman.
+
+    Scope: Global.

--- a/doc/barman.5.d/50-barman_lock_directory.md
+++ b/doc/barman.5.d/50-barman_lock_directory.md
@@ -1,2 +1,4 @@
 barman_lock_directory
-:   Directory for locks. Default: `%(barman_home)s`. Global.
+:   Directory for locks. Default: `%(barman_home)s`.
+
+    Scope: Global.

--- a/doc/barman.5.d/50-basebackup_retry_sleep.md
+++ b/doc/barman.5.d/50-basebackup_retry_sleep.md
@@ -1,4 +1,6 @@
 basebackup_retry_sleep
 :   Number of seconds of wait after a failed copy, before retrying
     Used during both backup and recovery operations.
-    Positive integer, default 30. Global/Server.
+    Positive integer, default 30.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-basebackup_retry_times.md
+++ b/doc/barman.5.d/50-basebackup_retry_times.md
@@ -1,4 +1,6 @@
 basebackup_retry_times
 :   Number of retries of base backup copy, after an error.
     Used during both backup and recovery operations.
-    Positive integer, default 0. Global/Server.
+    Positive integer, default 0.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-basebackups_directory.md
+++ b/doc/barman.5.d/50-basebackups_directory.md
@@ -1,2 +1,4 @@
 basebackups_directory
-:   Directory where base backups will be placed. Server.
+:   Directory where base backups will be placed.
+
+    Scope: Server.

--- a/doc/barman.5.d/50-check_timeout.md
+++ b/doc/barman.5.d/50-check_timeout.md
@@ -1,4 +1,6 @@
 check_timeout
 :   Maximum execution time, in seconds per server, for a barman check
     command. Set to 0 to disable the timeout.
-    Positive integer, default 30. Global/Server.
+    Positive integer, default 30.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-cluster.md
+++ b/doc/barman.5.d/50-cluster.md
@@ -3,4 +3,6 @@ cluster
     by Barman to group servers and configuration models that can be applied to
     them. Can be omitted for servers, in which case it defaults to the server
     name. Must be set for configuration models, so Barman knows the set of
-    servers which can apply a given model. Server/Model.
+    servers which can apply a given model.
+
+    Scope: Server/Model.

--- a/doc/barman.5.d/50-cluster.md
+++ b/doc/barman.5.d/50-cluster.md
@@ -1,0 +1,6 @@
+cluster
+:   Name of the Barman cluster which a Barman server or model relates to. Used
+    by Barman to group servers and configuration models that can be applied to
+    them. Can be omitted for servers, in which case it defaults to the server
+    name. Must be set for configuration models, so Barman knows the set of
+    servers which can apply a given model. Server/Model.

--- a/doc/barman.5.d/50-cluster.md
+++ b/doc/barman.5.d/50-cluster.md
@@ -1,5 +1,5 @@
 cluster
-:   Name of the Barman cluster which a Barman server or model relates to. Used
+:   Name of the Barman cluster associated with a Barman server or model. Used
     by Barman to group servers and configuration models that can be applied to
     them. Can be omitted for servers, in which case it defaults to the server
     name. Must be set for configuration models, so Barman knows the set of

--- a/doc/barman.5.d/50-compression.md
+++ b/doc/barman.5.d/50-compression.md
@@ -3,4 +3,6 @@ compression
     are: `gzip` (requires `gzip` to be installed on the system),
     `bzip2` (requires `bzip2`), `pigz` (requires `pigz`), `pygzip`
     (Python's internal gzip compressor) and `pybzip2` (Python's internal
-    bzip2 compressor). Global/Server.
+    bzip2 compressor).
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-conninfo.md
+++ b/doc/barman.5.d/50-conninfo.md
@@ -2,6 +2,8 @@ conninfo
 :   Connection string used by Barman to connect to the Postgres server.
     This is a libpq connection string, consult the
     [PostgreSQL manual][conninfo] for more information. Commonly used
-    keys are: host, hostaddr, port, dbname, user, password. Server/Model.
+    keys are: host, hostaddr, port, dbname, user, password.
+
+    Scope: Server/Model.
 
 [conninfo]: https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING

--- a/doc/barman.5.d/50-conninfo.md
+++ b/doc/barman.5.d/50-conninfo.md
@@ -2,6 +2,6 @@ conninfo
 :   Connection string used by Barman to connect to the Postgres server.
     This is a libpq connection string, consult the
     [PostgreSQL manual][conninfo] for more information. Commonly used
-    keys are: host, hostaddr, port, dbname, user, password. Server.
+    keys are: host, hostaddr, port, dbname, user, password. Server/Model.
 
 [conninfo]: https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING

--- a/doc/barman.5.d/50-create_slot.md
+++ b/doc/barman.5.d/50-create_slot.md
@@ -2,4 +2,6 @@ create_slot
 :   When set to `auto` and `slot_name` is defined, Barman automatically
     attempts to create the replication slot if not present.
     When set to `manual` (default), the replication slot needs to be
-    manually created. Global/Server.
+    manually created.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-custom_compression_filter.md
+++ b/doc/barman.5.d/50-custom_compression_filter.md
@@ -1,2 +1,4 @@
 custom_compression_filter
-:   Customised compression algorithm applied to WAL files. Global/Server.
+:   Customised compression algorithm applied to WAL files.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-custom_compression_magic.md
+++ b/doc/barman.5.d/50-custom_compression_magic.md
@@ -5,4 +5,6 @@ custom_compression_magic
     applying the custom compression to WALs which have been
     pre-compressed with that compression. If you do not configure this
     then custom compression will still be applied but any pre-compressed
-    WAL files will be compressed again during WAL archive. Global/Server.
+    WAL files will be compressed again during WAL archive.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-custom_decompression_filter.md
+++ b/doc/barman.5.d/50-custom_decompression_filter.md
@@ -1,3 +1,5 @@
 custom_decompression_filter
 :   Customised decompression algorithm applied to compressed WAL files;
-    this must match the compression algorithm. Global/Server.
+    this must match the compression algorithm.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-description.md
+++ b/doc/barman.5.d/50-description.md
@@ -1,2 +1,4 @@
 description
-:   A human readable description of a server. Server.
+:   A human readable description of a server.
+
+    Scope: Server/Model.

--- a/doc/barman.5.d/50-errors_directory.md
+++ b/doc/barman.5.d/50-errors_directory.md
@@ -2,3 +2,5 @@ errors_directory
 :   Directory that contains WAL files that contain an error; usually
     this is related to a conflict with an existing WAL file (e.g. a WAL
     file that has been archived after a streamed one).
+
+    Scope: Server.

--- a/doc/barman.5.d/50-forward-config-path.md
+++ b/doc/barman.5.d/50-forward-config-path.md
@@ -4,3 +4,5 @@ forward_config_path
     commands. Set to true if you are invoking barman with the `-c/--config`
     option and your configuration is in the same place on both the passive
     and primary barman servers. Defaults to false.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-gcp-project.md
+++ b/doc/barman.5.d/50-gcp-project.md
@@ -1,5 +1,7 @@
 gcp_project
 :   The ID of the GCP project which owns the instance and storage volumes
-    defined by `snapshot_instance` and `snapshot_disks`. Global/Server.
+    defined by `snapshot_instance` and `snapshot_disks`.
     Required when the `snapshot` value is specified for `backup_method`
     and `snapshot_provider` is set to `gcp`.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-gcp-zone.md
+++ b/doc/barman.5.d/50-gcp-zone.md
@@ -1,5 +1,7 @@
 gcp_zone
 :   The name of the availability zone where the compute instance and disks
-    to be backed up in a snapshot backup are located. Server. Required when
+    to be backed up in a snapshot backup are located. Required when
     the `snapshot` value is specified for `backup_method` and
     `snapshot_provider` is set to `gcp`.
+
+    Scope: Server/Model.

--- a/doc/barman.5.d/50-immediate_checkpoint.md
+++ b/doc/barman.5.d/50-immediate_checkpoint.md
@@ -5,4 +5,6 @@ immediate_checkpoint
     will be limited, according to the `checkpoint_completion_target`
     setting on the PostgreSQL server. If set to `true`, an immediate
     checkpoint will be requested, meaning that PostgreSQL will complete
-    the checkpoint as soon as possible. Global/Server.
+    the checkpoint as soon as possible.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-incoming_wals_directory.md
+++ b/doc/barman.5.d/50-incoming_wals_directory.md
@@ -1,3 +1,5 @@
 incoming_wals_directory
 :   Directory where incoming WAL files are archived into.
-    Requires `archiver` to be enabled. Server.
+    Requires `archiver` to be enabled.
+
+    Scope: Server.

--- a/doc/barman.5.d/50-last_backup_maximum_age.md
+++ b/doc/barman.5.d/50-last_backup_maximum_age.md
@@ -5,4 +5,6 @@ last_backup_maximum_age
     If empty (default), latest backup is always considered valid.
     Syntax for this option is: "i (DAYS | WEEKS | MONTHS)" where i is an integer
     greater than zero, representing the number of days | weeks | months
-    of the time frame. Global/Server.
+    of the time frame.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-last_backup_minimum_size.md
+++ b/doc/barman.5.d/50-last_backup_minimum_size.md
@@ -1,9 +1,12 @@
 last_backup_minimum_size
-:   This option identifies lower limit to the acceptable size of the latest successful backup.
-    If the latest backup is smaller than the specified size, barman check command will
-    report an error to the user.
+:   This option identifies lower limit to the acceptable size of the latest
+    successful backup.
+    If the latest backup is smaller than the specified size, barman check
+    command will report an error to the user.
     If empty (default), latest backup is always considered valid.
     Syntax for this option is: "i (k|Ki|M|Mi|G|Gi|T|Ti)" where i is an integer
-    greater than zero, with an optional SI or IEC suffix. k=kilo=1000, Ki=Kibi=1024 and so forth.
+    greater than zero, with an optional SI or IEC suffix. k=kilo=1000,
+    Ki=Kibi=1024 and so forth.
     Note that the suffix is case-sensitive.
-    Global/Server.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-last_wal_maximum_age.md
+++ b/doc/barman.5.d/50-last_wal_maximum_age.md
@@ -1,7 +1,9 @@
 last_wal_maximum_age
-:   This option identifies a time frame that must contain the latest WAL file archived.
+:   This option identifies a time frame that must contain the latest WAL file
+    archived.
     If the latest WAL file is older than the time frame, barman check command
     will report an error to the user.
     If empty (default), the age of the WAL files is not checked.
     Syntax is the same as last_backup_maximum_age (above).
-    Global/Server.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-lock_directory_cleanup.md
+++ b/doc/barman.5.d/50-lock_directory_cleanup.md
@@ -1,2 +1,5 @@
 lock_directory_cleanup
-:   enables automatic cleaning up of the `barman_lock_directory` from unused lock files.
+:   enables automatic cleaning up of the `barman_lock_directory` from unused
+    lock files.
+
+    Scope: Global.

--- a/doc/barman.5.d/50-log_file.md
+++ b/doc/barman.5.d/50-log_file.md
@@ -1,2 +1,4 @@
 log_file
-:   Location of Barman's log file. Global.
+:   Location of Barman's log file.
+
+    Scope: Global.

--- a/doc/barman.5.d/50-log_level.md
+++ b/doc/barman.5.d/50-log_level.md
@@ -1,2 +1,4 @@
 log_level
-:   Level of logging (DEBUG, INFO, WARNING, ERROR, CRITICAL). Global.
+:   Level of logging (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+
+    Scope: Global.

--- a/doc/barman.5.d/50-max_incoming_wals_queue.md
+++ b/doc/barman.5.d/50-max_incoming_wals_queue.md
@@ -1,4 +1,6 @@
 max_incoming_wals_queue
 :   Maximum number of WAL files in the incoming queue (in both streaming and
     archiving pools) that are allowed before barman check returns an error
-    (that does not block backups). Global/Server. Default: None (disabled).
+    (that does not block backups). Default: None (disabled).
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-minimum_redundancy.md
+++ b/doc/barman.5.d/50-minimum_redundancy.md
@@ -1,2 +1,4 @@
 minimum_redundancy
-:   Minimum number of backups to be retained. Default 0. Global/Server.
+:   Minimum number of backups to be retained. Default 0.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-model.md
+++ b/doc/barman.5.d/50-model.md
@@ -2,4 +2,6 @@ model
 :   By default any section configured in the Barman configuration files define
     the configuration for a Barman server. If you set `model = true` in a
     section, that turns that section into a configuration model for a given
-    `cluster`. Cannot be set as `false`. Model.
+    `cluster`. Cannot be set as `false`.
+
+    Scope: Model.

--- a/doc/barman.5.d/50-model.md
+++ b/doc/barman.5.d/50-model.md
@@ -1,0 +1,5 @@
+model
+:   By default any section configured in the Barman configuration files define
+    the configuration for a Barman server. If you set `model = true` in a
+    section, that turns that section into a configuration model for a given
+    `cluster`. Cannot be set as `false`. Model.

--- a/doc/barman.5.d/50-network_compression.md
+++ b/doc/barman.5.d/50-network_compression.md
@@ -3,4 +3,5 @@ network_compression
     transfers.
     If set to `false` (default), no compression is used.
     If set to `true`, compression is enabled, reducing network usage.
-    Global/Server.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-parallel_jobs.md
+++ b/doc/barman.5.d/50-parallel_jobs.md
@@ -1,4 +1,6 @@
 parallel_jobs
 :   This option controls how many parallel workers will copy files during a
-    backup or recovery command. Default 1. Global/Server. For backup purposes,
-    it works only when `backup_method` is `rsync`.
+    backup or recovery command. Default 1. For backup purposes, it works only
+    when `backup_method` is `rsync`.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-parallel_jobs_start_batch_period.md
+++ b/doc/barman.5.d/50-parallel_jobs_start_batch_period.md
@@ -1,3 +1,5 @@
 parallel_jobs_start_batch_period
 :   The time period in seconds over which a single batch of jobs will be
     started. Default: 1 second.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-parallel_jobs_start_batch_size.md
+++ b/doc/barman.5.d/50-parallel_jobs_start_batch_size.md
@@ -1,3 +1,5 @@
 parallel_jobs_start_batch_size
 :   Maximum number of parallel jobs to start in a single batch. Default:
     10 jobs.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-path_prefix.md
+++ b/doc/barman.5.d/50-path_prefix.md
@@ -1,4 +1,6 @@
 path_prefix
 :   One or more absolute paths, separated by colon, where Barman looks for
     executable files. The paths specified in `path_prefix` are tried before
-    the ones specified in `PATH` environment variable. Global/server.
+    the ones specified in `PATH` environment variable.
+
+    Scope: Global/server/Model.

--- a/doc/barman.5.d/50-post_archive_retry_script.md
+++ b/doc/barman.5.d/50-post_archive_retry_script.md
@@ -3,4 +3,6 @@ post_archive_retry_script
     Being this a _retry_ hook script, Barman will retry the execution of the
     script until this either returns a SUCCESS (0), an ABORT_CONTINUE (62) or
     an ABORT_STOP (63) code. In a post archive scenario, ABORT_STOP
-    has currently the same effects as ABORT_CONTINUE. Global/Server.
+    has currently the same effects as ABORT_CONTINUE.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-post_archive_script.md
+++ b/doc/barman.5.d/50-post_archive_script.md
@@ -1,3 +1,5 @@
 post_archive_script
 :   Hook script launched after a WAL file is archived by maintenance,
-    after 'post_archive_retry_script'. Global/Server.
+    after 'post_archive_retry_script'.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-post_backup_retry_script.md
+++ b/doc/barman.5.d/50-post_backup_retry_script.md
@@ -3,4 +3,6 @@ post_backup_retry_script
     Being this a _retry_ hook script, Barman will retry the execution of the
     script until this either returns a SUCCESS (0), an ABORT_CONTINUE (62) or
     an ABORT_STOP (63) code. In a post backup scenario, ABORT_STOP
-    has currently the same effects as ABORT_CONTINUE. Global/Server.
+    has currently the same effects as ABORT_CONTINUE.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-post_backup_script.md
+++ b/doc/barman.5.d/50-post_backup_script.md
@@ -1,3 +1,4 @@
 post_backup_script
 :   Hook script launched after a base backup, after 'post_backup_retry_script'.
-    Global/Server.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-post_delete_retry_script.md
+++ b/doc/barman.5.d/50-post_delete_retry_script.md
@@ -3,4 +3,6 @@ post_delete_retry_script
     Being this a _retry_ hook script, Barman will retry the execution of the
     script until this either returns a SUCCESS (0), an ABORT_CONTINUE (62) or
     an ABORT_STOP (63) code. In a post delete scenario, ABORT_STOP
-    has currently the same effects as ABORT_CONTINUE. Global/Server.
+    has currently the same effects as ABORT_CONTINUE.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-post_delete_script.md
+++ b/doc/barman.5.d/50-post_delete_script.md
@@ -1,3 +1,5 @@
 post_delete_script
-:   Hook script launched after the deletion of a backup, after 'post_delete_retry_script'.
-    Global/Server.
+:   Hook script launched after the deletion of a backup, after
+    'post_delete_retry_script'.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-post_recovery_retry_script.md
+++ b/doc/barman.5.d/50-post_recovery_retry_script.md
@@ -3,4 +3,6 @@ post_recovery_retry_script
     Being this a _retry_ hook script, Barman will retry the execution of the
     script until this either returns a SUCCESS (0), an ABORT_CONTINUE (62) or
     an ABORT_STOP (63) code. In a post recovery scenario, ABORT_STOP
-    has currently the same effects as ABORT_CONTINUE. Global/Server.
+    has currently the same effects as ABORT_CONTINUE.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-post_recovery_script.md
+++ b/doc/barman.5.d/50-post_recovery_script.md
@@ -1,3 +1,4 @@
 post_recovery_script
 :   Hook script launched after a recovery, after 'post_recovery_retry_script'.
-    Global/Server.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-post_wal_delete_retry_script.md
+++ b/doc/barman.5.d/50-post_wal_delete_retry_script.md
@@ -3,4 +3,6 @@ post_wal_delete_retry_script
     Being this a _retry_ hook script, Barman will retry the execution of the
     script until this either returns a SUCCESS (0), an ABORT_CONTINUE (62) or
     an ABORT_STOP (63) code. In a post delete scenario, ABORT_STOP
-    has currently the same effects as ABORT_CONTINUE. Global/Server.
+    has currently the same effects as ABORT_CONTINUE.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-post_wal_delete_script.md
+++ b/doc/barman.5.d/50-post_wal_delete_script.md
@@ -1,3 +1,5 @@
 post_wal_delete_script
-:   Hook script launched after the deletion of a WAL file, after 'post_wal_delete_retry_script'.
-    Global/Server.
+:   Hook script launched after the deletion of a WAL file, after
+    'post_wal_delete_retry_script'.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-pre_archive_retry_script.md
+++ b/doc/barman.5.d/50-pre_archive_retry_script.md
@@ -4,4 +4,6 @@ pre_archive_retry_script
     Being this a _retry_ hook script, Barman will retry the execution of the
     script until this either returns a SUCCESS (0), an ABORT_CONTINUE (62) or
     an ABORT_STOP (63) code. Returning ABORT_STOP will propagate the failure at
-    a higher level and interrupt the WAL archiving operation. Global/Server.
+    a higher level and interrupt the WAL archiving operation.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-pre_archive_script.md
+++ b/doc/barman.5.d/50-pre_archive_script.md
@@ -1,3 +1,4 @@
 pre_archive_script
 :   Hook script launched before a WAL file is archived by maintenance.
-    Global/Server.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-pre_backup_retry_script.md
+++ b/doc/barman.5.d/50-pre_backup_retry_script.md
@@ -3,4 +3,6 @@ pre_backup_retry_script
     Being this a _retry_ hook script, Barman will retry the execution of the
     script until this either returns a SUCCESS (0), an ABORT_CONTINUE (62) or
     an ABORT_STOP (63) code. Returning ABORT_STOP will propagate the failure at
-    a higher level and interrupt the backup operation. Global/Server.
+    a higher level and interrupt the backup operation.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-pre_backup_script.md
+++ b/doc/barman.5.d/50-pre_backup_script.md
@@ -1,2 +1,4 @@
 pre_backup_script
-:   Hook script launched before a base backup. Global/Server.
+:   Hook script launched before a base backup.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-pre_delete_retry_script.md
+++ b/doc/barman.5.d/50-pre_delete_retry_script.md
@@ -1,6 +1,8 @@
 pre_delete_retry_script
-:   Hook script launched before the deletion of a backup, after 'pre_delete_script'.
-    Being this a _retry_ hook script, Barman will retry the execution of the
-    script until this either returns a SUCCESS (0), an ABORT_CONTINUE (62) or
-    an ABORT_STOP (63) code. Returning ABORT_STOP will propagate the failure at
-    a higher level and interrupt the backup deletion. Global/Server.
+:   Hook script launched before the deletion of a backup, after
+    'pre_delete_script'. Being this a _retry_ hook script, Barman will retry
+    the execution of the script until this either returns a SUCCESS (0), an
+    ABORT_CONTINUE (62) or an ABORT_STOP (63) code. Returning ABORT_STOP will
+    propagate the failure at a higher level and interrupt the backup deletion.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-pre_delete_script.md
+++ b/doc/barman.5.d/50-pre_delete_script.md
@@ -1,2 +1,4 @@
 pre_delete_script
-:   Hook script launched before the deletion of a backup. Global/Server.
+:   Hook script launched before the deletion of a backup.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-pre_recovery_retry_script.md
+++ b/doc/barman.5.d/50-pre_recovery_retry_script.md
@@ -3,4 +3,6 @@ pre_recovery_retry_script
     Being this a _retry_ hook script, Barman will retry the execution of the
     script until this either returns a SUCCESS (0), an ABORT_CONTINUE (62) or
     an ABORT_STOP (63) code. Returning ABORT_STOP will propagate the failure at
-    a higher level and interrupt the recover operation. Global/Server.
+    a higher level and interrupt the recover operation.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-pre_recovery_script.md
+++ b/doc/barman.5.d/50-pre_recovery_script.md
@@ -1,2 +1,4 @@
 pre_recovery_script
-:   Hook script launched before a recovery. Global/Server.
+:   Hook script launched before a recovery.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-pre_wal_delete_retry_script.md
+++ b/doc/barman.5.d/50-pre_wal_delete_retry_script.md
@@ -1,6 +1,9 @@
 pre_wal_delete_retry_script
-:   Hook script launched before the deletion of a WAL file, after 'pre_wal_delete_script'.
+:   Hook script launched before the deletion of a WAL file, after
+    'pre_wal_delete_script'.
     Being this a _retry_ hook script, Barman will retry the execution of the
     script until this either returns a SUCCESS (0), an ABORT_CONTINUE (62) or
     an ABORT_STOP (63) code. Returning ABORT_STOP will propagate the failure at
-    a higher level and interrupt the WAL file deletion. Global/Server.
+    a higher level and interrupt the WAL file deletion.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-pre_wal_delete_script.md
+++ b/doc/barman.5.d/50-pre_wal_delete_script.md
@@ -1,2 +1,4 @@
 pre_wal_delete_script
-:   Hook script launched before the deletion of a WAL file. Global/Server.
+:   Hook script launched before the deletion of a WAL file.
+
+    Scope: Global/Server.

--- a/doc/barman.5.d/50-primary_checkpoint_timeout.md
+++ b/doc/barman.5.d/50-primary_checkpoint_timeout.md
@@ -11,3 +11,5 @@ primary_checkpoint_timeout
 
     This option works only if `primary_conninfo` option is set, and it is
     ignored otherwise.
+
+    Scope: Server/Model.

--- a/doc/barman.5.d/50-primary_conninfo.md
+++ b/doc/barman.5.d/50-primary_conninfo.md
@@ -13,6 +13,8 @@ primary_conninfo
 
     The primary_conninfo value must be a libpq connection string; consult the
     [PostgreSQL manual][conninfo] for more information. Commonly used
-    keys are: host, hostaddr, port, dbname, user, password. Server/Model.
+    keys are: host, hostaddr, port, dbname, user, password.
+
+    Scope: Server/Model.
 
 [conninfo]: https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING

--- a/doc/barman.5.d/50-primary_conninfo.md
+++ b/doc/barman.5.d/50-primary_conninfo.md
@@ -13,6 +13,6 @@ primary_conninfo
 
     The primary_conninfo value must be a libpq connection string; consult the
     [PostgreSQL manual][conninfo] for more information. Commonly used
-    keys are: host, hostaddr, port, dbname, user, password. Server.
+    keys are: host, hostaddr, port, dbname, user, password. Server/Model.
 
 [conninfo]: https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING

--- a/doc/barman.5.d/50-primary_ssh_command.md
+++ b/doc/barman.5.d/50-primary_ssh_command.md
@@ -5,3 +5,5 @@ primary_ssh_command
     If `primary_ssh_command` is specified, Barman uses it to establish a
     connection with the primary server.
     Empty by default, it can also be set globally.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-recovery_options.md
+++ b/doc/barman.5.d/50-recovery_options.md
@@ -3,4 +3,6 @@ recovery_options
     `get-wal` activates generation of a basic `restore_command` in
     the resulting recovery configuration that uses the `barman get-wal`
     command to fetch WAL files directly from Barman's archive of WALs.
-    Comma separated list of values, default empty. Global/Server.
+    Comma separated list of values, default empty.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-recovery_staging_path.md
+++ b/doc/barman.5.d/50-recovery_staging_path.md
@@ -7,4 +7,6 @@ recovery_staging_path
     "barman-staging-SERVER_NAME-BACKUP_ID". The staging directory within
     the staging path will be removed at the end of the recovery process.
     This option is *required* when recovering from compressed backups and
-    has no effect otherwise. Global/Server.
+    has no effect otherwise.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-retention_policy.md
+++ b/doc/barman.5.d/50-retention_policy.md
@@ -7,4 +7,6 @@ retention_policy
     "RECOVERY WINDOW OF i MONTHS" where i is a positive integer representing,
     specifically, the number of days, weeks or months to retain your backups.
     For more detailed information, refer to the official documentation.
-    Default value is empty. Global/Server.
+    Default value is empty.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-retention_policy_mode.md
+++ b/doc/barman.5.d/50-retention_policy_mode.md
@@ -1,2 +1,4 @@
 retention_policy_mode
-:   Currently only "auto" is implemented. Global/Server.
+:   Currently only "auto" is implemented.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-reuse_backup.md
+++ b/doc/barman.5.d/50-reuse_backup.md
@@ -1,5 +1,5 @@
 reuse_backup
-:   This option controls incremental backup support. Global/Server.
+:   This option controls incremental backup support.
     Possible values are:
 
     * `off`: disabled (default);
@@ -9,3 +9,5 @@ reuse_backup
       create a hard link of the unchanged files (reduce backup time
       and space). Requires operating system and file system support
       for hard links.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-slot_name.md
+++ b/doc/barman.5.d/50-slot_name.md
@@ -1,4 +1,6 @@
 slot_name
 :   Physical replication slot to be used by the `receive-wal`
     command when `streaming_archiver` is set to `on`.
-    Default: None (disabled). Global/Server.
+    Default: None (disabled).
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-snapshot-disks.md
+++ b/doc/barman.5.d/50-snapshot-disks.md
@@ -1,4 +1,6 @@
 snapshot_disks
 :   A comma-separated list of disks which should be included in a backup
-    taken using cloud snapshots. Server. Required when the `snapshot` value
+    taken using cloud snapshots. Required when the `snapshot` value
     is specified for `backup_method`.
+
+    Scope: Server/Model.

--- a/doc/barman.5.d/50-snapshot-instance.md
+++ b/doc/barman.5.d/50-snapshot-instance.md
@@ -1,4 +1,6 @@
 snapshot_instance
 :   The name of the VM or compute instance where the storage volumes are
-    attached. Server. Required when the `snapshot` value is specified for
+    attached. Required when the `snapshot` value is specified for
     `backup_method`.
+
+    Scope: Server/Model.

--- a/doc/barman.5.d/50-snapshot-provider.md
+++ b/doc/barman.5.d/50-snapshot-provider.md
@@ -1,4 +1,6 @@
 snapshot_provider
 :   The name of the cloud provider which should be used to create snapshots.
-    Global/Server. Required when the `snapshot` value is specified for
+    Required when the `snapshot` value is specified for
     `backup_method`. Supported values: `gcp`.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-ssh_command.md
+++ b/doc/barman.5.d/50-ssh_command.md
@@ -1,2 +1,4 @@
 ssh_command
-:   Command used by Barman to login to the Postgres server via ssh. Server.
+:   Command used by Barman to login to the Postgres server via ssh.
+
+    Scope: Server/Model.

--- a/doc/barman.5.d/50-streaming_archiver.md
+++ b/doc/barman.5.d/50-streaming_archiver.md
@@ -12,4 +12,5 @@ streaming_archiver
     `true`. This is in order to maintain parity with deprecated behaviour
     where `archiver` would be enabled by default. This behaviour will be
     removed from the next major Barman version.
-    Global/Server.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-streaming_archiver_batch_size.md
+++ b/doc/barman.5.d/50-streaming_archiver_batch_size.md
@@ -4,4 +4,6 @@ streaming_archiver_batch_size
     Otherwise, the traditional unlimited processing of the WAL queue
     is enabled. When batch processing is activated, the `archive-wal`
     process would limit itself to maximum `streaming_archiver_batch_size`
-    WAL segments per single run. Integer. Global/Server.
+    WAL segments per single run. Integer.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-streaming_archiver_name.md
+++ b/doc/barman.5.d/50-streaming_archiver_name.md
@@ -1,4 +1,6 @@
 streaming_archiver_name
 :   Identifier to be used as `application_name` by the `receive-wal` command.
     Only available with `pg_receivewal` (or `pg_receivexlog` >= 9.3).
-    By default it is set to `barman_receive_wal`. Global/Server.
+    By default it is set to `barman_receive_wal`.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-streaming_backup_name.md
+++ b/doc/barman.5.d/50-streaming_backup_name.md
@@ -1,3 +1,5 @@
 streaming_backup_name
 :   Identifier to be used as `application_name` by the `pg_basebackup` command.
-    By default it is set to `barman_streaming_backup`. Global/Server.
+    By default it is set to `barman_streaming_backup`.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-streaming_conninfo.md
+++ b/doc/barman.5.d/50-streaming_conninfo.md
@@ -1,3 +1,4 @@
 streaming_conninfo
 :   Connection string used by Barman to connect to the Postgres server via
-    streaming replication protocol. By default it is set to `conninfo`. Server.
+    streaming replication protocol. By default it is set to `conninfo`.
+    Server/Model.

--- a/doc/barman.5.d/50-streaming_conninfo.md
+++ b/doc/barman.5.d/50-streaming_conninfo.md
@@ -1,4 +1,5 @@
 streaming_conninfo
 :   Connection string used by Barman to connect to the Postgres server via
     streaming replication protocol. By default it is set to `conninfo`.
-    Server/Model.
+
+    Scope: Server/Model.

--- a/doc/barman.5.d/50-streaming_wals_directory.md
+++ b/doc/barman.5.d/50-streaming_wals_directory.md
@@ -1,3 +1,5 @@
 streaming_wals_directory
 :   Directory where WAL files are streamed from the PostgreSQL server
-    to Barman. Requires `streaming_archiver` to be enabled. Server.
+    to Barman. Requires `streaming_archiver` to be enabled.
+
+    Scope: Server.

--- a/doc/barman.5.d/50-tablespace_bandwidth_limit.md
+++ b/doc/barman.5.d/50-tablespace_bandwidth_limit.md
@@ -2,4 +2,6 @@ tablespace_bandwidth_limit
 :   This  option  allows  you  to specify a maximum transfer rate in
     kilobytes per second, by specifying a comma separated list of
     tablespaces (pairs TBNAME:BWLIMIT). A value of zero specifies no limit
-    (default). Global/Server.
+    (default).
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-wal_retention_policy.md
+++ b/doc/barman.5.d/50-wal_retention_policy.md
@@ -1,3 +1,5 @@
 wal_retention_policy
 :   Policy for retention of archive logs (WAL files). Currently only "MAIN"
-    is available. Global/Server.
+    is available.
+
+    Scope: Global/Server/Model.

--- a/doc/barman.5.d/50-wals_directory.md
+++ b/doc/barman.5.d/50-wals_directory.md
@@ -1,2 +1,4 @@
 wals_directory
-:   Directory which contains WAL files. Server.
+:   Directory which contains WAL files.
+
+    Scope: Server.

--- a/doc/manual/17-configuration.en.md
+++ b/doc/manual/17-configuration.en.md
@@ -2,7 +2,7 @@
 
 # Configuration
 
-There are two types of configuration files in Barman:
+There are three types of configuration files in Barman:
 
 - **global/general configuration**
 - **server configuration**
@@ -14,7 +14,7 @@ Server configuration files, one for each server to be backed up by Barman, are l
 
 Similarly, model configuration files are located in the `/etc/barman.d` directory and must have a `.conf` suffix.
 
-> *NOTE*: models define a set of configuration overrides which can be applied on top of the configuration of Barman servers that are part of the same cluster as the model, through the `barman config-switch` command.
+> *NOTE*: models define a set of configuration overrides which can be applied on top of the configuration of Barman servers that are part of the same cluster as the model, through the [barman config-switch](#config-switch) command.
 
 > **IMPORTANT**: For historical reasons, you can still have one single
 > configuration file containing both global as well as server and model options.

--- a/doc/manual/17-configuration.en.md
+++ b/doc/manual/17-configuration.en.md
@@ -12,7 +12,7 @@ The main configuration file (set to `/etc/barman.conf` by default) contains gene
 
 Server configuration files, one for each server to be backed up by Barman, are located in the `/etc/barman.d` directory and must have a `.conf` suffix.
 
-Similarly, model configuration files, one for each model that can be applied to a server which is part of a cluster, are located in the `/etc/barman.d` directory and must have a `.conf` suffix.
+Similarly, model configuration files are located in the `/etc/barman.d` directory and must have a `.conf` suffix.
 
 > *NOTE*: models define a set of configuration overrides which can be applied on top of the configuration of Barman servers that are part of the same cluster as the model, through the `barman config-switch` command.
 

--- a/doc/manual/21-preliminary_steps.en.md
+++ b/doc/manual/21-preliminary_steps.en.md
@@ -64,7 +64,7 @@ GRANT pg_checkpoint TO barman;
 > ["The Password File" section in the PostgreSQL Documentation][pgpass].
 
 This connection is required by Barman in order to coordinate its
-activities with the server, as well as for monitoring purposes.
+activities with the server, as well as for monitoring purposes.`
 
 You can choose your favourite client authentication method among those
 offered by PostgreSQL. More information can be found in the

--- a/doc/manual/21-preliminary_steps.en.md
+++ b/doc/manual/21-preliminary_steps.en.md
@@ -64,7 +64,7 @@ GRANT pg_checkpoint TO barman;
 > ["The Password File" section in the PostgreSQL Documentation][pgpass].
 
 This connection is required by Barman in order to coordinate its
-activities with the server, as well as for monitoring purposes.`
+activities with the server, as well as for monitoring purposes.
 
 You can choose your favourite client authentication method among those
 offered by PostgreSQL. More information can be found in the

--- a/doc/manual/42-server-commands.en.md
+++ b/doc/manual/42-server-commands.en.md
@@ -71,8 +71,8 @@ barman check <server_name>
 
 The `config-switch` command is used to apply a set of configuration overrides
 defined through a model to a Barman server. The final configuration of the Barman
-server is composed by the configuration of the server plus the overrides applied
-by the selected model. Models are specially useful for clustered environments,
+server is composed of the configuration of the server plus the overrides applied
+by the selected model. Models are particularly useful for clustered environments,
 so you can create different configuration models which can be used in response to
 failover events, for example.
 

--- a/doc/manual/42-server-commands.en.md
+++ b/doc/manual/42-server-commands.en.md
@@ -67,6 +67,40 @@ barman check <server_name>
 > and monitoring infrastructure. The `--nagios` option allows you
 > to easily create a plugin for Nagios/Icinga.
 
+## `config-switch`
+
+The `config-switch` command is used to apply a set of configuration overrides
+defined through a model to a Barman server. The final configuration of the Barman
+server is composed by the configuration of the server plus the overrides applied
+by the selected model. Models are specially useful for clustered environments,
+so you can create different configuration models which can be used in response to
+failover events, for example.
+
+The syntax for applying a model through `config-switch` command is:
+
+```bash
+barman config-switch <server_name> <model_name>
+```
+
+> *NOTE*: the command will only succeed if `<model_name>` exists and belongs
+> to the same `cluster` as `<server_name>`.
+
+> *NOTE*: there can be at most one model active at a time. If you run the command
+> twice with different models, only the overrides defined for the last one apply.
+
+The syntax for unapplying an existing active model for a server is:
+
+```bash
+barman config-switch <server_name> --reset
+```
+
+It will take care of unapplying the overrides that were previously in place by
+some active model.
+
+> *NOTE*: this command can also be useful for recovering from a specific situation:
+> when you have a server with an active model which was previously configured but
+> which no longer exists in your configuration.
+
 ## `generate-manifest`
 
 This command is useful when backup is created remotely and pg_basebackup is not

--- a/doc/manual/50-feature-details.en.md
+++ b/doc/manual/50-feature-details.en.md
@@ -899,7 +899,7 @@ As an example, let's say you have a PostgreSQL cluster with the following nodes:
 * `pg-node-3`: standby
 
 Assume you are backing up from the primary node, and have a configuration which
-include the following options:
+includes the following options:
 
 ```ini
 [my-barman-server]
@@ -926,7 +926,7 @@ the following command, so you start backing up from the new primary node:
 barman config-switch my-barman-server my-barman-server:backup-from-pg-node-2
 ```
 
-That will basically override the cluster configuration options with the values
+That will override the cluster configuration options with the values
 defined in the selected model.
 
 > *NOTE*: not all options are configurable through models. Please refer to

--- a/doc/manual/50-feature-details.en.md
+++ b/doc/manual/50-feature-details.en.md
@@ -888,7 +888,7 @@ managed server, in particular hot standby servers and WAL streamers.
 
 Configuration models define a set of overrides for configuration options. These
 overrides can be applied to Barman servers which are part of the same cluster as
-the config models. They can be handy to handle clustered environments, so you
+the config models. They can be useful when handling clustered environments, so you
 can change the configuration of a Barman server in response to failover events,
 for example.
 
@@ -915,7 +915,7 @@ You could, for example, have a configuration model for that cluster as follows:
 [my-barman-server:backup-from-pg-node-2]
 cluster = my-cluster
 model = true
-conninfo = host=pg-node-2 user=barman
+conninfo = host=pg-node-2 user=barman database=postgres
 streaming_conninfo = host=pg-node-2 user=streaming_barman
 ```
 

--- a/doc/manual/50-feature-details.en.md
+++ b/doc/manual/50-feature-details.en.md
@@ -884,6 +884,59 @@ The `replication-status` command allows
 you to get information about any streaming client attached to the
 managed server, in particular hot standby servers and WAL streamers.
 
+### Configuration Models
+
+Configuration models define a set of overrides for configuration options. These
+overrides can be applied to Barman servers which are part of the same cluster as
+the config models. They can be handy to handle clustered environments, so you
+can change the configuration of a Barman server in response to failover events,
+for example.
+
+As an example, let's say you have a PostgreSQL cluster with the following nodes:
+
+* `pg-node-1`: primary
+* `pg-node-2`: standby
+* `pg-node-3`: standby
+
+Assume you are backing up from the primary node, and have a configuration which
+include the following options:
+
+```ini
+[my-barman-server]
+cluster = my-cluster
+conninfo = host=pg-node-1 user=barman database=postgres
+streaming_conninfo = host=pg-node-1 user=streaming_barman
+; other options...
+```
+
+You could, for example, have a configuration model for that cluster as follows:
+
+```ini
+[my-barman-server:backup-from-pg-node-2]
+cluster = my-cluster
+model = true
+conninfo = host=pg-node-2 user=barman
+streaming_conninfo = host=pg-node-2 user=streaming_barman
+```
+
+Which could be applied upon a failover from `pg-node-1` to `pg-node-2` with
+the following command, so you start backing up from the new primary node:
+
+```bash
+barman config-switch my-barman-server my-barman-server:backup-from-pg-node-2
+```
+
+That will basically override the cluster configuration options with the values
+defined in the selected model.
+
+> *NOTE*: not all options are configurable through models. Please refer to
+> [section 5 of the 'man' page][man5] to check settings which scope applies to
+> models.
+
+> *NOTE*: you might be interested in checking [pg-backup-api](https://www.enterprisedb.com/docs/supported-open-source/barman/pg-backup-api/),
+> which can start a REST API and listen for remote requests for executing
+> `barman` commands, including `barman config-switch`.
+
 ## Parallel jobs
 
 By default, Barman uses only one worker for file copy during both backup and


### PR DESCRIPTION
This PR adds documentation for all the features that have been as part
of the work of making it easier to integrate Barman with HA clusters.

We perform the following changes to the web docs / `man`:

* Add `cluster` configuration option to `man 5`
* Add `model` configuration option to `man 5`
* Include the `Model` scope to all options that configuration models support
* Add information about configuration models under the `Integration with cluster
  management systems` section of the web docs
* Add information about configuration models and examples under the `Configuration`
  section of the web docs
* Add documentation about the `barman config-switch` new CLI command in the
  web docs

Some changes to the documentation related with `wal_conninfo` and
`wal_streaming_conninfo` have already been applied through #868, and are only
pending to be merged.

Besides that we applied some standardization on all configuration options in `man`
(`doc/barman.5.d/50-*` files):

* Have an empty new line at the end -- some of them were missing this;
* Have at most 80 characters per line -- some of them were not following
  this rule;
* Have a `Scope: ` line near the end, after the description of the
  configuration option: it specifies which is the scope of the config
  option, i.e., if it can be applied to one or more scopes among
  `Global`, `Server` and `Model`. This information used to be present
  in the `man 5` files already, however they were part of the descritpion.
  Now we have some emphasis with a separate paragraph which follows the
  same standard over all files.

Also, there are more docs to come, once we finish other work related with HA cluster
features which is still pending.

References: BAR-136.