### PR TITLE
Fix receive-wal command exiting with status 0 on errors

### DIFF
--- a/barman/server.py
+++ b/barman/server.py
@@ -2934,12 +2934,12 @@ class Server(RemoteStatusMixin):
         except LockFileBusy:
             # If another process is running for this server,
             if reset:
-                output.info(
+                output.error(
                     "Unable to reset the status of receive-wal "
                     "for server %s. Process is still running" % self.config.name
                 )
             else:
-                output.info(
+                output.error(
                     "Another receive-wal process is already running "
                     "for server %s." % self.config.name
                 )


### PR DESCRIPTION
Fixes #539 where some errors of the `receive-wal` command were exiting with a status of zero, indicating success. The referenced issue reports an error when using the `--reset` option, but the same also occurs with another error when you execute it without the flag and a receive-wal process is already running. This commit fixes both.

In the code, it was just a matter of using the proper logging type and the rest is already handled. Now both errors exit with a status different than zero:

```
[gustavo@localhost ~]$ barman receive-wal --reset pg17_server
ERROR: Unable to reset the status of receive-wal for server pg17_server. Process is still running
[gustavo@localhost ~]$ echo $?
1
```

```
[gustavo@localhost ~]$ barman receive-wal pg17_server
Starting receive-wal for server pg17_server
ERROR: Another receive-wal process is already running for server pg17_server.
[gustavo@localhost ~]$ echo $?
1
```

References: BAR-230
Closes: #539 