### PR TITLE
Require cramjam lib to be >= 2.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,11 @@ setup(
             "grpcio",
             "google-cloud-compute",  # requires minimum python3.7
         ],
-        "snappy": ["python-snappy==0.6.1"],
+        "snappy": [
+            'python-snappy==0.6.1; python_version<"3.7"',
+            'python-snappy; python_version>="3.7"',
+            'cramjam >= 2.7.0; python_version>="3.7"',
+        ],
     },
     platforms=["Linux", "Mac OS X"],
     classifiers=[


### PR DESCRIPTION
The library `python-snappy` internally uses the library cramjam from versions > 0.6.1.
This doesn't work well with versions of cramjam < 2.7.0 as the structure of the code is different than the one used by python-snappy.

References: bar-156