### PR TITLE
Add docs about the new keep-alive mechanism

### DIFF
--- a/doc/barman.1.d/50-backup.md
+++ b/doc/barman.1.d/50-backup.md
@@ -75,6 +75,11 @@ backup *SERVER_NAME*
     :   the time, in seconds, spent waiting for the required WAL
         files to be archived before timing out
 
+    --keepalive-interval
+    :   an interval, in seconds, at which a hearbeat query will be sent to the
+        server to keep the libpq connection alive during an Rsync backup. Default
+        is 60. A value of 0 disables it.
+
     --manifest
     :   forces the creation of a backup manifest file at the end of a backup. 
         Overrides value of the parameter `autogenerate_manifest`, 

--- a/doc/barman.5.d/50-keepalive-interval.md
+++ b/doc/barman.5.d/50-keepalive-interval.md
@@ -1,0 +1,6 @@
+keepalive_interval
+:   An interval, in seconds, at which a hearbeat query will be sent to the
+    server to keep the libpq connection alive during an Rsync backup. Default
+    is 60. A value of 0 disables it.
+
+    Scope: Server.

--- a/doc/manual/26-rsync_backup.en.md
+++ b/doc/manual/26-rsync_backup.en.md
@@ -34,3 +34,11 @@ To take a backup use the `barman backup` command:
 barman@backup$ barman backup pg
 ```
 
+> **NOTE:**
+> Starting with Barman 3.11.0, Barman uses a keep-alive mechanism when taking
+> rsync-based backups. It keeps sending a simple `SELECT 1` query over the
+> libpq connection where Barman runs `pg_backup_start`/`pg_backup_stop`
+> low-level API functions, and it's in place to reduce the probability of a firewall or
+> a router dropping that connection as it can be idle for a long time while the base
+> backup is being copied. You can control the interval of the hearbeats, or even
+> disable the mechanism, through the `keepalive_interval` configuration option.


### PR DESCRIPTION
Add in the docs a description of the new `keepalive_interval` server configuration as well as your equivalent CLI argument `--keepalive-interval` that can be specifided together with the `backup` command.

References: BAR-256