### PR TITLE
Add information to `barman show-backup` about incremental backups

### DIFF
--- a/barman/infofile.py
+++ b/barman/infofile.py
@@ -770,6 +770,35 @@ class LocalBackupInfo(BackupInfo):
             return "rsync"
         return "incremental" if self.is_incremental else "full"
 
+    @property
+    def deduplication_ratio(self):
+        """
+        Returns a value between and including ``0`` and ``1`` related to the estimate
+        deduplication ratio of the backup.
+
+        .. note::
+            For ``rsync`` backups, the :attr:`size` of the backup, which is the sum of
+            all file sizes in basebackup directory, is used to calculate the
+            ratio. For ``postgres`` backups, the :attr:`cluster_size` is used, which contains
+            the estimated size of the Postgres cluster at backup time.
+
+            We perform this calculation to make an estimation of how much network and disk
+            I/O has been saved when taking an incremental backup through ``rsync`` or through
+            ``pg_basebackup``.
+
+            We abuse of the term "deduplication" here. It makes more sense to ``rsync`` than to
+            ``postgres`` method. However, the idea is the same in both cases: get an estimation
+            of resources saving.
+
+        :return float: The backup deduplication ratio.
+        """
+        size = self.cluster_size
+        if self.backup_type == "rsync":
+            size = self.size
+        if size and self.deduplicated_size:
+            return 1 - (self.deduplicated_size / size)
+        return 0
+
     def get_list_of_files(self, target):
         """
         Get the list of files for the current backup

--- a/tests/test_barman_cloud_backup_show.py
+++ b/tests/test_barman_cloud_backup_show.py
@@ -43,8 +43,9 @@ class TestCloudBackupShow(object):
             begin_wal="000000010000000000000002",
             end_time=datetime.datetime(2038, 1, 19, 4, 14, 8),
             end_wal="000000010000000000000004",
-            size=None,
+            size=2048,
             data_checksums="on",
+            summarize_wal="on",
             snapshots_info=GcpSnapshotsInfo(
                 project="test_project",
                 snapshots=[
@@ -65,6 +66,8 @@ class TestCloudBackupShow(object):
                 ],
             ),
             version=150000,
+            cluster_size=2048,
+            deduplicated_size=1024,
         )
         backup_info.mode = "concurrent"
         cloud_backup_catalog = mock.Mock()
@@ -97,7 +100,11 @@ class TestCloudBackupShow(object):
             "  Status                 : DONE\n"
             "  PostgreSQL Version     : 150000\n"
             "  PGDATA directory       : /pgdata/location\n"
-            "  Checksums              : on\n"
+            "  Estimated Cluster Size : 2.0 KiB\n"
+            "\n"
+            "  Server information:\n"
+            "    Checksums            : on\n"
+            "    WAL summarizer       : on\n"
             "\n"
             "  Snapshot information:\n"
             "    provider             : gcp\n"
@@ -120,6 +127,8 @@ class TestCloudBackupShow(object):
             "    tbs2                 : /another/location (oid: 16405)\n"
             "\n"
             "  Base backup information:\n"
+            "    Backup Method        : concurrent\n"
+            "    Backup Size          : 1.0 KiB\n"
             "    Timeline             : 1\n"
             "    Begin WAL            : 000000010000000000000002\n"
             "    End WAL              : 000000010000000000000004\n"
@@ -160,10 +169,12 @@ class TestCloudBackupShow(object):
             "begin_wal": "000000010000000000000002",
             "begin_xlog": "0/2000028",
             "children_backup_ids": None,
+            "cluster_size": 2048,
             "compression": None,
             "config_file": "/pgdata/location/postgresql.conf",
             "copy_stats": None,
-            "deduplicated_size": None,
+            "data_checksums": "on",
+            "deduplicated_size": 1024,
             "end_offset": 184,
             "end_time": "Tue Jan 19 04:14:08 2038",
             "end_wal": "000000010000000000000004",
@@ -175,9 +186,8 @@ class TestCloudBackupShow(object):
             "mode": "concurrent",
             "parent_backup_id": None,
             "pgdata": "/pgdata/location",
-            "data_checksums": "on",
             "server_name": "main",
-            "size": None,
+            "size": 2048,
             "snapshots_info": {
                 "provider": "gcp",
                 "provider_info": {
@@ -209,6 +219,7 @@ class TestCloudBackupShow(object):
                 ],
             },
             "status": "DONE",
+            "summarize_wal": "on",
             "systemid": None,
             "tablespaces": [
                 ["tbs1", 16387, "/fake/location"],
@@ -218,8 +229,6 @@ class TestCloudBackupShow(object):
             "version": 150000,
             "xlog_segment_size": 16777216,
             "backup_id": "backup_id_1",
-            "summarize_wal": None,
-            "cluster_size": None,
         }
 
     @pytest.mark.parametrize("extra_args", [[], ["--format", "json"]])

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -874,7 +874,7 @@ class TestStrategy(object):
             Tablespace(name="tbs2", oid=16405, location="/another/location"),
         ]
         assert backup_info.summarize_wal is None
-        assert backup_info.cluster_size is None
+        assert backup_info.cluster_size == 2048
 
         strategy._pg_get_metadata(backup_info)
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -47,7 +47,7 @@ EXPECTED_MINIMAL = {
             "size": 12345,
             "server_name": "main",
             "begin_xlog": "0/2000028",
-            "deduplicated_size": None,
+            "deduplicated_size": 1024,
             "version": 90302,
             "ident_file": "/pgdata/location/pg_ident.conf",
             "end_time": "Wed Jul 23 12:00:43 2014",
@@ -78,7 +78,7 @@ EXPECTED_MINIMAL = {
             "summarize_wal": None,
             "parent_backup_id": None,
             "children_backup_ids": None,
-            "cluster_size": None,
+            "cluster_size": 2048,
         }
     },
     "config": {},
@@ -752,7 +752,10 @@ class TestSync(object):
 
         # Add a backup to the remote response
         primary_info = dict(EXPECTED_MINIMAL)
-        backup_info_dict = LocalBackupInfo(server, backup_id="1234567891").to_json()
+        backup_info_dict = LocalBackupInfo(
+            server,
+            backup_id="1234567891",
+        ).to_json()
         primary_info["backups"]["1234567891"] = backup_info_dict
         command_mock.return_value.out = json.dumps(primary_info)
         server.cron()

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -46,7 +46,7 @@ def build_test_backup_info(
     begin_xlog="0/2000028",
     compression=None,
     config_file="/pgdata/location/postgresql.conf",
-    deduplicated_size=None,
+    deduplicated_size=1024,
     end_offset=184,
     end_time=None,
     end_wal="000000010000000000000002",
@@ -74,7 +74,7 @@ def build_test_backup_info(
     summarize_wal=None,
     parent_backup_id=None,
     children_backup_ids=None,
-    cluster_size=None,
+    cluster_size=2048,
 ):
     """
     Create an 'Ad Hoc' BackupInfo object for testing purposes.
@@ -154,6 +154,15 @@ def mock_backup_ext_info(
     wal_until_next_compression_ratio=0.0,
     children_timelines=[],
     copy_stats={},
+    root_backup_id=None,
+    chain_size=None,
+    est_dedup_size=None,
+    deduplication_ratio=None,
+    backup_type=None,
+    copy_time=None,
+    analysis_time=None,
+    number_of_workers=None,
+    estimated_throughput=None,
     **kwargs
 ):
     # make a dictionary with all the arguments


### PR DESCRIPTION
Now that Postgres 17 have the ability to take incremental backups with pg_basebackup, there is a need to add new information to the show-backup command. 

This PR will:
1. Add fields to the `get_backup_ext_info` method from `Server` so we have extra information to be reused in the outputs.
2. Modify `output.py` to accommodate the new information that came with the introduction of incremental backups.
3. Fix tests broken by this implementation
4. Add unit tests according to use cases.


Note: 
The code in the output.py have to deal with two inputs: the result of the `get_backup_ext_info` method call **(which is a dictionary with the extra fields mentioned in 1.)** or backup_info.to_dict() **(which is for cloud-show-backup)**. 
The latter will not have the new fields mentioned in 1.  This is also the case for `--format json` for barman-cloud-backup-show. It relies on the backup_info.to_json() method. The code implemented is a little repetitive so we do not break the barman-cloud-backup-show command.

References: BAR-208 & BAR-214