### PR TITLE
Add docs about the behavior of --target-time with no timezone

### DIFF
--- a/doc/manual/43-backup-commands.en.md
+++ b/doc/manual/43-backup-commands.en.md
@@ -251,6 +251,10 @@ the following mutually exclusive options:
 > the start and the end of a backup, you must recover from the
 > previous backup in the catalogue.
 
+> **IMPORTANT:**
+> If no timezone is specified when using `--target-time`, the timezone of the Barman
+> host will be used.
+
 You can use the `--exclusive` option to specify whether to stop immediately
 before or immediately after the recovery target.
 


### PR DESCRIPTION
Adds a note in the docs about the behavior of `--target-time` when no timezone is specified, in which case the Barman host timezone is used instead.

References: BAR-257