### PR TITLE
Update docs according to changes to the `list-backup` command

### DIFF
--- a/doc/barman.1.d/50-list-backups.md
+++ b/doc/barman.1.d/50-list-backups.md
@@ -1,9 +1,13 @@
 list-backups *SERVER_NAME*
 :   Show available backups for `SERVER_NAME`. This command is useful to
-    retrieve a backup ID. For example:
+    retrieve a backup ID and the backup type. For example:
 
 ```
-servername 20111104T102647 - Fri Nov  4 10:26:48 2011 - Size: 17.0 MiB - WAL Size: 100 B
+servername 20111104T102647 - F - Fri Nov  4 10:26:48 2011 - Size: 17.0 MiB - WAL Size: 100 B
 ```
 
-    In this case, *20111104T102647* is the backup ID.
+In this case, *20111104T102647* is the backup ID, and `F` is the backup type label for a full backup taken with `pg_basebackup`. The backup type label displayed by this command takes one of the following values:
+    - `F`: for full backups taken with `pg_basebackup`
+    - `I`: for incremental backups taken with `pg_basebackup`
+    - `R`: for backups taken with `rsync`
+    - `S`: for cloud snapshot backups

--- a/doc/barman.1.d/50-list-backups.md
+++ b/doc/barman.1.d/50-list-backups.md
@@ -6,7 +6,7 @@ list-backups *SERVER_NAME*
 servername 20111104T102647 - F - Fri Nov  4 10:26:48 2011 - Size: 17.0 MiB - WAL Size: 100 B
 ```
 
-In this case, *20111104T102647* is the backup ID, and `F` is the backup type label for a full backup taken with `pg_basebackup`. The backup type label displayed by this command takes one of the following values:
+In this case, *20111104T102647* is the backup ID, and `F` is the backup type label for a full backup taken with `pg_basebackup`. The backup type label displayed by this command uses one of the following values:
     - `F`: for full backups taken with `pg_basebackup`
     - `I`: for incremental backups taken with `pg_basebackup`
     - `R`: for backups taken with `rsync`

--- a/doc/manual/42-server-commands.en.md
+++ b/doc/manual/42-server-commands.en.md
@@ -280,7 +280,8 @@ barman list-backups <server_name>
 > **TIP:** You can request a full list of the backups of all servers
 > using `all` as the server name.
 
-To have a machine-readable output you can use the `--minimal` option.
+To have a machine-readable output you can use the `--minimal` option, 
+and to have the output in JSON format use the `--format=json` option.
 
 ## `rebuild-xlogdb`
 

--- a/doc/manual/42-server-commands.en.md
+++ b/doc/manual/42-server-commands.en.md
@@ -280,8 +280,8 @@ barman list-backups <server_name>
 > **TIP:** You can request a full list of the backups of all servers
 > using `all` as the server name.
 
-To have a machine-readable output you can use the `--minimal` option, 
-and to have the output in JSON format use the `--format=json` option.
+To get a machine-readable output you can use the `--minimal` option, 
+and to get the output in JSON format you can use the `--format=json` option.
 
 ## `rebuild-xlogdb`
 


### PR DESCRIPTION
Update the docs according to the new output of the `list-backups` command, which now also displays the backup type, and complement information on how to generate the output in JSON format.

References: BAR-254