### PR TITLE
Load the autoconf file only if it exists

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -1994,9 +1994,10 @@ def global_config(args):
 
     # Load additional configuration files
     config.load_configuration_files_directory()
-    config.load_config_file(
-        "%s/.barman.auto.conf" % config.get("barman", "barman_home")
-    )
+    # Handle the autoconf file, load it only if exists
+    autoconf_path = "%s/.barman.auto.conf" % config.get("barman", "barman_home")
+    if os.path.exists(autoconf_path):
+        config.load_config_file(autoconf_path)
     # We must validate the configuration here in order to have
     # both output and logging configured
     config.validate_global_config()

--- a/barman/config.py
+++ b/barman/config.py
@@ -1336,20 +1336,24 @@ class Config(object):
 
     def load_config_file(self, cfile):
         filename = os.path.basename(cfile)
-        if os.path.isfile(cfile):
-            # Load a file
-            _logger.debug("Including configuration file: %s", filename)
-            self._config.read_config(cfile)
-            if self._is_global_config_changed():
-                msg = (
-                    "the configuration file %s contains a not empty [barman] section"
-                    % filename
-                )
-                _logger.fatal(msg)
-                raise SystemExit("FATAL: %s" % msg)
+        if os.path.exists(cfile):
+            if os.path.isfile(cfile):
+                # Load a file
+                _logger.debug("Including configuration file: %s", filename)
+                self._config.read_config(cfile)
+                if self._is_global_config_changed():
+                    msg = (
+                        "the configuration file %s contains a not empty [barman] section"
+                        % filename
+                    )
+                    _logger.fatal(msg)
+                    raise SystemExit("FATAL: %s" % msg)
+            else:
+                # Add an warning message that a file has been discarded
+                _logger.warn("Discarding configuration file: %s (not a file)", filename)
         else:
-            # Add an info that a file has been discarded
-            _logger.warn("Discarding configuration file: %s (not a file)", filename)
+            # Add an warning message that a file has been discarded
+            _logger.warn("Discarding configuration file: %s (not found)", filename)
 
     def _is_model(self, name):
         """


### PR DESCRIPTION
Added a guarding statement that loads the barman.auto.conf file only if the file exists.
Improved warning messages in the load_config_file method, adding a specific one in case the file is not found.