### PR TITLE
Add zstd compression support to Barman Cloud

### DIFF
--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -279,6 +279,13 @@ def parse_arguments(args=None):
         const="snappy",
         dest="compression",
     )
+    compression.add_argument(
+        "--zstd",
+        help="zstd-compress the backup while uploading to the cloud",
+        action="store_const",
+        const="zst",
+        dest="compression",
+    )
     parser.add_argument(
         "-h",
         "--host",

--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -155,6 +155,14 @@ def parse_arguments(args=None):
         const="snappy",
         dest="compression",
     )
+    compression.add_argument(
+        "--zstd",
+        help="zstd-compress the WAL while uploading to the cloud "
+        "(requires optional zstandard library)",
+        action="store_const",
+        const="zstd",
+        dest="compression",
+    )
     add_tag_argument(
         parser,
         name="tags",
@@ -319,6 +327,10 @@ class CloudWalUploader(object):
         elif self.compression == "snappy":
             # add snappy extension
             return "%s.snappy" % wal_name
+
+        elif self.compression == "zstd":
+            # add zstd extension
+            return "%s.zst" % wal_name
         else:
             raise ValueError("Unknown compression type: %s" % self.compression)
 

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -72,7 +72,12 @@ BUFSIZE = 16 * 1024
 LOGGING_FORMAT = "%(asctime)s [%(process)s] %(levelname)s: %(message)s"
 
 # Allowed compression algorithms
-ALLOWED_COMPRESSIONS = {".gz": "gzip", ".bz2": "bzip2", ".snappy": "snappy"}
+ALLOWED_COMPRESSIONS = {
+    ".gz": "gzip",
+    ".bz2": "bzip2",
+    ".snappy": "snappy",
+    ".zst": "zstd",
+}
 
 DEFAULT_DELIMITER = "/"
 
@@ -193,7 +198,7 @@ class CloudTarUploader(object):
         self.buffer = None
         self.counter = 0
         self.compressor = None
-        # Some supported compressions (e.g. snappy) require CloudTarUploader to apply
+        # Some supported compressions (e.g. snappy, zstd) require CloudTarUploader to apply
         # compression manually rather than relying on the tar file.
         self.compressor = cloud_compression.get_compressor(compression)
         # If the compression is supported by tar then it will be added to the filemode
@@ -366,6 +371,8 @@ class CloudUploadController(object):
             components.append(".bz2")
         elif self.compression == "snappy":
             components.append(".snappy")
+        elif self.compression == "zst":
+            components.append(".zst")
         return "".join(components)
 
     def _get_tar(self, name):
@@ -2287,6 +2294,8 @@ class CloudBackupCatalog(KeepManagerMixinCloud):
                         info.compression = "bzip2"
                     elif ext == "tar.snappy":
                         info.compression = "snappy"
+                    elif ext == "tar.zst":
+                        info.compression = "zstd"
                     else:
                         logging.warning("Skipping unknown extension: %s", ext)
                         continue

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ setup(
         "azure": ["azure-identity", "azure-storage-blob"],
         "azure-snapshots": ["azure-identity", "azure-mgmt-compute"],
         "cloud": ["boto3"],
+        "zstd": ["zstandard"],
         "google": [
             "google-cloud-storage",
         ],

--- a/tests/requirements_dev.txt
+++ b/tests/requirements_dev.txt
@@ -2,6 +2,7 @@
 .[cloud]
 .[azure]
 .[snappy]
+.[zstd]
 .[google]
 pytest
 mock


### PR DESCRIPTION
This implements zstandard support to Barman cloud

Quick benchmark (from my laptop over internet to S3) shows it's the fastest and second smallest size:
| Type | Size | Time |
|--------|--------|--------|
| bz2 | 187.7 MB | 81,26s |
| gz | 250.5 MB | 137,36s |
| snappy | 398.1 MB | 8,41s |
| tar | 945.9 MB | 9,05s |
| zstd | 242.2 MB | 8,24s |

Fixes #850