### PR TITLE
create new recovery executor that uses `pg_combinebackup`

### DIFF
--- a/barman/clients/walrestore.py
+++ b/barman/clients/walrestore.py
@@ -253,9 +253,7 @@ def try_deliver_from_spool(config, dest_file):
         shutil.move(spool_file, dest_file)
         sys.exit(0)
     except IOError as e:
-        exit_with_error(
-            "Failure moving %s to %s: %s" % (spool_file, dest_file, e)
-        )
+        exit_with_error("Failure moving %s to %s: %s" % (spool_file, dest_file, e))
 
 
 def exit_with_error(message, status=2, sleep=0):

--- a/barman/command_wrappers.py
+++ b/barman/command_wrappers.py
@@ -1150,6 +1150,64 @@ class PgVerifyBackup(PostgreSQLClient):
             self.args += args
 
 
+class PgCombineBackup(PostgreSQLClient):
+    """
+    Wrapper class for the ``pg_combinebackup`` system command
+    """
+
+    COMMAND_ALTERNATIVES = ["pg_combinebackup"]
+
+    def __init__(
+        self,
+        destination,
+        command,
+        tbs_mapping=None,
+        connection=None,
+        version=None,
+        app_name=None,
+        check=True,
+        args=None,
+        **kwargs
+    ):
+        """
+        Constructor
+
+        :param str destination: destination directory path
+        :param str command: the command to use
+        :param None|Dict[str, str] tbs_mapping: used for tablespace
+        :param PostgreSQL connection: an object representing
+          a database connection
+        :param Version version: the command version
+        :param str app_name: the application name to use for the connection
+        :param bool check: check if the return value is in the list of
+          allowed values of the :class:`Command` obj
+        :param None|List[str] args: additional arguments
+        """
+        PostgreSQLClient.__init__(
+            self,
+            connection=connection,
+            command=command,
+            version=version,
+            app_name=app_name,
+            check=check,
+            **kwargs
+        )
+
+        # Set the backup destination
+        self.args = ["--output=%s" % destination]
+
+        # The tablespace mapping option is repeated once for each tablespace
+        if tbs_mapping:
+            for tbs_source, tbs_destination in tbs_mapping.items():
+                self.args.append(
+                    "--tablespace-mapping=%s=%s" % (tbs_source, tbs_destination)
+                )
+
+        # Manage additional args
+        if args:
+            self.args += args
+
+
 class BarmanSubProcess(object):
     """
     Wrapper class for barman sub instances

--- a/barman/infofile.py
+++ b/barman/infofile.py
@@ -973,7 +973,7 @@ class SyntheticBackupInfo(LocalBackupInfo):
     ):
         """
         Stores meta information about a single synthetic backup.
-        
+
         .. note::
             A synthetic backup is a base backup which was artificially created
             through ``pg_combinebackup``. A synthetic backup is not part of

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -537,6 +537,7 @@ class TestCli(object):
         backup_info.status = BackupInfo.DONE
         backup_info.tablespaces = []
         backup_info.compression = None
+        backup_info.parent_backup_id = None
         return backup_info
 
     @pytest.fixture


### PR DESCRIPTION
pg_combinebackup utility is coming to Postgresql 17 with the introduction of incremental backup to reconstruct a synthetic full backup from a sequence of incremental backups and the previous full backup.  

This PR:
- Create a new command wrapper for the `pg_combinebackup` utility.
- Create a new recovery executor, which does the following:
   1. Get the backup chain and combine them into a synthetic backup in a common staging path
   2. Reuse the recover method from the `RecoveryExecutor` super class, by passing the newly created synthetic backup;
   3. In the copy phase, we check if is remote or local recovery:
      a. if it is remote, we reuse the rsync logic already present in the parent recovery executor;
      b. if it is local, we move the data directory and tablespaces from staging to the destination.

Note: we are reusing the `--recovery-staging-path` config options to point the place where `pg_combinebackup` should create the synthetic backup in the Barman host. Originally that config option was used only to point the path in the Postgres host where a backup should be decompressed.

References: BAR-167 & BAR-168