### PR TITLE
Replace checks on `parent_backup_id` with the property `is_incremental`

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -957,7 +957,7 @@ def recover(args):
 
     # If the backup to be recovered is incremental then there are additional
     # checks to be carried out
-    if backup_id.parent_backup_id is not None:
+    if backup_id.is_incremental:
         # Set the local staging path from the cli if it is set
         if args.local_staging_path is not None:
             try:
@@ -1863,7 +1863,7 @@ def keep(args):
             ) % (backup_info.backup_id, backup_info.status)
             output.error(msg)
             output.close_and_exit()
-        if backup_info.parent_backup_id:
+        if backup_info.is_incremental:
             msg = (
                 "Unable to execute the keep command on backup %s: is an incremental backup.\n"
                 "Only full backups are eligible for the use of the keep command."

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -2133,7 +2133,7 @@ def recovery_executor_factory(backup_manager, command, backup_info):
     :param: command barman.fs.UnixLocalCommand
     :return: RecoveryExecutor instance
     """
-    if backup_info.parent_backup_id is not None:
+    if backup_info.is_incremental:
         return IncrementalRecoveryExecutor(backup_manager)
     if backup_info.snapshots_info is not None:
         return SnapshotRecoveryExecutor(backup_manager)

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -2271,28 +2271,28 @@ class TestRecoveryExecutorFactory(object):
     @pytest.mark.parametrize(
         (
             "compression",
-            "parent_backup_id",
+            "is_incremental",
             "expected_executor",
             "snapshots_info",
             "should_error",
         ),
         [
             # No compression or snapshots_info should return RecoveryExecutor
-            (None, None, RecoveryExecutor, None, False),
+            (None, False, RecoveryExecutor, None, False),
             # Supported compression should return TarballRecoveryExecutor
-            ("gzip", None, TarballRecoveryExecutor, None, False),
+            ("gzip", False, TarballRecoveryExecutor, None, False),
             # Unrecognised compression should cause an error
-            ("snappy", None, None, None, True),
+            ("snappy", False, None, None, True),
             # A backup_info with snapshots_info should return SnapshotRecoveryExecutor
-            (None, None, SnapshotRecoveryExecutor, mock.Mock(), False),
+            (None, False, SnapshotRecoveryExecutor, mock.Mock(), False),
             # A backup with a parent_backup_id should return IncrementalRecoveryExecutor
-            (None, "some_parent_id", IncrementalRecoveryExecutor, None, False),
+            (None, True, IncrementalRecoveryExecutor, None, False),
         ],
     )
     def test_recovery_executor_factory(
         self,
         compression,
-        parent_backup_id,
+        is_incremental,
         expected_executor,
         snapshots_info,
         should_error,
@@ -2302,7 +2302,7 @@ class TestRecoveryExecutorFactory(object):
         mock_backup_info = mock.Mock(
             compression=compression,
             snapshots_info=snapshots_info,
-            parent_backup_id=parent_backup_id,
+            is_incremental=is_incremental,
         )
 
         # WHEN recovery_executor_factory is called with the specified compression


### PR DESCRIPTION
In the beginning of the implementation of the incremental backups when released with PostgreSQL 17, we introduced a `parent_backup_id` field to the BackupInfo class, and we had been using that to distinguish between incremental and non-incremental backups.

At some point we introduced a new property `is_incremental` which abstracts that logic. However, that property started being used in new code after that, but was not used in the places where there were already checks on `parent_backup_id`.

This PR is taking care of that and replacing all checks made with `parent_backup_id` for the property `is_incremental`. 
Also the unit tests were all modified according to the changes in implementation.

References: BAR-276