### PR TITLE
Change the minor version on the docs for rsync optionally needed

### DIFF
--- a/doc/manual/15-system_requirements.en.md
+++ b/doc/manual/15-system_requirements.en.md
@@ -10,7 +10,7 @@
     - python-dateutil
     - setuptools
 - PostgreSQL >= 10 (next version will require PostgreSQL >= 11)
-- rsync >= 3.0.4 (optional)
+- rsync >= 3.1.0 (optional)
 
 > **IMPORTANT:**
 > Users of RedHat Enterprise Linux, CentOS and Scientific Linux are


### PR DESCRIPTION
There's a requirement in the docs which is optional if you don't use rsync mode. This stated that you needed version 3.0.4 or better, yet this was not true as we need at least version 3.1.0 to use `--ignore-missing-args`.

This commit sets the documentation right so there's no confusion regarding the minimum version of rsync that is required to run barman with rsync.