### PR TITLE
Add "snapshot" backup type to `list-backup` output

### DIFF
--- a/barman/infofile.py
+++ b/barman/infofile.py
@@ -757,13 +757,16 @@ class LocalBackupInfo(BackupInfo):
         Returns a string with the backup type label.
 
         The backup type can be one of the following:
-        - ``rsync``: If the backup mode is "rsync``.
+        - ``snapshot``: If the backup mode starts with ``snapshot``.
+        - ``rsync``: If the backup mode starts with ``rsync``.
         - ``incremental``: If the mode is ``postgres`` and the backup is incremental.
         - ``full``: If the mode is ``postgres`` and the backup is not incremental.
 
         :return str: The backup type label.
         """
-        if self.mode != "postgres":
+        if self.mode.startswith("snapshot"):
+            return "snapshot"
+        elif self.mode.startswith("rsync"):
             return "rsync"
         return "incremental" if self.is_incremental else "full"
 

--- a/tests/test_infofile.py
+++ b/tests/test_infofile.py
@@ -1283,6 +1283,7 @@ class TestLocalBackupInfo:
             ("rsync", None, "rsync"),
             ("postgres", "some_id", "incremental"),
             ("postgres", None, "full"),
+            ("snapshot", None, "snapshot"),
         ],
     )
     def test_backup_type(self, mode, parent_backup_id, expected_backup_type):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1156,7 +1156,7 @@ class TestConsoleWriter(object):
         writer.close()
         (out, err) = capsys.readouterr()
         assert not writer.minimal
-        assert "%s %s - R - %s" % (bi.server_name, bi.backup_id, bi.status) in out
+        assert "%s %s - S - %s" % (bi.server_name, bi.backup_id, bi.status) in out
 
     def test_result_list_backup_with_backup_name(self, capsys):
         # GIVEN a backup info with a backup_name
@@ -1176,12 +1176,12 @@ class TestConsoleWriter(object):
         # THEN the console output contains the backup name
         out, _err = capsys.readouterr()
         assert (
-            "%s %s '%s' - R - " % (bi.server_name, bi.backup_id, bi.backup_name) in out
+            "%s %s '%s' - S - " % (bi.server_name, bi.backup_id, bi.backup_name) in out
         )
 
     def test_result_list_backup_types(self, capsys):
         # GIVEN a backup info with a specific backup type
-        backup_types = ["rsync", "incremental", "full"]
+        backup_types = ["rsync", "incremental", "full", "snapshot"]
         backup_size = 12345
         wal_size = 54321
         retention_status = "test status"
@@ -1897,7 +1897,7 @@ class TestJsonWriter(object):
 
     def test_result_list_backup_types(self, capsys):
         # GIVEN a backup info with specific backup types
-        backup_types = ["rsync", "incremental", "full"]
+        backup_types = ["rsync", "incremental", "full", "snapshot"]
         backup_size = 12345
         wal_size = 54321
         retention_status = "test status"


### PR DESCRIPTION
Update `backup_type` property to also return the label for snapshot backups and adjust the unit tests accordingly. Since the updates to the `list-backup` command introduced by BAR-207 on adding backup type information to the output did not account for snapshot backups, this update fixes this oversight.

References: BAR-268