### PR TITLE
Update instructions for barman user needed privileges

### DIFF
--- a/barman/clients/cloud_restore.py
+++ b/barman/clients/cloud_restore.py
@@ -300,9 +300,11 @@ class CloudBackupDownloaderObjectStore(CloudBackupDownloader):
                 "Extracting %s to %s (%s)",
                 file_info.path,
                 target_dir,
-                "decompressing " + file_info.compression
-                if file_info.compression
-                else "no compression",
+                (
+                    "decompressing " + file_info.compression
+                    if file_info.compression
+                    else "no compression"
+                ),
             )
             self.cloud_interface.extract_tar(file_info.path, target_dir)
 

--- a/barman/config.py
+++ b/barman/config.py
@@ -79,7 +79,6 @@ BASEBACKUP_COMPRESSIONS = ["gzip", "lz4", "zstd", "none"]
 
 
 class CsvOption(set):
-
     """
     Base class for CSV options.
 

--- a/barman/hooks.py
+++ b/barman/hooks.py
@@ -210,7 +210,6 @@ class HookScriptRunner(object):
 
 
 class RetryHookScriptRunner(HookScriptRunner):
-
     """
     A 'retry' hook script is a special kind of hook script that Barman
     tries to run indefinitely until it either returns a SUCCESS or

--- a/barman/output.py
+++ b/barman/output.py
@@ -1642,11 +1642,11 @@ class JsonOutputWriter(ConsoleOutputWriter):
                     percent=data["wal_until_next_compression_ratio"]
                 )
             if data["children_timelines"]:
-                wal_output[
-                    "_WARNING"
-                ] = "WAL information is inaccurate \
+                wal_output["_WARNING"] = (
+                    "WAL information is inaccurate \
                     due to multiple timelines interacting with \
                     this backup"
+                )
                 for history in data["children_timelines"]:
                     wal_output["timelines"].append(str(history.tli))
 

--- a/doc/manual/21-preliminary_steps.en.md
+++ b/doc/manual/21-preliminary_steps.en.md
@@ -29,9 +29,8 @@ postgres@pg$ createuser -P barman
 ```
 
 ``` sql
-GRANT EXECUTE ON FUNCTION pg_start_backup(text, boolean, boolean) to barman;
-GRANT EXECUTE ON FUNCTION pg_stop_backup() to barman;
-GRANT EXECUTE ON FUNCTION pg_stop_backup(boolean, boolean) to barman;
+GRANT EXECUTE ON FUNCTION pg_backup_start(text, boolean) to barman;
+GRANT EXECUTE ON FUNCTION pg_backup_stop(boolean) to barman;
 GRANT EXECUTE ON FUNCTION pg_switch_wal() to barman;
 GRANT EXECUTE ON FUNCTION pg_create_restore_point(text) to barman;
 
@@ -39,14 +38,15 @@ GRANT pg_read_all_settings TO barman;
 GRANT pg_read_all_stats TO barman;
 ```
 
-In the PostgreSQL 15 beta and any subsequent PostgreSQL versions the functions
-`pg_start_backup` and `pg_stop_backup` have been renamed and have different
-signatures. You will therefore need to replace the first three lines in the
+In the case of using PostgreSQL version 14 or a prior version, the functions
+`pg_backup_start` and `pg_backup_stop` had different names and different
+signatures. You will therefore need to replace the first two lines in the
 above block with:
 
 ``` sql
-GRANT EXECUTE ON FUNCTION pg_backup_start(text, boolean) to barman;
-GRANT EXECUTE ON FUNCTION pg_backup_stop(boolean) to barman;
+GRANT EXECUTE ON FUNCTION pg_start_backup(text, boolean, boolean) to barman;
+GRANT EXECUTE ON FUNCTION pg_stop_backup() to barman;
+GRANT EXECUTE ON FUNCTION pg_stop_backup(boolean, boolean) to barman;
 ```
 
 It is worth noting that with PostgreSQL version 13 and below without a real 

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -1763,9 +1763,9 @@ class TestSnapshotRecoveryExecutor(object):
             attached_volumes["disk0"].mount_point = "/opt/disk0"
             attached_volumes["disk0"].mount_options = "rw,noatime"
 
-        attached_volumes[
-            "disk0"
-        ].resolve_mounted_volume.side_effect = mock_resolve_mounted_volume
+        attached_volumes["disk0"].resolve_mounted_volume.side_effect = (
+            mock_resolve_mounted_volume
+        )
         mock_get_snapshot_interface.return_value.get_attached_volumes.return_value = (
             attached_volumes
         )
@@ -2195,9 +2195,9 @@ class TestSnapshotRecoveryExecutor(object):
             # If resolved_mount_info should raise an exception then just set it as the
             # side effect
             if isinstance(resolved_mount_info, Exception):
-                attached_volumes[
-                    disk
-                ].resolve_mounted_volume.side_effect = resolved_mount_info
+                attached_volumes[disk].resolve_mounted_volume.side_effect = (
+                    resolved_mount_info
+                )
             # Otherwise, create a partial which sets the mount point and options to the
             # values at the current index
             else:


### PR DESCRIPTION
There was a block of SQL code added some time ago which helps users that do not want to have a superuser running the backups.

These instructions provided SQL commands to GRANT those specific privileges to the barman user.

Since version 15, two of the functions that needed to be GRANTed have not only changed their names, but also their signatures. There is a note regarding such change with appropriate instructions on the new lines to use.

Given there are already two newer versions out, and Postgres 17 coming out in a some months, it makes more sense to have instructions for the latest versions, and a note for anyone running on older Postgres versions.

This patch amends this.