### PR TITLE
Handle malformed or empty config_changes.queue file

### DIFF
--- a/barman/config.py
+++ b/barman/config.py
@@ -1860,6 +1860,11 @@ class ConfigChangesQueue:
                 return json.load(queue_file, object_hook=ConfigChangeSet.from_dict)
         except FileNotFoundError:
             return []
+        except json.JSONDecodeError:
+            output.warning(
+                "Malformed or empty configuration change queue: %s" % queue_file.name
+            )
+            return []
 
     def __enter__(self):
         """


### PR DESCRIPTION
If for whatever reason (ie: invalid JSON content or empty queue file)
The JSON parser throws an exception, emits a warning and continues with an
empty list

References: BAR-151