### PR TITLE
Add check of backup compression when taking incremental backups

### DIFF
--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -44,6 +44,7 @@ def build_test_backup_info(
     begin_time=None,
     begin_wal="000000010000000000000002",
     begin_xlog="0/2000028",
+    compression=None,
     config_file="/pgdata/location/postgresql.conf",
     deduplicated_size=None,
     end_offset=184,


### PR DESCRIPTION
Backups taken with pg_basebackup can get compression. On the other hand, incremental backups with barman cannot leverage that feature yet because `barman recover` is not prepared to combine compressed backups, so barman needs to prevent users from taking backups with the `backup_compression` option set in the configuration file. For the same reason, Barman also needs to prevent users from taking incremental backups on top of backups that were compressed when taken.

This PR is adding those checks to be made before taking any incremental backup and the unit tests for both use cases.

References: BAR-253