### PR TITLE
Change docs related to `show-backup` command new output

### DIFF
--- a/doc/barman.1.d/50-show-backup.md
+++ b/doc/barman.1.d/50-show-backup.md
@@ -1,18 +1,27 @@
 show-backup *SERVER_NAME* *BACKUP_ID*
 :   Show detailed information about a particular backup, identified by
     the server name and the backup ID. See the [Backup ID shortcuts](#shortcuts)
-    section below for available shortcuts. For example:
+    section below for available shortcuts. The following example is from
+    a block-level incremental backup (which requires Postgres version >= 17):
 
 ```
-Backup 20150828T130001:
+Backup 20240814T017504:
   Server Name            : quagmire
   Status                 : DONE
   PostgreSQL Version     : 90402
   PGDATA directory       : /srv/postgresql/9.4/main/data
+  Estimated Cluster Size : 22.4 MiB
+
+  Server information:
+    Checksums            : on
+    WAL summarizer       : on
 
   Base backup information:
-    Disk usage           : 12.4 TiB (12.4 TiB with WALs)
-    Incremental size     : 4.9 TiB (-60.02%)
+    Backup Method        : postgres
+    Backup Type          : incremental
+    Backup Size          : 22.3 MiB (54.3 MiB with WALs)
+    WAL Size             : 32.0 MiB
+    Resource savings     : 19.5 MiB (86.80%)
     Timeline             : 1
     Begin WAL            : 0000000100000CFD000000AD
     End WAL              : 0000000100000D0D00000008
@@ -20,6 +29,8 @@ Backup 20150828T130001:
     WAL compression ratio: 79.51%
     Begin time           : 2015-08-28 13:00:01.633925+00:00
     End time             : 2015-08-29 10:27:06.522846+00:00
+    Copy time            : 1 second
+    Estimated throughput : 2.0 MiB/s
     Begin Offset         : 1575048
     End Offset           : 13853016
     Begin XLOG           : CFD/AD180888
@@ -36,4 +47,39 @@ Backup 20150828T130001:
     Retention Policy     : not enforced
     Previous Backup      : 20150821T130001
     Next Backup          : - (this is the latest base backup)
+    Root Backup          : 20240814T015504
+    Parent Backup        : 20240814T016504
+    Backup chain size    : 3
+    Children Backup(s)   : 20240814T018515
 ```
+
+> **NOTE:**
+> Depending on the version of your Postgres Server and/or the type
+> of the backup, the output of `barman show-backup` command may
+> be different. For example, fields like "Root Backup", "Parent Backup",
+> "Backup chain size", and "Children Backup(s)" only make sense when
+> showing information about a block-level incremental backup taken
+> with `backup_method = postgres` and using Postgres 17 or newer,
+> thus those fields are omitted for other kind of backups or older versions
+> of Postgres.
+>
+> Also note that `show-backup` relies on the backup metadata so if a backup
+> was created with Barman version 3.10 or earlier, the backup will not 
+> contain the fields added in version 3.11 (which are those added after
+> the introduction of "incremental" backups in PostgreSQL 17).
+>
+> These are the possible values for the field "Backup Type":
+>
+> * `rsync`: for a backup taken with `rsync`;
+> * `full`: for a full backup taken with `pg_basebackup`;
+> * `incremental`: for an incremental backup taken with `pg_basebackup`;
+> * `snapshot`: for a snapshot-based backup taken in the cloud.
+>
+> Below you can find a list of fields that may be shown or omitted depending
+> on the type of the backup:
+>
+> * `Resource savings`: available for "rsync" and "incremental" backups;
+> * `Root Backup`, `Parent Backup`, `Backup chain size`: available for 
+> "incremental" backups only;
+> * `Children Backup(s)`: available for "full" and "incremental" backups;
+> * `Snapshot information`: available for "snapshot" backups only.

--- a/doc/manual/50-feature-details.en.md
+++ b/doc/manual/50-feature-details.en.md
@@ -1226,6 +1226,9 @@ Backup 20230123T131430:
   PostgreSQL Version     : 140006
   PGDATA directory       : /opt/postgres/data
 
+  Server information:
+    Checksums            : on
+
   Snapshot information:
     provider             : gcp
     project              : project_id


### PR DESCRIPTION
After the introduction of incremental backups in PostgreSQL 17, new fields were added to the backup info and a new output of the show-backup command was implemented.

This PR is modifying the documentation so users can have a better sense of the show-backup output.

Summary of changes:

1. A small change was made in the "Backup metadata for snapshot backups" part in the manual.
2. A bigger change was made in the man1 where the `show-backup` command is explained and detailed.

References: BAR-275