### PR TITLE
Add doc about incremental backup recover in the manual

### DIFF
--- a/doc/barman.1.d/50-recover.md
+++ b/doc/barman.1.d/50-recover.md
@@ -106,6 +106,14 @@ recover *\[OPTIONS\]* *SERVER_NAME* *BACKUP_ID* *DESTINATION_DIRECTORY*
         This option is *required* when recovering from compressed backups and
         has no effect otherwise.
 
+    --local-staging-path *STAGING_PATH*
+    :   A path to a location on the barman host where the chain of backups will
+        be combined before being copied to the destination directory. Contents
+        created inside the staging path are removed at the
+        end of the recovery process. This option is *required* when recovering
+        from incremental backups (backup_method=postgres) and has no effect 
+        otherwise.
+
     --recovery-conf-filename *RECOVERY_CONF_FILENAME*
     :   The name of the file where Barman should write the PostgreSQL recovery
         options when recovering backups for PostgreSQL versions 12 and later.

--- a/doc/barman.5.d/50-local_staging_path.md
+++ b/doc/barman.5.d/50-local_staging_path.md
@@ -1,0 +1,8 @@
+local_staging_path
+:   A path to a location on the local host where incremental backups will
+    be combined during the recovery. This location must have enough
+    available space to temporarily hold the new synthetic backup. This 
+    option is *required* when recovering from an incremental backup and
+    has no effect otherwise.
+
+    Scope: Global/Server/Model.


### PR DESCRIPTION
There are changes in the behavior of barman recover with the new incremental backup feature. This PR will add the proper documentation about the recover of incremental backups.

This needs to address:
1.   Add note with a brief description of how Barman recovers the backups, mainly mentioning the use of pg_combinebackup, etc.
2.  Mention the use of the `local_staging_path` to place the `pg_combinebackup` synthetic backup.
3.  Add note, with links to the PG docs about checksums being on and off in different backups of a chain of backups.
4. Add field and details about `local_staging_path` to args in the man1 recover command documentation.

References: BAR-252