### PR TITLE
Fix python version in barman diagnose output

### DIFF
--- a/barman/fs.py
+++ b/barman/fs.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys
 import logging
 import re
 import shutil
@@ -265,8 +266,11 @@ class UnixLocalCommand(object):
 
         self.cmd("uname", args=["-a"])
         result["kernel_ver"] = self.internal_cmd.out.rstrip()
-        self.cmd("python", args=["--version", "2>&1"])
-        result["python_ver"] = self.internal_cmd.out.rstrip()
+        result["python_ver"] = "Python %s.%s.%s" % (
+            sys.version_info.major,
+            sys.version_info.minor,
+            sys.version_info.micro,
+        )
         self.cmd("rsync", args=["--version", "2>&1"])
         try:
             result["rsync_ver"] = self.internal_cmd.out.splitlines(True)[0].rstrip()


### PR DESCRIPTION
This PR fixes an issue with the `barman diagnose` command, where it was actually getting the Python version from the first Python interpreter found in the `PATH` environment variable instead of the one the Barman is actually using to run. This could lead to wrong outputs if the one found in `PATH` is different from the one that Barman is using. This was fixed by getting the version from the `sys` module instead of the `python --version` command which was previously.

There were no tests directly testing these outputs of the diagnose command so I didn't have to touch any tests for this fix.

An example:

I have Python 3.11 in my machine
```
[gustavo@localhost barman]$ python --version
Python 3.11.7
```

And Python 3.9 in a virtual env I created for Barman, this is what it actually uses
```
[gustavo@localhost barman]$ source venv/bin/activate
(venv) [gustavo@localhost barman]$ python --version
Python 3.9.18
```

When I run diagnose inside the virtual env, it displays correctly
```
(venv) [gustavo@localhost barman]$ barman diagnose
        "system_info": {
            "barman_ver": "3.10.1",
            "kernel_ver": "Linux localhost.localdomain 5.14.0-427.24.1.el9_4.aarch64 #1 SMP PREEMPT_DYNAMIC Mon Jul 8 12:55:19 EDT 2024 aarch64 aarch64 aarch64 GNU/Linux",
            "python_ver": "Python 3.9.18",
```

However, when I exit the virtual env and run it again, it displays the verion on my machine, which is not what Barman is using
```
(venv) [gustavo@localhost barman]$ deactivate
[gustavo@localhost barman]$ barman diagnose
        "system_info": {
            "barman_ver": "3.10.1",
            "kernel_ver": "Linux localhost.localdomain 5.14.0-427.24.1.el9_4.aarch64 #1 SMP PREEMPT_DYNAMIC Mon Jul 8 12:55:19 EDT 2024 aarch64 aarch64 aarch64 GNU/Linux",
            "python_ver": "Python 3.11.7",

```

References: BAR-247