### PR TITLE
Add shortcut to get latest full backup

### DIFF
--- a/barman/backup.py
+++ b/barman/backup.py
@@ -361,8 +361,8 @@ class BackupManager(RemoteStatusMixin, KeepManagerMixin):
         Get the id of the latest/last backup in the catalog (if exists)
 
         :param status_filter: The status of the backup to return,
-            default to DEFAULT_STATUS_FILTER.
-        :return string|None: ID of the backup
+            default to :attr:`DEFAULT_STATUS_FILTER`.
+        :return str|None: ID of the backup
         """
         available_backups = self.get_available_backups(status_filter)
         if len(available_backups) == 0:
@@ -370,6 +370,29 @@ class BackupManager(RemoteStatusMixin, KeepManagerMixin):
 
         ids = sorted(available_backups.keys())
         return ids[-1]
+
+    def get_last_full_backup_id(self, status_filter=DEFAULT_STATUS_FILTER):
+        """
+        Get the id of the latest/last FULL backup in the catalog (if exists)
+
+        :param status_filter: The status of the backup to return,
+            default to :attr:`DEFAULT_STATUS_FILTER`.
+        :return str|None: ID of the backup
+        """
+        available_full_backups = list(
+            filter(
+                lambda backup: backup.is_full_and_eligible_for_incremental(),
+                self.get_available_backups(status_filter).values(),
+            )
+        )
+
+        if len(available_full_backups) == 0:
+            return None
+
+        backup_infos = sorted(
+            available_full_backups, key=lambda backup_info: backup_info.backup_id
+        )
+        return backup_infos[-1].backup_id
 
     def get_first_backup_id(self, status_filter=DEFAULT_STATUS_FILTER):
         """

--- a/barman/infofile.py
+++ b/barman/infofile.py
@@ -877,3 +877,26 @@ class LocalBackupInfo(BackupInfo):
                     return backup_info
 
         return None
+
+    def is_full_and_eligible_for_incremental(self):
+        """
+        Used to filter out backups that have a parent backup id and are not
+        considered as FULL backups.
+
+        .. note::
+            Only consider backups which are eligible for Postgres core
+            incremental backups:
+
+            * backup_method = ``postgres``
+            * summarize_wal = ``on``
+            * parent_backup_id = ``None``
+
+        :return bool: True if it's a full backup or False if not.
+        """
+        if (
+            self.backup_manager.config.backup_method == "postgres"
+            and self.summarize_wal == "on"
+            and not self.parent_backup_id
+        ):
+            return True
+        return False

--- a/barman/server.py
+++ b/barman/server.py
@@ -1691,10 +1691,22 @@ class Server(RemoteStatusMixin):
         Get the id of the latest/last backup in the catalog (if exists)
 
         :param status_filter: The status of the backup to return,
+            default to :attr:`BackupManager.DEFAULT_STATUS_FILTER`.
+        :return str|None: ID of the backup
+        """
+        return self.backup_manager.get_last_backup_id(status_filter)
+
+    def get_last_full_backup_id(
+        self, status_filter=BackupManager.DEFAULT_STATUS_FILTER
+    ):
+        """
+        Get the id of the latest/last FULL backup in the catalog (if exists)
+
+        :param status_filter: The status of the backup to return,
             default to DEFAULT_STATUS_FILTER.
         :return string|None: ID of the backup
         """
-        return self.backup_manager.get_last_backup_id(status_filter)
+        return self.backup_manager.get_last_full_backup_id(status_filter)
 
     def get_first_backup_id(self, status_filter=BackupManager.DEFAULT_STATUS_FILTER):
         """

--- a/barman/utils.py
+++ b/barman/utils.py
@@ -864,6 +864,8 @@ def get_backup_id_using_shortcut(server, shortcut, BackupInfo):
         backup_id = server.get_first_backup_id()
     elif shortcut in ("last-failed"):
         backup_id = server.get_last_backup_id([BackupInfo.FAILED])
+    elif shortcut in ("latest-full", "last-full"):
+        backup_id = server.get_last_full_backup_id()
     elif is_backup_id(shortcut):
         backup_id = shortcut
 


### PR DESCRIPTION
With the imminent introduction of Postgres core incremental backups support in Barman, it will become necessary to retrieve the latest full backup. Currently, Barman can only retrieve the most recent backup regardless of its type.

This adjustment is essential to align with the specifications outlined in the BAR-161 proposal for enhancing the command-line interface that introduces the --incremental option, which facilitates the execution of incremental backups for postgres databases.

Incremental backups establish a sequential series of backups, where the initial backup invariably constitutes a full backup. Subsequently, numerous instances may arise wherein both full and incremental backups are generated.

References: BAR-173

Signed-off-by: Andre <andre.marchesini@enterprisedb.com>