### PR TITLE
Add super linter to Barman

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,92 @@
+---
+# Copyright (C) 2024 EnterpriseDB
+
+name: Linters
+
+on:
+  pull_request:
+    branches:
+      - master
+
+  push:
+    branches:
+      - master
+
+  schedule:
+    # Lint code base every Monday 12:00 am. The idea here is to catch possible
+    # issues that were not detected during the normal development workflow.
+    - cron: '0 0 * * 1'
+
+  workflow_dispatch:
+    inputs:
+      source-ref:
+        description: Source code branch/ref name
+        default: master
+        required: true
+        type: string
+
+env:
+  SOURCE_REF: ${{ inputs.source-ref || github.ref }}
+  GITHUB_TOKEN: ${{ secrets.GH_SLONIK }}
+
+jobs:
+  run-super-linter:
+    name: Run super linter
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SOURCE_REF }}
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+
+      - name: Super-linter
+        uses: super-linter/super-linter/slim@v7
+        env:
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Linters configuration.
+          LINTER_RULES_PATH: '.'
+          # We are not interested in linting these files:
+          # * Markdown files under `doc` or `sphinx` directories, which belong to the
+          #   old docs, and are going to be replaced soon.
+          FILTER_REGEX_EXCLUDE: '(doc|sphinx)/.*\.md'
+          DOCKERFILE_HADOLINT_FILE_NAME: .hadolint.yaml
+          GITLEAKS_CONFIG_FILE: .gitleaks.toml
+          MARKDOWN_CONFIG_FILE: .markdownlint.yml
+          PYTHON_BLACK_CONFIG_FILE: .python-black
+          PYTHON_FLAKE8_CONFIG_FILE: tox.ini
+          PYTHON_ISORT_CONFIG_FILE: .isort.cfg
+          YAML_CONFIG_FILE: .yamllint.yml
+          YAML_ERROR_ON_WARNING: false
+          # On runs triggered by PRs we only lint the added/modified files.
+          VALIDATE_ALL_CODEBASE: ${{ github.event_name != 'pull_request' }}
+          # Validate file types used in the Barman repo.
+          # Bash because of bash scripts.
+          VALIDATE_BASH: true
+          VALIDATE_BASH_EXEC: true
+          # Dockerfile because we might add some of them soon.
+          VALIDATE_DOCKERFILE_HADOLINT: true
+          # Validate the own GitHub workflows and actions.
+          VALIDATE_GITHUB_ACTIONS: true
+          # Search for leaks in the repository.
+          VALIDATE_GITLEAKS: true
+          # Validate all documentation files from the repo.
+          VALIDATE_MARKDOWN: true
+          # Validate Python code.
+          VALIDATE_PYTHON_BLACK: true
+          VALIDATE_PYTHON_FLAKE8: true
+          VALIDATE_PYTHON_ISORT: true
+          # Validate YAML files from workflows.
+          VALIDATE_YAML: true

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,4 @@
+[extend]
+# useDefault will extend the base configuration with the default gitleaks config:
+# https://github.com/zricethezav/gitleaks/blob/master/config/gitleaks.toml
+useDefault = true

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,1 @@
+failure-threshold: error

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+profile = black
+multi_line_output = 3

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,8 @@
+# MD013/line-length : Line length : https://github.com/DavidAnson/markdownlint/blob/v0.34.0/doc/md013.md
+# We don't want the linter to fail just because line-length was exceeded.
+MD013: false
+# MD024/no-duplicate-heading: https://github.com/DavidAnson/markdownlint/blob/v0.34.0/doc/md024.md
+# We don't want the linter to fail when duplicated header names are found. That is not
+# relevant for us, and actually we rely on duplicated names when generating the RELNOTES.md
+# contents.
+MD024: false

--- a/.python-black
+++ b/.python-black
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 88

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,12 @@
+extends: default
+
+rules:
+  # comments should visibly make sense
+  comments:
+    level: error
+  comments-indentation:
+    level: error
+  # 88 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 88
+    level: warning


### PR DESCRIPTION
This PR is

* Adding the `linter.yml` workflow to the barman repository
* Adding the files that are referenced in the workflow
	* .gitleaks.toml
	* .hadolint.yaml
	* .isort.cfg
	* .markdownlint.yml
	* .python-black
	* .yamllint.yml

References: BAR-361