### PR TITLE
Get database cluster size and add to `backup.info`

### DIFF
--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -1787,6 +1787,9 @@ class BackupStrategy(with_metaclass(ABCMeta, object)):
             summarize_wal = self.postgres.get_setting("summarize_wal")
             backup_info.set_attribute("summarize_wal", summarize_wal)
 
+        # Set total size of the PostgreSQL server
+        backup_info.set_attribute("cluster_size", self.postgres.current_size)
+
     @staticmethod
     def _backup_info_from_start_location(backup_info, start_info):
         """

--- a/barman/infofile.py
+++ b/barman/infofile.py
@@ -531,6 +531,8 @@ class BackupInfo(FieldListFile):
         load=load_backup_ids,
     )
 
+    cluster_size = Field("cluster_size", load=int)
+
     __slots__ = "backup_id", "backup_version"
 
     _hide_if_null = ("backup_name", "snapshots_info")

--- a/tests/test_barman_cloud_backup_show.py
+++ b/tests/test_barman_cloud_backup_show.py
@@ -216,6 +216,7 @@ class TestCloudBackupShow(object):
             "xlog_segment_size": 16777216,
             "backup_id": "backup_id_1",
             "summarize_wal": None,
+            "cluster_size": None,
         }
 
     @pytest.mark.parametrize("extra_args", [[], ["--format", "json"]])

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -77,6 +77,7 @@ EXPECTED_MINIMAL = {
             "summarize_wal": None,
             "parent_backup_id": None,
             "children_backup_ids": None,
+            "cluster_size": None,
         }
     },
     "config": {},

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -72,6 +72,7 @@ def build_test_backup_info(
     summarize_wal=None,
     parent_backup_id=None,
     children_backup_ids=None,
+    cluster_size=None,
 ):
     """
     Create an 'Ad Hoc' BackupInfo object for testing purposes.
@@ -105,6 +106,9 @@ def build_test_backup_info(
     :param barman.server.Server|None server: Server object for the backup
     :param dict|None: Copy stats dictionary
     :param str|None: summarize_wal status flag
+    :param str|None: parent_backup_id status flag
+    :param list|None: children_backup_ids status flag
+    :param int|None: cluster_size status flag
     :rtype: barman.infofile.LocalBackupInfo
     """
     if begin_time is None:


### PR DESCRIPTION
After the introduction of incremental backups in Postgres 17, there is the need to review how we display information about backups, specially when using the `show-backup` command. Because of this need, we are adding the `cluster size` field to the backup.info. 
This new field is intended to be used in the calculation of the deduplication_ratio of backups and to show the estimated size of the Postgres cluster at the time the backup was taken. For this, we are reusing an existing property of the `PostgreSQLConnection` class called `current_size`.

The tests broken by the changes on the code were fixed.

Unit tests for the `current_size` property were added because they were found to missing from the test suite and the unit test for the `_pg_get_metadata` method of the `BackupStrategy` class was extended because of the changes in the method. 

References: BAR-215