### PR TITLE
Restrict the use of keep annotations to full backups only

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -1820,6 +1820,13 @@ def keep(args):
             ) % (backup_info.backup_id, backup_info.status)
             output.error(msg)
             output.close_and_exit()
+        if backup_info.parent_backup_id:
+            msg = (
+                "Unable to execute the keep command on backup %s: is an incremental backup.\n"
+                "Only full backups are eligible for the use of the keep command."
+            ) % (backup_info.backup_id)
+            output.error(msg)
+            output.close_and_exit()
         backup_manager.keep_backup(backup_info.backup_id, args.target)
 
 


### PR DESCRIPTION
An incremental backup with the keep annotation that has its parent deleted would become an orphan backup and therefore useless for recovery. To avoid this, we should restrict the use of keep annotations to full backups only. This adds a new check prior to starting the annotation process to make sure we do not allow keeping a backup if it has a parent backup, raising an error if so.

References: BAR-184