### PR TITLE
Add full and incremental backup information to `list-backup`

### DIFF
--- a/barman/infofile.py
+++ b/barman/infofile.py
@@ -751,6 +751,22 @@ class LocalBackupInfo(BackupInfo):
         """
         return self.children_backup_ids is not None
 
+    @property
+    def backup_type(self):
+        """
+        Returns a string with the backup type label.
+
+        The backup type can be one of the following:
+        - ``rsync``: If the backup mode is "rsync``.
+        - ``incremental``: If the mode is ``postgres`` and the backup is incremental.
+        - ``full``: If the mode is ``postgres`` and the backup is not incremental.
+
+        :return str: The backup type label.
+        """
+        if self.mode != "postgres":
+            return "rsync"
+        return "incremental" if self.is_incremental else "full"
+
     def get_list_of_files(self, target):
         """
         Get the list of files for the current backup

--- a/barman/output.py
+++ b/barman/output.py
@@ -676,11 +676,14 @@ class ConsoleOutputWriter(object):
             self.info(backup_info.backup_id)
             return
 
-        out_list = ["%s %s " % (backup_info.server_name, backup_info.backup_id)]
+        out_list = ["%s %s" % (backup_info.server_name, backup_info.backup_id)]
+
         if backup_info.backup_name is not None:
-            out_list.append("'%s' - " % backup_info.backup_name)
-        else:
-            out_list.append("- ")
+            out_list.append(" '%s'" % backup_info.backup_name)
+
+        # Set backup type label
+        out_list.append(" - %s - " % backup_info.backup_type[0].upper())
+
         if backup_info.status in BackupInfo.STATUS_COPY_DONE:
             end_time = backup_info.end_time.ctime()
             out_list.append(
@@ -1471,12 +1474,13 @@ class JsonOutputWriter(ConsoleOutputWriter):
             self.json_output[server_name].append(backup_info.backup_id)
             return
 
-        output = dict(
-            backup_id=backup_info.backup_id,
-        )
+        output = dict(backup_id=backup_info.backup_id)
 
         if backup_info.backup_name is not None:
             output.update({"backup_name": backup_info.backup_name})
+
+        # Set backup type label
+        output.update({"backup_type": backup_info.backup_type})
 
         if backup_info.status in BackupInfo.STATUS_COPY_DONE:
             output.update(

--- a/tests/test_infofile.py
+++ b/tests/test_infofile.py
@@ -1277,6 +1277,23 @@ class TestLocalBackupInfo:
 
         assert not backup_info.is_full_and_eligible_for_incremental()
 
+    @pytest.mark.parametrize(
+        ("mode", "parent_backup_id", "expected_backup_type"),
+        [
+            ("rsync", None, "rsync"),
+            ("postgres", "some_id", "incremental"),
+            ("postgres", None, "full"),
+        ],
+    )
+    def test_backup_type(self, mode, parent_backup_id, expected_backup_type):
+        """
+        Ensure :meth:`LocalBackupInfo.backup_type` returns the correct backup type label.
+        """
+        backup_info = build_test_backup_info(parent_backup_id=parent_backup_id)
+        backup_info.mode = mode
+
+        assert backup_info.backup_type == expected_backup_type
+
 
 class TestSyntheticBackupInfo:
     """


### PR DESCRIPTION
Add a new label to each backup in the `list-backup` output that references the backup type considering:
 - R: for rsync backup
 - F: for full pg_basebackup
 - I: for incremental pg_basebackup

If a backup doesn't have a parent backup nor the backup method set to rsync, it's labeled as a full backup. This also adds a new field "backup_type" to the JSON output, containing the type label.

To get the correct backup type without relying on volatile information, a new property `backup_type` was added to the `LocalBackupInfo` object, which returns the label for `backup.info` at backup time instead of relying on the configuration at runtime. 

References: BAR-207