### PR TITLE
Check for USAGE (instead of MEMBER) privilege in all pg_has_role occurrences

### DIFF
--- a/barman/postgres.py
+++ b/barman/postgres.py
@@ -610,11 +610,11 @@ class PostgreSQLConnection(PostgreSQL):
           OR
           (
             (
-              pg_has_role(CURRENT_USER, 'pg_monitor', 'MEMBER')
+              pg_has_role(CURRENT_USER, 'pg_monitor', 'USAGE')
               OR
               (
-                pg_has_role(CURRENT_USER, 'pg_read_all_settings', 'MEMBER')
-                AND pg_has_role(CURRENT_USER, 'pg_read_all_stats', 'MEMBER')
+                pg_has_role(CURRENT_USER, 'pg_read_all_settings', 'USAGE')
+                AND pg_has_role(CURRENT_USER, 'pg_read_all_stats', 'USAGE')
               )
             )
             AND
@@ -664,7 +664,7 @@ class PostgreSQLConnection(PostgreSQL):
             return True
         else:
             role_check_query = (
-                "select pg_has_role(CURRENT_USER ,'pg_checkpoint', 'MEMBER');"
+                "select pg_has_role(CURRENT_USER ,'pg_checkpoint', 'USAGE');"
             )
             try:
                 cur = self._cursor()
@@ -694,11 +694,11 @@ class PostgreSQLConnection(PostgreSQL):
             monitoring_check_query = """
             SELECT
             (
-                pg_has_role(CURRENT_USER, 'pg_monitor', 'MEMBER')
+                pg_has_role(CURRENT_USER, 'pg_monitor', 'USAGE')
                 OR
                 (
-                    pg_has_role(CURRENT_USER, 'pg_read_all_settings', 'MEMBER')
-                    AND pg_has_role(CURRENT_USER, 'pg_read_all_stats', 'MEMBER')
+                    pg_has_role(CURRENT_USER, 'pg_read_all_settings', 'USAGE')
+                    AND pg_has_role(CURRENT_USER, 'pg_read_all_stats', 'USAGE')
                 )
             )
             """

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1092,7 +1092,7 @@ class TestPostgres(object):
         cursor_mock.fetchone.side_effect = [(False,)]
         assert not server.postgres.has_checkpoint_privileges
         cursor_mock.execute.assert_called_with(
-            "select pg_has_role(CURRENT_USER ,'pg_checkpoint', 'MEMBER');"
+            "select pg_has_role(CURRENT_USER ,'pg_checkpoint', 'USAGE');"
         )
 
         # no superuser, pg_checkpoint -> True
@@ -1101,7 +1101,7 @@ class TestPostgres(object):
         cursor_mock.fetchone.side_effect = [(True,)]
         assert server.postgres.has_checkpoint_privileges
         cursor_mock.execute.assert_called_with(
-            "select pg_has_role(CURRENT_USER ,'pg_checkpoint', 'MEMBER');"
+            "select pg_has_role(CURRENT_USER ,'pg_checkpoint', 'USAGE');"
         )
 
         # superuser, no pg_checkpoint -> True
@@ -1718,11 +1718,11 @@ class TestPostgres(object):
                 """
             SELECT
             (
-                pg_has_role(CURRENT_USER, 'pg_monitor', 'MEMBER')
+                pg_has_role(CURRENT_USER, 'pg_monitor', 'USAGE')
                 OR
                 (
-                    pg_has_role(CURRENT_USER, 'pg_read_all_settings', 'MEMBER')
-                    AND pg_has_role(CURRENT_USER, 'pg_read_all_stats', 'MEMBER')
+                    pg_has_role(CURRENT_USER, 'pg_read_all_settings', 'USAGE')
+                    AND pg_has_role(CURRENT_USER, 'pg_read_all_stats', 'USAGE')
                 )
             )
             """


### PR DESCRIPTION
To work correctly Barman database user should be included in some roles ad this is checked by `pg_has_role` function.
In all `pg_has_role` functions `MEMBER` privilege is checked but in Barman code no `SET ROLE` is present so it better to check in `pg_has_role` functions `USAGE` privilege instead (that includes `INHERIT` check).

`pg_has_role` function documentation: https://www.postgresql.org/docs/16/functions-info.html#id-1.5.8.32.4.4.2.2.14.1.1.1

PR already discussed with @martinmarques here: https://github.com/EnterpriseDB/repmgr/pull/807#discussion_r1750197750