### PR TITLE
Always add an explicit time zone to `recovery_target_time`

### DIFF
--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -492,6 +492,12 @@ class RecoveryExecutor(object):
                         tzinfo=dateutil.tz.tzlocal()
                     )
 
+                    output.warning(
+                        "No time zone has been specified through '--target-time' "
+                        "command-line option. Barman assumed the same time zone from "
+                        "the Barman host.",
+                    )
+
                 # Check if the target time is reachable from the
                 # selected backup
                 if backup_info.end_time > target_datetime:
@@ -1048,7 +1054,19 @@ class RecoveryExecutor(object):
 
         # Writes recovery target
         if target_time:
-            recovery_conf_lines.append("recovery_target_time = '%s'" % target_time)
+            # 'target_time' is the value as it came from '--target-time' command-line
+            # option, which may be without a time zone. When writing the actual Postgres
+            # configuration we should use a value with an explicit time zone set, so we
+            # avoid hitting pitfalls. We use the 'target_datetime' which was prevously
+            # added to 'recovery_info'. It already handles the cases where the user
+            # specifies no time zone, and uses the Barman host time zone as a fallback.
+            # In short: if 'target_time' is present it means the user asked for a
+            # specific point in time, but we need a sanitized value to use in the
+            # Postgres configuration, so we use 'target_datetime'.
+            # See '_set_pitr_targets'.
+            recovery_conf_lines.append(
+                "recovery_target_time = '%s'" % recovery_info["target_datetime"],
+            )
         if target_xid:
             recovery_conf_lines.append("recovery_target_xid = '%s'" % target_xid)
         if target_lsn:


### PR DESCRIPTION
Previous to this commit there could be cases where Postgres would be misconfigured by `barman recover`.

For example, assume you had an environment like this:

* Barman host configured with time zone UTC+2, e.g. `Europe/Berlin`;`
* Postgres cluster with default value for timezone GUC, i.e. GMT value.

If we attempted a `barman recover` execution with `--target-time` set, but without an explicit time zone, recovery could fail:

* `barman recover` output would say that recovery target time was set with `+02:00`;
* However `postgresql.auto.conf` would not contain `+02:00`.

In practice either the recovery would fail because of an invalid recovery target, or the cluster would be recovered to a point-in-time different from the user needs. Neither of these cases are welcome.

This commit fixes that issue by reusing the `target_datetime` key from the `recovery_info` variable. That entry contains the target time with a time zone explicitly set, even if the user specified no time zone through the command-line option.

Note: a warning is issued if the user specified no time zone, and Barman assumed its host time zone.

References: BAR-185 #881.