### PR TITLE
Add note in the manual about recovery near retention policy

### DIFF
--- a/doc/manual/43-backup-commands.en.md
+++ b/doc/manual/43-backup-commands.en.md
@@ -198,6 +198,16 @@ command.
 
 The recovery command has several options that modify the command behavior.
 
+> **IMPORTANT:**
+> If you're unsure whether the backup you want to recover from will be
+> automatically deleted by retention policies during recovery,
+> mark it issuing the [keep command](#keep) using the appropriate target.
+> Once the recovery process is complete and your new PostgreSQL instance
+> has reached the desired recovery target, if you don’t want to
+> keep the backup beyond the retention policy, you can remove `keep`
+> annotation issuing the [keep command](#keep) again using the
+> `--release` option.
+
 ### Remote recovery
 
 Add the `--remote-ssh-command <COMMAND>` option to the invocation


### PR DESCRIPTION
This commit Closes: #200 .

It adds a note to the recovery section of the documentation manual. This note informs users about the risk of backup obsolescence and deletion during the recovery process, particularly when retention policy rules are enforced, and provides guidance on how to prevent this issue.

Initially, the team considered implementing an automatic solution for this problem. However, several concerns were raised, including the potential for unintended side effects during recovery, the existing `keep` feature designed to assist with backups, and the need for users to be fully aware of the implications and procedures during recovery—an operation often conducted under stressful situations.

References: BAR-222