### PR TITLE
Padding before h1 and h2 in documentation, makes docs easier to read

### DIFF
--- a/doc/build/html-templates/override.css
+++ b/doc/build/html-templates/override.css
@@ -6,6 +6,8 @@ h1 a { color: #333; } h2 a { color: #333; } h3 a { color: #333; }
 h4 a { color: #333; } h5 a { color: #333; } h6 a { color: #333; }
 h1:hover a { color: #333; } h2:hover a { color: #333; } h3:hover a { color: #333; }
 h4:hover a { color: #333; } h5:hover a { color: #333; } h6:hover a { color: #333; }
+h1 { padding-top: 1.5em; }
+h2 { padding-top: 0.5em; }
 .toc { margin-top: 30px; }
 .toc, .toc ul { padding: 0; }
 .toc ul { margin-bottom: 20px; list-style: none; }


### PR DESCRIPTION
There is no whitespace around the main titles/subtitles (h1 and h2) in the [html documentation](https://docs.pgbarman.org/release/3.9.0/index.html) which makes it harder to read. 
As you know, whitespace is [important for readability](https://pimpmytype.com/hugo-md/) :) Thanks! // from a typography nerd 