### PR TITLE
Change docs to introduce the new --incremental option

### DIFF
--- a/doc/barman.1.d/50-backup.md
+++ b/doc/barman.1.d/50-backup.md
@@ -19,6 +19,11 @@ backup *SERVER_NAME*
         Overrides value of the parameter `immediate_checkpoint`, if present
         in the configuration file.
 
+    --incremental [BACKUP_ID]
+    :   performs a block-level incremental backup. A `BACKUP_ID` or [backup ID shortcut](#shortcuts)
+        of a previous backup must be provided, which references a previous backup
+        in the catalog to be used as the parent backup from which the incremental is taken.
+
     --reuse-backup [INCREMENTAL_TYPE]
     :   Overrides `reuse_backup` option behaviour. Possible values for
         `INCREMENTAL_TYPE` are:

--- a/doc/barman.1.d/70-backup-id-shortcuts.md
+++ b/doc/barman.1.d/70-backup-id-shortcuts.md
@@ -17,3 +17,10 @@ oldest
 
 last-failed
 :   Latest failed backup, in chronological order.
+
+last-full
+:   Latest full-backup eligible for a block-level incremental backup using
+    the `--incremental` option.
+
+latest-full
+:   same as *last-full*

--- a/doc/manual/10-design.en.md
+++ b/doc/manual/10-design.en.md
@@ -64,9 +64,9 @@ Barman is able to take backups using either Rsync, which uses SSH as a transport
 Choosing one of these two methods is a decision you will need to make, however for general usage we recommend using streaming replication for all currently supported versions of PostgreSQL.
 
 > **IMPORTANT:** \newline
-> Because Barman transparently makes use of `pg_basebackup`, features such as incremental backup, parallel backup, and deduplication are currently not available. In this case, bandwidth limitation has some restrictions - compared to the traditional method via `rsync`.
+> Because Barman transparently makes use of `pg_basebackup`, features such as parallel backup are currently not available. In this case, bandwidth limitation has some restrictions - compared to the traditional method via `rsync`.
 
-Backup using `rsync`/SSH is recommended in all cases where `pg_basebackup` limitations occur (for example, a very large database that can benefit from incremental backup and deduplication).
+Backup using `rsync`/SSH is recommended in cases where `pg_basebackup` limitations pose an issue for you.
 
 The reason why we recommend streaming backup is that, based on our experience, it is easier to setup than the traditional one. Also, streaming backup allows you to backup a PostgreSQL server on Windows[^windows], and makes life easier when working with Docker.
 

--- a/doc/manual/25-streaming_backup.en.md
+++ b/doc/manual/25-streaming_backup.en.md
@@ -1,7 +1,9 @@
 ## Streaming backup
 
 Barman can backup a PostgreSQL server using the streaming connection,
-relying on `pg_basebackup`.
+relying on `pg_basebackup`. Since version 3.11, Barman also supports block-level
+incremental backups using the streaming connection, for more information
+consult the _"Features in detail"_ section.
 
 > **IMPORTANT:** Barman requires that `pg_basebackup` is installed in
 > the same server. It is recommended to install the last available 

--- a/doc/manual/26-rsync_backup.en.md
+++ b/doc/manual/26-rsync_backup.en.md
@@ -1,9 +1,10 @@
 ## Backup with `rsync`/SSH
 
-The backup over `rsync` was the only available method before 2.0, and
-is currently the only backup method that supports the incremental
-backup feature. Please consult the _"Features in detail"_ section for
-more information.
+The backup over `rsync` was the only method for backups in Barman before
+version 2.0, and before 3.11 it was the only method that supported incremental
+backups. Current Barman supports file-level as well as block-level incremental backups.
+Backups using `rsync` implements the file-level backup feature. Please consult the
+_"Features in detail"_ section for more information.
 
 To take a backup using `rsync` you need to put these parameters inside
 the Barman server configuration file:

--- a/doc/manual/42-server-commands.en.md
+++ b/doc/manual/42-server-commands.en.md
@@ -39,6 +39,9 @@ barman backup <server_name>
 > You can use `barman backup <server_1_name> <server_2_name>` to sequentially
 > backup both `<server_1_name>` and `<server_2_name>` servers.
 
+For information on how to take incremental backups in Barman, please check the
+[incremental backup section]{#incremental-backup}.
+
 Barman 2.10 introduces the `-w`/`--wait` option for the `backup` command.
 When set, Barman temporarily saves the state of the backup to
 `WAITING_FOR_WALS`, then waits for all the required WAL files to be


### PR DESCRIPTION
Change docs to explain the new `--incremental` option that can be used together with the `backup` command. Some sections which mentioned incremental backups are being something specific to Rsync were also changed to take the new block-level incremental option into account.

References: BAR-249