### PR TITLE
Include documentation about `barman config-update`

### DIFF
--- a/doc/barman.1.d/50-config-update.md
+++ b/doc/barman.1.d/50-config-update.md
@@ -1,0 +1,8 @@
+config-update *JSON_CHANGES*
+:   Create or update configuration of servers and/or models in Barman.
+    `JSON_CHANGES` should be a JSON string containing an array of documents.
+    Each document must contain the `scope` key, which can be either
+    `server` or `model`, and either the `server_name` or `model_name` key,
+    depending on the value of `scope`. Besides that, other keys are
+    expected to be Barman configuration options along with their desired
+    values.

--- a/doc/barman.5.d/50-config_changes_queue.md
+++ b/doc/barman.5.d/50-config_changes_queue.md
@@ -1,0 +1,10 @@
+config_changes_queue
+:   Barman uses a queue to apply configuration changes requested through
+    `barman config-update` command. This allows it to serialize multiple
+    requests of configuration changes, and also retry an operation which
+    has been abruptly terminated. This configuration option allows you
+    to specify where in the filesystem the queue should be written. By
+    default Barman writes to a file named `cfg_changes.queue` under
+    `barman_home`.
+
+    Scope: global.

--- a/doc/manual/42-server-commands.en.md
+++ b/doc/manual/42-server-commands.en.md
@@ -67,6 +67,51 @@ barman check <server_name>
 > and monitoring infrastructure. The `--nagios` option allows you
 > to easily create a plugin for Nagios/Icinga.
 
+## `config-update`
+
+The `config-update` command is used to create or update configuration of servers
+and models in Barman
+
+The syntax for running `config-update` command is:
+
+```bash
+barman config-update <json_changes>
+```
+
+`json_changes` should be a JSON string containing an array of documents.
+Each document must contain the following key:
+
+* `scope`: either `server` or `model`, depending on if you want to
+  create or update a Barman server or a Barman model;
+
+They must also contain either of the following keys, depending on value of
+``scope``:
+
+* `server_name`: if `scope` is `server`, you should fill this key with
+  the Barman server name;
+* `model_name`: if `scope` is `model`, you should fill this key with the
+  Barman model name.
+
+Besides these, you should fill each document with one or more Barman configuration
+options along with the desired values for them.
+
+This is an example for updating the Barman server `my_server` with
+`archiver=on` and `streaming_archiver=off`:
+
+```bash
+barman config-update \
+  ‘[{“scope”: “server”, “server_name”: “my_server”, “archiver”: “on”, “streaming_archiver”: “off”}]’
+```
+
+> *NOTE*: `barman config-update` command writes the configuration options to
+> a file named `.barman.auto.conf`, which is created under the `barman_home`.
+> That configuration file takes higher precedence and overrides values coming from
+> the Barman global configuration file (typically `/etc/barman.conf`) and from
+> included files as per `configuration_files_directory` (typically files in
+> `/etc/barman.d`). Keep that in mind if you later, for any reason, decide to
+> manually change configuration options in those files..
+
+
 ## `config-switch`
 
 The `config-switch` command is used to apply a set of configuration overrides


### PR DESCRIPTION
This commit introduces documentation about:

* The `barman config-update` command
* The file which is managed by Barman when calling that command (`.barman.auto.conf`)
* The `config_changes_queue` global setting, which is used by that command.

References: BAR-143.