### PR TITLE
Make argcomplete optional

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -36,7 +36,10 @@ from barman.lockfile import ConfigUpdateLock
 
 if sys.version_info.major < 3:
     from argparse import Action, _SubParsersAction, _ActionsContainer
-import argcomplete
+try:
+    import argcomplete
+except ImportError:
+    argcomplete = None
 from collections import OrderedDict
 from contextlib import closing
 
@@ -2381,7 +2384,8 @@ def main():
     """
     # noinspection PyBroadException
     try:
-        argcomplete.autocomplete(p)
+        if argcomplete:
+            argcomplete.autocomplete(p)
         args = p.parse_args()
         global_config(args)
         if args.command is None:

--- a/doc/manual/15-system_requirements.en.md
+++ b/doc/manual/15-system_requirements.en.md
@@ -5,7 +5,7 @@
 - Linux/Unix
 - Python >= 3.6
 - Python modules:
-    - argcomplete
+    - argcomplete (optional)
     - psycopg2 >= 2.4.2
     - python-dateutil
     - setuptools

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup_requires = pytest_runner
 install_requires = [
     "psycopg2 >= 2.4.2",
     "python-dateutil",
-    "argcomplete",
 ]
 
 barman = {}
@@ -100,10 +99,11 @@ setup(
     long_description="\n".join(__doc__.split("\n")[2:]),
     install_requires=install_requires,
     extras_require={
-        "cloud": ["boto3"],
+        "argcomplete": ["argcomplete"],
         "aws-snapshots": ["boto3"],
         "azure": ["azure-identity", "azure-storage-blob"],
         "azure-snapshots": ["azure-identity", "azure-mgmt-compute"],
+        "cloud": ["boto3"],
         "google": [
             "google-cloud-storage",
         ],


### PR DESCRIPTION
Argcomplete is a nice library for bash completion but is not necessary for barman to work properly.
Installation of the lib should be optional and not enforced, and the code should handle this.