### PR TITLE
Output info from the check-backup command

### DIFF
--- a/barman/backup.py
+++ b/barman/backup.py
@@ -1564,6 +1564,10 @@ class BackupManager(RemoteStatusMixin, KeepManagerMixin):
             )
             backup_info.status = BackupInfo.FAILED
             backup_info.save()
+            output.error(
+                "This backup has been marked as FAILED due to the "
+                "following reason: %s" % backup_info.error
+            )
             return
 
         if end_wal <= last_archived_wal:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2014,7 +2014,7 @@ class TestServer(object):
     @patch("barman.infofile.BackupInfo.save")
     @patch("os.path.exists")
     def test_check_backup(
-        self, mock_exists, backup_info_save, tmpdir, orig_exists=os.path.exists
+        self, mock_exists, backup_info_save, tmpdir, capsys, orig_exists=os.path.exists
     ):
         """
         Test the check_backup method
@@ -2090,6 +2090,8 @@ class TestServer(object):
             "The first missing WAL file is "
             "000000010000000000000003"
         )
+        _, err = capsys.readouterr()
+        assert backup_info.error in err
         backup_info_save.reset_mock()
 
         # Case 4: the more recent WAL archived is more recent than the end
@@ -2129,6 +2131,8 @@ class TestServer(object):
             "The first missing WAL file is "
             "000000010000000000000004"
         )
+        _, err = capsys.readouterr()
+        assert backup_info.error in err
         backup_info_save.reset_mock()
 
         # Case 4.3: we have all the files, but the backup is marked as


### PR DESCRIPTION
The `check-backup` command can mark a backup as failed if it notices that some of its required WAL files are missing. This works correctly, however no output is provided, so the only way to check why the backup has been marked as failed is by executing a `show-backup` on the backup. This commit fixes this issue by outputting the reason as an error message in the CLI.

Note: I though about using debug or warning log level, but considering that, as I've seen, there's a change of this happening also during a backup, I think it's better to display it with an error level instead. Also, if by any chance the user runs this manually they should be able to see the failure reason immediately on the screen I think.

References: BAR-213