### PR TITLE
Fix bug in `is_full_and_eligigle_for_incremental` method

### DIFF
--- a/barman/infofile.py
+++ b/barman/infofile.py
@@ -961,7 +961,7 @@ class LocalBackupInfo(BackupInfo):
         :return bool: True if it's a full backup or False if not.
         """
         if (
-            self.backup_manager.config.backup_method == "postgres"
+            self.mode == "postgres"
             and self.summarize_wal == "on"
             and not self.parent_backup_id
         ):


### PR DESCRIPTION
While working on the new list-backup (BAR-207), a bug was spotted in the method `is_full_and_eligible_for_incremental` from the `LocalBackupInfo` class.

The method was using the volatile information `backup_method` of the server configuration. This would be harmful if the user creates backups with backup_method='postgres' and changes to 'rsync'. When using list-backup or show-backup commands, the user would get an error. To fix this, we just need to use the `mode` field from the `backup.info` object, which is what this commit is doing.

References: BAR-228