### PR TITLE
fixes and improvements on  `barman diagnose` command

### DIFF
--- a/barman/fs.py
+++ b/barman/fs.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys
 import logging
 import re
 import shutil
@@ -265,8 +266,11 @@ class UnixLocalCommand(object):
 
         self.cmd("uname", args=["-a"])
         result["kernel_ver"] = self.internal_cmd.out.rstrip()
-        self.cmd("python", args=["--version", "2>&1"])
-        result["python_ver"] = self.internal_cmd.out.rstrip()
+        result["python_ver"] = "Python %s.%s.%s" % (
+            sys.version_info.major,
+            sys.version_info.minor,
+            sys.version_info.micro,
+        )
         self.cmd("rsync", args=["--version", "2>&1"])
         try:
             result["rsync_ver"] = self.internal_cmd.out.splitlines(True)[0].rstrip()

--- a/barman/fs.py
+++ b/barman/fs.py
@@ -271,6 +271,7 @@ class UnixLocalCommand(object):
             sys.version_info.minor,
             sys.version_info.micro,
         )
+        result["python_executable"] = sys.executable
         self.cmd("rsync", args=["--version", "2>&1"])
         try:
             result["rsync_ver"] = self.internal_cmd.out.splitlines(True)[0].rstrip()


### PR DESCRIPTION
Opening a new PR as I got the wrong branch naming in #978

What this PR is doing:

c05da293ca531248d4f8a7ba47dbf81d78459592 fixes an issue with the barman diagnose command, where it was actually getting the Python version from the first Python interpreter found in the PATH environment variable instead of the one the Barman is actually using to run. This could lead to wrong outputs if the one found in PATH is different from the one that Barman is using. This was fixed by getting the version from the sys module instead of the python --version command which was previously.

c935a76ce380f19f4ca831caa24d0281bae6d17a adds also the Python executable path to the Barman diagnose output, as suggested by @gcalacoci

ba6956f1c99076d4a7557c666ba5285dde4c90b9 adds tests to the `get_system_info` method of the `UnixLocalCommand` as they were currently missing and is related to both previous modifications. These tests got bigger than expected for a short method because there are many cases for the `release` field of the output and i had to test them all.

References: BAR-232