### PR TITLE
Remove tablespace information from the `list-backup` output

### DIFF
--- a/barman/output.py
+++ b/barman/output.py
@@ -687,12 +687,6 @@ class ConsoleOutputWriter(object):
                 "%s - Size: %s - WAL Size: %s"
                 % (end_time, pretty_size(backup_size), pretty_size(wal_size))
             )
-            if backup_info.tablespaces:
-                tablespaces = [
-                    ("%s:%s" % (tablespace.name, tablespace.location))
-                    for tablespace in backup_info.tablespaces
-                ]
-                out_list.append(" (tablespaces: %s)" % ", ".join(tablespaces))
             if backup_info.status == BackupInfo.WAITING_FOR_WALS:
                 out_list.append(" - %s" % BackupInfo.WAITING_FOR_WALS)
             if retention_status and retention_status != BackupInfo.NONE:
@@ -1496,12 +1490,6 @@ class JsonOutputWriter(ConsoleOutputWriter):
                     retention_status=retention_status or BackupInfo.NONE,
                 )
             )
-            output["tablespaces"] = []
-            if backup_info.tablespaces:
-                for tablespace in backup_info.tablespaces:
-                    output["tablespaces"].append(
-                        dict(name=tablespace.name, location=tablespace.location)
-                    )
         else:
             output.update(dict(status=backup_info.status))
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1144,8 +1144,6 @@ class TestConsoleWriter(object):
         assert bi.server_name in out
         assert bi.backup_id in out
         assert str(bi.end_time.ctime()) in out
-        for name, _, location in bi.tablespaces:
-            assert "%s:%s" % (name, location)
         assert "Size: " + pretty_size(backup_size) in out
         assert "WAL Size: " + pretty_size(wal_size) in out
         assert err == ""
@@ -1816,10 +1814,6 @@ class TestJsonWriter(object):
         assert bi.backup_id == backup["backup_id"]
         assert str(bi.end_time.ctime()) == backup["end_time"]
         assert self.end_epoch == backup["end_time_timestamp"]
-        for name, _, location in bi.tablespaces:
-            tablespace = find_by_attr(backup["tablespaces"], "name", name)
-            assert name == tablespace["name"]
-            assert location == tablespace["location"]
         assert pretty_size(backup_size) == backup["size"]
         assert pretty_size(wal_size) == backup["wal_size"]
         assert err == ""


### PR DESCRIPTION
Displaying tablespace information for each backup often leads to unclean outputs in `list-backups`. Now, tablespace and other verbose information about each backup will only be shown by the `show-backups` command, while `list-backups` gets more concise.

References: BAR-216