### PR TITLE
Implementation of backup tree deletion

### DIFF
--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -247,22 +247,7 @@ class TestBackup(object):
             "fake_backup_id": b_info,
         }
 
-        # Test 1: minimum redundancy not satisfied
-        caplog_reset(caplog)
-        backup_manager.server.config.minimum_redundancy = 2
-        b_info.set_attribute("backup_version", 1)
-        build_backup_directories(b_info)
-        backup_manager.delete_backup(b_info)
-        assert re.search("WARNING .* Skipping delete of backup ", caplog.text)
-        assert "ERROR" not in caplog.text
-        assert os.path.exists(pg_data.strpath)
-        assert not os.path.exists(pg_data_v2.strpath)
-        assert os.path.exists(wal_file.strpath)
-        assert os.path.exists(wal_history_file02.strpath)
-        assert os.path.exists(wal_history_file03.strpath)
-        assert os.path.exists(wal_history_file04.strpath)
-
-        # Test 2: normal delete expecting no errors (old format)
+        # Test 1: normal delete expecting no errors (old format)
         caplog_reset(caplog)
         backup_manager.server.config.minimum_redundancy = 1
         b_info.set_attribute("backup_version", 1)
@@ -278,7 +263,7 @@ class TestBackup(object):
         assert os.path.exists(wal_history_file03.strpath)
         assert os.path.exists(wal_history_file04.strpath)
 
-        # Test 3: delete the backup again, expect a failure in log
+        # Test 2: delete the backup again, expect a failure in log
         caplog_reset(caplog)
         backup_manager.delete_backup(b_info)
         assert re.search("ERROR .* Failure deleting backup fake_backup_id", caplog.text)
@@ -289,7 +274,7 @@ class TestBackup(object):
         assert os.path.exists(wal_history_file03.strpath)
         assert os.path.exists(wal_history_file04.strpath)
 
-        # Test 4: normal delete expecting no errors (new format)
+        # Test 3: normal delete expecting no errors (new format)
         caplog_reset(caplog)
         b_info.set_attribute("backup_version", 2)
         build_backup_directories(b_info)
@@ -303,7 +288,7 @@ class TestBackup(object):
         assert os.path.exists(wal_history_file03.strpath)
         assert os.path.exists(wal_history_file04.strpath)
 
-        # Test 5: normal delete of first backup no errors and no skip
+        # Test 4: normal delete of first backup no errors and no skip
         # removing one of the two backups present (new format)
         # and all the previous wal
         caplog_reset(caplog)
@@ -319,7 +304,7 @@ class TestBackup(object):
         assert os.path.exists(wal_history_file03.strpath)
         assert os.path.exists(wal_history_file04.strpath)
 
-        # Test 6: normal delete of first backup no errors and no skip
+        # Test 5: normal delete of first backup no errors and no skip
         # removing one of the two backups present (new format)
         # the previous wal is retained as on a different timeline
         caplog_reset(caplog)
@@ -337,7 +322,7 @@ class TestBackup(object):
         assert os.path.exists(wal_history_file03.strpath)
         assert os.path.exists(wal_history_file04.strpath)
 
-        # Test 7: simulate an error deleting the backup.
+        # Test 6: simulate an error deleting the backup.
         with patch(
             "barman.backup.BackupManager.delete_backup_data"
         ) as mock_delete_data:
@@ -353,27 +338,6 @@ class TestBackup(object):
             assert os.path.exists(wal_history_file02.strpath)
             assert os.path.exists(wal_history_file03.strpath)
             assert os.path.exists(wal_history_file04.strpath)
-
-    @patch("barman.backup.BackupManager.should_keep_backup")
-    def test_cannot_delete_keep_backup(self, mock_should_keep_backup, caplog):
-        """Verify that we cannot delete backups directly if they have a keep"""
-        # Setup of the test backup_manager
-        backup_manager = build_backup_manager()
-        backup_manager.server.config.name = "TestServer"
-        backup_manager.server.config.backup_options = []
-
-        mock_should_keep_backup.return_value = True
-
-        b_info = build_test_backup_info(
-            backup_id="fake_backup_id",
-            server=backup_manager.server,
-        )
-        assert backup_manager.delete_backup(b_info) is False
-        assert (
-            "Skipping delete of backup fake_backup_id for server TestServer as it "
-            "has a current keep request. If you really want to delete this backup "
-            "please remove the keep and try again." in caplog.text
-        )
 
     def test_available_backups(self, tmpdir):
         """

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1225,6 +1225,61 @@ class TestServer(object):
         server.delete_backup(backup_info)
         delete_mock.assert_called_with(backup_info)
 
+    def test_delete_backup_with_children(self, tmpdir):
+        """
+        Test that a parent backup is deleted along with its descendants
+        """
+        server = build_real_server({"barman_home": tmpdir.strpath})
+        server.backup_manager.delete_backup = Mock()
+
+        # This test works with the following backup tree structure:
+        #            root
+        #             |
+        #      -----------------
+        #     |                 |
+        #   child1            child2
+        #    |                  |
+        #    |                child2.1
+        # child1.1 child1.2
+
+        # Mounts the tree. key = backup_id, value = tuple(parent_id, children_ids)
+        backup_tree = {
+            "root": (None, ["child1", "child2"]),
+            "child1": ("root", ["child1.1", "child1.2"]),
+            "child1.1": ("child1", None),
+            "child1.2": ("child1", None),
+            "child2": ("root", ["child2.1"]),
+            "child2.1": ("child2", None),
+        }
+        for backup_id, attributes in backup_tree.items():
+            backup_info_object = build_test_backup_info(
+                backup_id=backup_id,
+                server=server,
+                parent_backup_id=attributes[0],
+                children_backup_ids=attributes[1],
+            )
+            backup_info_object.save()
+            backup_tree[backup_id] = backup_info_object
+
+        # Test 1: deleting the root backup should also delete all its children
+        root_backup = backup_tree["root"]
+        server.delete_backup(root_backup)
+        # assert that the backup manager mock received the expected backups for deletion
+        manager_delete_calls = server.backup_manager.delete_backup.call_args_list
+        to_delete = ["child1.1", "child1.2", "child1", "child2.1", "child2", "root"]
+        for n_call, call_obj in enumerate(manager_delete_calls):
+            assert call_obj.args[0].backup_id == to_delete[n_call]
+
+        # Test 2: deleting a leaf backup should only delete that one
+        server.backup_manager.delete_backup.reset_mock()
+        leaf_backup = backup_tree["child2.1"]
+        server.delete_backup(leaf_backup)
+        server.backup_manager.delete_backup.assert_called_once_with(leaf_backup)
+
+        # We could have additional tests with other backups in different positions in the tree
+        # but then we would essentially be testing the tree-walk algorithm instead.
+        # This test only ensures that children are being deleted along with the parent when they exist
+
     @patch("subprocess.Popen")
     def test_archive_wal_lock_acquisition(self, subprocess_mock, tmpdir, capsys):
         """


### PR DESCRIPTION
This PR got bigger than I expected so I will try to explain the changes per commit.

In 129c6723302daea0f7a59954fd303b53f578b36c is the implementation for deleting descendant backup nodes when a parent is deleted. To achieve this, I divided the current `delete` method of the `Server` into two methods:

- `delete` which will now have some validations to make sure the backup is deletable (this used to be done later in the backup manager) as well as pass the whole chain for deletion inside a server level lock;
- `perform_delete` will be doing some of the same work that the previous delete method was doing i.e. validating file permissions, holding the backup level lock and calling the `BackupManager.delete`. One thing to notice here is that this code used to acquire a server lock in the beginning, but it was released before the deletion even started , I also think the error message there was not entirely correct as it would say something like "there's another process for this backup id" when the lock was actually on the server, not on the backup. I "fixed" those things, but would like a check-up just to make sure.

In b0f38bef5e6e9dc89fb0c8900b35f7bd796dacc0 I fixed the tests that were broken due to moving validations and locks around. I had to create new tests in the server logic as well as change some existing ones and remove some code from the backup manager tests.

In b41d409bbc62c00509e317be0ac3d1f414da3811 I created new tests for the children deletion logic. It basically tests that the whole chain is being passed for deletion and also that a child deletion also deletes its reference in its parent.

References: BAR-181