### PR TITLE
Pin python-snappy to 0.6.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,6 @@ setup(
         "aws-snapshots": ["boto3"],
         "azure": ["azure-identity", "azure-storage-blob"],
         "azure-snapshots": ["azure-identity", "azure-mgmt-compute"],
-        "snappy": ["python-snappy"],
         "google": [
             "google-cloud-storage",
         ],
@@ -112,6 +111,7 @@ setup(
             "grpcio",
             "google-cloud-compute",  # requires minimum python3.7
         ],
+        "snappy": ["python-snappy==0.6.1"],
     },
     platforms=["Linux", "Mac OS X"],
     classifiers=[


### PR DESCRIPTION
The latest version of snappy, 0.7.1 seems to have some issues with python 3.6. Pin the version to the previous version while we investigate on the issue.