### PR TITLE
Modify retention policies so incremental backups are ignored

### DIFF
--- a/barman/infofile.py
+++ b/barman/infofile.py
@@ -731,6 +731,24 @@ class LocalBackupInfo(BackupInfo):
                 e,
             )
 
+    @property
+    def is_incremental(self):
+        """
+        Only checks if the backup_info is an incremental backup
+
+        :return bool: ``True`` if this backup has a parent, ``False`` otherwise.
+        """
+        return self.parent_backup_id is not None
+
+    @property
+    def has_children(self):
+        """
+        Only checks if the backup_info has children
+
+        :return bool: ``True`` if this backup has at least one child, ``False`` otherwise.
+        """
+        return self.children_backup_ids is not None
+
     def get_list_of_files(self, target):
         """
         Get the list of files for the current backup
@@ -878,16 +896,19 @@ class LocalBackupInfo(BackupInfo):
 
         return None
 
-    def walk_backups_tree(self):
+    def walk_backups_tree(self, return_self=True):
         """
         Walk through all the children backups of the current backup.
 
         .. note::
-            The objects are returned with a bottom-up approach, including all children
-            backups plus the caller backup.
+            The objects are returned with a bottom-up approach, including all
+            children backups plus the caller backup.
 
-        :yield: a generator of :class:`LocalBackupInfo` objects for each backup, walking
-           from the leaves to self.
+        :param bool return_self: Whether to return the current backup.
+            Default to ``True``.
+
+        :yields: a generator of :class:`LocalBackupInfo` objects for each
+            backup, walking from the leaves to self.
         """
 
         if self.children_backup_ids:
@@ -897,6 +918,8 @@ class LocalBackupInfo(BackupInfo):
                     backup_id=child_backup_id,
                 )
                 yield from backup_info.walk_backups_tree()
+        if not return_self:
+            return
         yield self
 
     def walk_to_root(self):

--- a/tests/test_infofile.py
+++ b/tests/test_infofile.py
@@ -1127,14 +1127,25 @@ class TestLocalBackupInfo:
             side_effect=provide_child_backup_info,
         ):
             # Call the `walk_backups_tree` method on the root backup info
-            backups = list(root_backup_info.walk_backups_tree())
+            backups = list(root_backup_info.walk_backups_tree(return_self=True))
             # Assert that the backups are returned in the correct order
             # We want to walk through the tree in a depth-first post order,
             # so leaf nodes are visited first, then their parent, and so on.
+            assert len(backups) == 4
             assert backups[0].backup_id == "child_backup3"
             assert backups[1].backup_id == "child_backup1"
             assert backups[2].backup_id == "child_backup2"
             assert backups[3].backup_id == "root_backup"
+
+            # Call the `walk_backups_tree` method on the root backup info
+            backups = list(root_backup_info.walk_backups_tree(return_self=False))
+            # Assert that the backups are returned in the correct order
+            # We want to walk through the tree in a depth-first post order,
+            # so leaf nodes are visited first, then their parent, and so on.
+            assert len(backups) == 3
+            assert backups[0].backup_id == "child_backup3"
+            assert backups[1].backup_id == "child_backup1"
+            assert backups[2].backup_id == "child_backup2"
 
     def test_true_is_full_and_eligible_for_incremental(self):
         """

--- a/tests/test_retention_policies.py
+++ b/tests/test_retention_policies.py
@@ -261,6 +261,12 @@ class TestRetentionPolicies(object):
         assert empty_report_child == BackupInfo.NONE
 
     def test_first_backup(self, server):
+        """
+        Basic unit test of method first_backup
+
+        This method tests the retrieval of the first backup using both
+        RedundancyRetentionPolicy and RecoveryWindowRetentionPolicy
+        """
         rp = RetentionPolicyFactory.create(
             "retention_policy", "RECOVERY WINDOW OF 4 WEEKS", server
         )
@@ -268,12 +274,21 @@ class TestRetentionPolicies(object):
 
         # Build a BackupInfo object with status to DONE
         backup_info = build_test_backup_info(
-            server=server, backup_id="test0", end_time=datetime.now(tzlocal())
+            server=server,
+            backup_id="test0",
+            end_time=datetime.now(tzlocal()) - timedelta(days=1),
+        )
+        # Build another BackupInfo object with status to DONE taken one day after
+        backup_info2 = build_test_backup_info(
+            server=server, backup_id="test1", end_time=datetime.now(tzlocal())
         )
 
         # instruct the get_available_backups method to return a map with
         # our mock as result and minimum_redundancy = 1
-        server.get_available_backups.return_value = {"test_backup": backup_info}
+        server.get_available_backups.return_value = {
+            "test_backup": backup_info,
+            "test_backup2": backup_info2,
+        }
         server.config.minimum_redundancy = 1
         # execute retention policy report
         report = rp.first_backup()
@@ -285,14 +300,12 @@ class TestRetentionPolicies(object):
         )
         assert isinstance(rp, RedundancyRetentionPolicy)
 
-        # Build a BackupInfo object with status to DONE
-        backup_info = build_test_backup_info(
-            server=server, backup_id="test1", end_time=datetime.now(tzlocal())
-        )
-
         # instruct the get_available_backups method to return a map with
         # our mock as result and minimum_redundancy = 1
-        server.get_available_backups.return_value = {"test_backup": backup_info}
+        server.get_available_backups.return_value = {
+            "test_backup": backup_info,
+            "test_backup2": backup_info2,
+        }
         server.config.minimum_redundancy = 1
 
         # execute retention policy report


### PR DESCRIPTION
Starting from Postgres version 17, the introduction of incremental backups ensures a continuous chain of backups beginning with a full backup and extending through several incremental backups, specifically when backup_method="postgres". Consequently, any retention policy should exclusively target full backups for
deletion, as incremental backups rely on their parent chain of backups to remain valid and usable.

This commit:
1. Add new method to RetentionPolicy class
	1.1 propagate_retention_status_to_children

- This new method is used to set the retention status for incremental backups. This is needed because we want to control the retention status of the incremental backup based on its parent backup (AKA full backup). This will propagate the parent retention status to its children incremental backups. For KEEP status of the parent, we propagate the VALID status to the incrementals since the incrementals will always depend on the full backup.

2. Modify method _backup_report of RecoveryWindowRetentionPolicy and RedundancyRetentionPolicy

- These were modified so we could add the logic for skipping incremental backups and only account full backups for retention policy. Whatever status the full backup is reported, the value is propagated to its children incremental backups (KEEP status for parent will propagate VALID for incrementals).

4. Add properties to infofile.py LocalBackupInfo
	3.1 is_incremental

- 	This property was created to verify if the BackupInfo is an incremental backup.

	3.2 has_children

- 	This property was created to verify if the BackupInfo has any children (incremental backups).

5. Add new parameter to walk_backups_tree in infofile.py

- This parameter was added so we can control whether to return the current backup info (self) calling the method.

References: BAR-166

Signed-off-by: Andre <andre.marchesini@enterprisedb.com>