### PR TITLE
add summarize_wal field to backup.info (backup metadata)

### DIFF
--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -1771,6 +1771,13 @@ class BackupStrategy(with_metaclass(ABCMeta, object)):
                 msg = "\t%s, %s, %s" % (item.oid, item.name, item.location)
                 _logger.info(msg)
 
+        # Get summarize_wal information for incremental backups
+        # Postgres major version should be >= 17
+        backup_info.set_attribute("summarize_wal", None)
+        if self.postgres.server_version >= 170000:
+            summarize_wal = self.postgres.get_setting("summarize_wal")
+            backup_info.set_attribute("summarize_wal", summarize_wal)
+
     @staticmethod
     def _backup_info_from_start_location(backup_info, start_info):
         """

--- a/barman/infofile.py
+++ b/barman/infofile.py
@@ -497,6 +497,8 @@ class BackupInfo(FieldListFile):
         "snapshots_info", load=load_snapshots_info, dump=output_snapshots_info
     )
 
+    summarize_wal = Field("summarize_wal")
+
     __slots__ = "backup_id", "backup_version"
 
     _hide_if_null = ("backup_name", "snapshots_info")

--- a/tests/test_barman_cloud_backup_show.py
+++ b/tests/test_barman_cloud_backup_show.py
@@ -213,6 +213,7 @@ class TestCloudBackupShow(object):
             "version": 150000,
             "xlog_segment_size": 16777216,
             "backup_id": "backup_id_1",
+            "summarize_wal": None,
         }
 
     @pytest.mark.parametrize("extra_args", [[], ["--format", "json"]])

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -614,7 +614,6 @@ class TestStrategy(object):
             "file_offset": 11845848,
             "timestamp": start_time,
         }
-
         # Build a test empty backup info
         backup_info = LocalBackupInfo(server=backup_manager.server, backup_id="fake_id")
 
@@ -664,7 +663,8 @@ class TestStrategy(object):
         # Test: start concurrent backup
         # Build a backup_manager using a mocked server
         server = build_mocked_server(
-            main_conf={"backup_options": BackupOptions.CONCURRENT_BACKUP}
+            main_conf={"backup_options": BackupOptions.CONCURRENT_BACKUP},
+            pg_version=90600,  # this is a postgres 9.6
         )
         backup_manager = build_backup_manager(server=server)
         # Mock server.get_pg_setting('data_directory') call
@@ -678,9 +678,6 @@ class TestStrategy(object):
         # Mock server.get_pg_tablespaces() call
         tablespaces = [Tablespace._make(("test_tbs", 1234, "/tbs/test"))]
         server.postgres.get_tablespaces.return_value = tablespaces
-        # this is a postgres 9.6
-        server.postgres.server_version = 90600
-
         # Mock call to new api method
         start_time = datetime.datetime.now()
         server.postgres.start_concurrent_backup.return_value = {
@@ -761,13 +758,12 @@ class TestStrategy(object):
         """
         # Build a backup info and configure the mocks
         server = build_mocked_server(
-            main_conf={"backup_options": BackupOptions.CONCURRENT_BACKUP}
+            main_conf={"backup_options": BackupOptions.CONCURRENT_BACKUP},
+            pg_version=90600,  # This is a postgres 9.6
         )
         backup_manager = build_backup_manager(server=server)
 
         stop_time = datetime.datetime.now()
-        # This is a pg 9.6
-        server.postgres.server_version = 90600
         # Mock stop backup call for the new api method
         start_time = datetime.datetime.now(tz.tzlocal()).replace(microsecond=0)
         server.postgres.stop_concurrent_backup.return_value = {
@@ -881,6 +877,7 @@ class TestPostgresBackupExecutor(object):
             begin_offset=28,
             copy_stats=dict(copy_time=100, total_time=105),
         )
+        backup_manager.server.postgres.server_version = backup_info.version
         current_xlog_timestamp = datetime.datetime(2015, 10, 26, 14, 38)
         backup_manager.server.postgres.current_xlog_info = dict(
             location="0/12000090",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -74,6 +74,7 @@ EXPECTED_MINIMAL = {
             "xlog_segment_size": 16777216,
             "systemid": None,
             "compression": None,
+            "summarize_wal": None,
         }
     },
     "config": {},

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -69,6 +69,7 @@ def build_test_backup_info(
     server=None,
     systemid=None,
     copy_stats=None,
+    summarize_wal=None,
 ):
     """
     Create an 'Ad Hoc' BackupInfo object for testing purposes.
@@ -101,6 +102,7 @@ def build_test_backup_info(
     :param int version: postgres version of the backup
     :param barman.server.Server|None server: Server object for the backup
     :param dict|None: Copy stats dictionary
+    :param str|None: summarize_wal status flag
     :rtype: barman.infofile.LocalBackupInfo
     """
     if begin_time is None:
@@ -405,7 +407,9 @@ def build_real_server(global_conf=None, main_conf=None):
     )
 
 
-def build_mocked_server(name=None, config=None, global_conf=None, main_conf=None):
+def build_mocked_server(
+    name=None, config=None, global_conf=None, main_conf=None, pg_version=None
+):
     """
     Build a mock server object
     :param str name: server name, defaults to 'main'
@@ -415,6 +419,7 @@ def build_mocked_server(name=None, config=None, global_conf=None, main_conf=None
         it is possible to override or add new values to the [barman] section
     :param dict[str,str|None]|None main_conf: using this dictionary
         it is possible to override/add new values to the [main] section
+    :param int pg_version: postgres server version, default to ``None``
     :rtype: barman.server.Server
     """
     # instantiate a retention policy object using mocked parameters
@@ -433,11 +438,17 @@ def build_mocked_server(name=None, config=None, global_conf=None, main_conf=None
     server.postgres.xlog_segment_size = DEFAULT_XLOG_SEG_SIZE
     server.path = "/test/bin"
     server.systemid = "6721602258895701769"
+    server.postgres.server_version = pg_version
     return server
 
 
 def build_backup_manager(
-    server=None, name=None, config=None, global_conf=None, main_conf=None
+    server=None,
+    name=None,
+    config=None,
+    global_conf=None,
+    main_conf=None,
+    pg_version=None,
 ):
     """
     Instantiate a BackupManager object using mocked parameters
@@ -448,7 +459,7 @@ def build_backup_manager(
     :rtype: barman.backup.BackupManager
     """
     if server is None:
-        server = build_mocked_server(name, config, global_conf, main_conf)
+        server = build_mocked_server(name, config, global_conf, main_conf, pg_version)
     with mock.patch("barman.backup.CompressionManager"):
         manager = BackupManager(server=server)
     manager.compression_manager.unidentified_compression = None


### PR DESCRIPTION
With postgres major version >= 17, we have the possibility to do incremental backups with pg_basebackup. 

A crucial element for enabling this functionality is the WAL summarizer process. This is a recent addition, designed to assist incremental backups by identifying the differences in the data directory since the previous backup. 

A new field was added in configuration file ` postgresql.conf` called `summarize_wal`. This field handles the state of the process (on or off).

This commit adds a new field called summarize_wal to the backup.info metadata.

For postgres versions prior to 17, this field will remain as `None`.

Unit tests updated accordingly.

References: BAR-172.

Signed-off-by: Andre Marchesini de Aguiar <andre.marchesini@enterprisedb.com>