### PR TITLE
Verify that the Postgres version is 17 or newer on incremental backups

### DIFF
--- a/barman/output.py
+++ b/barman/output.py
@@ -1642,11 +1642,11 @@ class JsonOutputWriter(ConsoleOutputWriter):
                     percent=data["wal_until_next_compression_ratio"]
                 )
             if data["children_timelines"]:
-                wal_output[
-                    "_WARNING"
-                ] = "WAL information is inaccurate \
+                wal_output["_WARNING"] = (
+                    "WAL information is inaccurate \
                     due to multiple timelines interacting with \
                     this backup"
+                )
                 for history in data["children_timelines"]:
                     wal_output["timelines"].append(str(history.tli))
 

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -1763,9 +1763,9 @@ class TestSnapshotRecoveryExecutor(object):
             attached_volumes["disk0"].mount_point = "/opt/disk0"
             attached_volumes["disk0"].mount_options = "rw,noatime"
 
-        attached_volumes[
-            "disk0"
-        ].resolve_mounted_volume.side_effect = mock_resolve_mounted_volume
+        attached_volumes["disk0"].resolve_mounted_volume.side_effect = (
+            mock_resolve_mounted_volume
+        )
         mock_get_snapshot_interface.return_value.get_attached_volumes.return_value = (
             attached_volumes
         )
@@ -2195,9 +2195,9 @@ class TestSnapshotRecoveryExecutor(object):
             # If resolved_mount_info should raise an exception then just set it as the
             # side effect
             if isinstance(resolved_mount_info, Exception):
-                attached_volumes[
-                    disk
-                ].resolve_mounted_volume.side_effect = resolved_mount_info
+                attached_volumes[disk].resolve_mounted_volume.side_effect = (
+                    resolved_mount_info
+                )
             # Otherwise, create a partial which sets the mount point and options to the
             # values at the current index
             else:


### PR DESCRIPTION
Performing an incremental backup using Postgres mode requires the Postgres server's version to be 17 or newer. This PR builds from the validation methods introduced by BAR-160 (`validate_backup_args` and `_validate_incremental_backup_configs`), adding a check for the Postgres server's version and issue an error if it's not compatible with incremental backups (<17).

References: BAR-163