### PR TITLE
Checks checksum consistency on backup chain

### DIFF
--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -1780,6 +1780,10 @@ class BackupStrategy(with_metaclass(ABCMeta, object)):
                 msg = "\t%s, %s, %s" % (item.oid, item.name, item.location)
                 _logger.info(msg)
 
+        # Set data_checksums state
+        data_checksums = self.postgres.get_setting("data_checksums")
+        backup_info.set_attribute("data_checksums", data_checksums)
+
         # Get summarize_wal information for incremental backups
         # Postgres major version should be >= 17
         backup_info.set_attribute("summarize_wal", None)

--- a/barman/infofile.py
+++ b/barman/infofile.py
@@ -522,7 +522,7 @@ class BackupInfo(FieldListFile):
     snapshots_info = Field(
         "snapshots_info", load=load_snapshots_info, dump=output_snapshots_info
     )
-
+    data_checksums = Field("data_checksums")
     summarize_wal = Field("summarize_wal")
     parent_backup_id = Field("parent_backup_id")
     children_backup_ids = Field(

--- a/barman/output.py
+++ b/barman/output.py
@@ -715,6 +715,7 @@ class ConsoleOutputWriter(object):
         if backup_info["status"] in BackupInfo.STATUS_COPY_DONE:
             output_fun(row.format("PostgreSQL Version", backup_info["version"]))
             output_fun(row.format("PGDATA directory", backup_info["pgdata"]))
+            output_fun(row.format("Checksums", backup_info["data_checksums"]))
             output_fun("")
 
     @staticmethod
@@ -1520,6 +1521,7 @@ class JsonOutputWriter(ConsoleOutputWriter):
                 dict(
                     postgresql_version=data["version"],
                     pgdata_directory=data["pgdata"],
+                    data_checksums=data["data_checksums"],
                     tablespaces=[],
                 )
             )

--- a/barman/server.py
+++ b/barman/server.py
@@ -1705,6 +1705,16 @@ class Server(RemoteStatusMixin):
             if not previous_backup:
                 self.backup_manager.remove_wal_before_backup(backup_info)
 
+            # check if the backup chain (in case it is a Postgres incremental) is consistent
+            # with their checksums configurations
+            if not backup_info.is_checksum_consistent():
+                output.warning(
+                    "This is an incremental backup taken with `data_checksums = on` whereas "
+                    "some previous backups in the chain were taken with `data_checksums = off`. "
+                    "This can lead to potential recovery issues. Consider taking a new full backup "
+                    "to avoid having inconsistent backup chains."
+                )
+
             if backup_info.status == BackupInfo.WAITING_FOR_WALS:
                 output.warning(
                     "IMPORTANT: this backup is classified as "

--- a/tests/test_barman_cloud_backup_show.py
+++ b/tests/test_barman_cloud_backup_show.py
@@ -44,6 +44,7 @@ class TestCloudBackupShow(object):
             end_time=datetime.datetime(2038, 1, 19, 4, 14, 8),
             end_wal="000000010000000000000004",
             size=None,
+            data_checksums="on",
             snapshots_info=GcpSnapshotsInfo(
                 project="test_project",
                 snapshots=[
@@ -96,6 +97,7 @@ class TestCloudBackupShow(object):
             "  Status                 : DONE\n"
             "  PostgreSQL Version     : 150000\n"
             "  PGDATA directory       : /pgdata/location\n"
+            "  Checksums              : on\n"
             "\n"
             "  Snapshot information:\n"
             "    provider             : gcp\n"
@@ -173,6 +175,7 @@ class TestCloudBackupShow(object):
             "mode": "concurrent",
             "parent_backup_id": None,
             "pgdata": "/pgdata/location",
+            "data_checksums": "on",
             "server_name": "main",
             "size": None,
             "snapshots_info": {
@@ -215,7 +218,6 @@ class TestCloudBackupShow(object):
             "version": 150000,
             "xlog_segment_size": 16777216,
             "backup_id": "backup_id_1",
-            "data_checksums": None,
             "summarize_wal": None,
             "cluster_size": None,
         }

--- a/tests/test_barman_cloud_backup_show.py
+++ b/tests/test_barman_cloud_backup_show.py
@@ -215,6 +215,7 @@ class TestCloudBackupShow(object):
             "version": 150000,
             "xlog_segment_size": 16777216,
             "backup_id": "backup_id_1",
+            "data_checksums": None,
             "summarize_wal": None,
             "cluster_size": None,
         }

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1189,6 +1189,7 @@ class TestConsoleWriter(object):
             systemid="systemid",
             wal_until_next_compression_ratio=1.5,
             wals_per_second=wal_per_second,
+            data_checksums="on",
         )
 
         writer = output.ConsoleOutputWriter()
@@ -1202,6 +1203,7 @@ class TestConsoleWriter(object):
         assert ext_info["status"] in out
         assert str(ext_info["end_time"]) in out
         assert ext_info["systemid"] in out
+        assert "Checksums              : %s" % ext_info["data_checksums"] in out
         for name, _, location in ext_info["tablespaces"]:
             assert "{:<21}: {}".format(name, location) in out
         assert (pretty_size(ext_info["size"] + ext_info["wal_size"])) in out
@@ -1882,6 +1884,7 @@ class TestJsonWriter(object):
         assert server_name in json_output
         assert ext_info["backup_id"] == json_output[server_name]["backup_id"]
         assert ext_info["status"] == json_output[server_name]["status"]
+        assert ext_info["data_checksums"] == json_output[server_name]["data_checksums"]
         assert str(ext_info["end_time"]) == base_information["end_time"]
         assert self.end_epoch == base_information["end_time_timestamp"]
         assert self.begin_epoch == base_information["begin_time_timestamp"]

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -74,6 +74,7 @@ EXPECTED_MINIMAL = {
             "xlog_segment_size": 16777216,
             "systemid": None,
             "compression": None,
+            "data_checksums": None,
             "summarize_wal": None,
             "parent_backup_id": None,
             "children_backup_ids": None,

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -69,6 +69,7 @@ def build_test_backup_info(
     server=None,
     systemid=None,
     copy_stats=None,
+    data_checksums=None,
     summarize_wal=None,
     parent_backup_id=None,
     children_backup_ids=None,
@@ -105,6 +106,7 @@ def build_test_backup_info(
     :param int version: postgres version of the backup
     :param barman.server.Server|None server: Server object for the backup
     :param dict|None: Copy stats dictionary
+    :param str|None data_checksums: The checksum state (on/off)
     :param str|None: summarize_wal status flag
     :param str|None: parent_backup_id status flag
     :param list|None: children_backup_ids status flag


### PR DESCRIPTION
Postgres incremental backups have the risk of the user switching the `data_checkums` configuration on the server between backups, which could potentially cause problems during recovery. An attempt of reducing these cases is implemented in this PR, where we will now store the state of `data_checksums` in the `backup.info` file of each backup, which will allow Barman to check the consistency of the chain during backup and recovery execution and emit warnings to the user so they can take action about it.

- 67b16d71e2f5a3bea23b18348031c46b56d5f406 Add the new `data_checksums` config to the `backup.info` file
- eb68c24f4da496686aa1d8788f17e76f012ea40c Fix tests broken due to the new config added in the previous commit
- b116e52d4e363ae01d58f9f959763dda876ccc1e Add a new method `is_checksum_consistent` in the `LocalBackupInfo` class to check for the chain consistency. This check is performed on backup and recovery executions.
- c29a4c7787ca74c1e6d85ca2311e8ac021b4e548 Add tests to the new method `is_checksum_consistent` created in the previous commit
- ef79368719bd301f79e29b5b965caf7846a80f79 Add the new checksums config to be displayed on the show-backup command. Related tests were also modified in this same commit, since they were very small changes.