### PR TITLE
Rename `Resource savings` into `Resources saved`

### DIFF
--- a/barman/output.py
+++ b/barman/output.py
@@ -882,7 +882,7 @@ class ConsoleOutputWriter(object):
                 pretty_size(est_dedup_size),
                 "{percent:.2%}".format(percent=deduplication_ratio),
             )
-            output_fun(nested_row.format("Resource savings", dedupe_output))
+            output_fun(nested_row.format("Resources saved", dedupe_output))
 
         output_fun(nested_row.format("Timeline", backup_info["timeline"]))
         output_fun(nested_row.format("Begin WAL", backup_info["begin_wal"]))
@@ -1693,9 +1693,9 @@ class JsonOutputWriter(ConsoleOutputWriter):
             if backup_type and backup_type in {"rsync", "incremental"}:
                 output["base_backup_information"].update(
                     dict(
-                        resource_savings=pretty_size(data["est_dedup_size"]),
-                        resource_savings_bytes=int(data["est_dedup_size"]),
-                        resource_savings_percentage="{percent:.2%}".format(
+                        resources_saved=pretty_size(data["est_dedup_size"]),
+                        resources_saved_bytes=int(data["est_dedup_size"]),
+                        resources_saved_percentage="{percent:.2%}".format(
                             percent=data["deduplication_ratio"]
                         ),
                     )

--- a/doc/barman.1.d/50-show-backup.md
+++ b/doc/barman.1.d/50-show-backup.md
@@ -21,7 +21,7 @@ Backup 20240814T017504:
     Backup Type          : incremental
     Backup Size          : 22.3 MiB (54.3 MiB with WALs)
     WAL Size             : 32.0 MiB
-    Resource savings     : 19.5 MiB (86.80%)
+    Resources saved     : 19.5 MiB (86.80%)
     Timeline             : 1
     Begin WAL            : 0000000100000CFD000000AD
     End WAL              : 0000000100000D0D00000008
@@ -78,7 +78,7 @@ Backup 20240814T017504:
 > Below you can find a list of fields that may be shown or omitted depending
 > on the type of the backup:
 >
-> * `Resource savings`: available for "rsync" and "incremental" backups;
+> * `Resources saved`: available for "rsync" and "incremental" backups;
 > * `Root Backup`, `Parent Backup`, `Backup chain size`: available for 
 > "incremental" backups only;
 > * `Children Backup(s)`: available for "full" and "incremental" backups;

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1358,7 +1358,7 @@ class TestConsoleWriter(object):
         writer.close()
         (out, err) = capsys.readouterr()
 
-        resource_savings_output = "{} ({})".format(
+        resources_saved_output = "{} ({})".format(
             pretty_size(ext_info["est_dedup_size"]),
             "{percent:.2%}".format(percent=ext_info["deduplication_ratio"]),
         )
@@ -1367,7 +1367,7 @@ class TestConsoleWriter(object):
         if ext_info["backup_type"] in ("rsync", "incremental"):
             assert (
                 TestConsoleWriter.nested_row.format(
-                    "Resource savings", resource_savings_output
+                    "Resources saved", resources_saved_output
                 )
                 in out
             )
@@ -2248,15 +2248,14 @@ class TestJsonWriter(object):
 
         assert (
             pretty_size(ext_info["est_dedup_size"])
-            == base_information["resource_savings"]
+            == base_information["resources_saved"]
         )
-        assert ext_info["est_dedup_size"] == base_information["resource_savings_bytes"]
-        resource_savings_percentage = "{percent:.2%}".format(
+        assert ext_info["est_dedup_size"] == base_information["resources_saved_bytes"]
+        resources_saved_percentage = "{percent:.2%}".format(
             percent=ext_info["deduplication_ratio"]
         )
         assert (
-            resource_savings_percentage
-            == base_information["resource_savings_percentage"]
+            resources_saved_percentage == base_information["resources_saved_percentage"]
         )
 
         assert ext_info["timeline"] == base_information["timeline"]


### PR DESCRIPTION
Resources saved is a better and clearer name