### PR TITLE
Run isort on code to remove unused imports and blank lines

### DIFF
--- a/barman/annotations.py
+++ b/barman/annotations.py
@@ -19,7 +19,6 @@
 import errno
 import io
 import os
-
 from abc import ABCMeta, abstractmethod
 
 from barman.exceptions import ArchivalBackupException

--- a/barman/backup.py
+++ b/barman/backup.py
@@ -39,17 +39,19 @@ from barman.backup_executor import (
     RsyncBackupExecutor,
     SnapshotBackupExecutor,
 )
+from barman.backup_manifest import BackupManifest
 from barman.cloud_providers import get_snapshot_interface_from_backup_info
+from barman.command_wrappers import PgVerifyBackup
 from barman.compression import CompressionManager
 from barman.config import BackupOptions
 from barman.exceptions import (
     AbortedRetryHookScript,
     BackupException,
+    CommandFailedException,
     CompressionIncompatibility,
     LockFileBusy,
     SshCommandException,
     UnknownBackupIdException,
-    CommandFailedException,
 )
 from barman.fs import unix_command_factory
 from barman.hooks import HookScriptRunner, RetryHookScriptRunner
@@ -57,18 +59,16 @@ from barman.infofile import BackupInfo, LocalBackupInfo, WalFileInfo
 from barman.lockfile import ServerBackupIdLock, ServerBackupSyncLock
 from barman.recovery_executor import recovery_executor_factory
 from barman.remote_status import RemoteStatusMixin
+from barman.storage.local_file_manager import LocalFileManager
 from barman.utils import (
+    SHA256,
     force_str,
     fsync_dir,
     fsync_file,
     get_backup_info_from_name,
     human_readable_timedelta,
     pretty_size,
-    SHA256,
 )
-from barman.command_wrappers import PgVerifyBackup
-from barman.storage.local_file_manager import LocalFileManager
-from barman.backup_manifest import BackupManifest
 
 _logger = logging.getLogger(__name__)
 

--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -34,10 +34,10 @@ import re
 import shutil
 from abc import ABCMeta, abstractmethod
 from contextlib import closing
+from distutils.version import LooseVersion as Version
 from functools import partial
 
 import dateutil.parser
-from distutils.version import LooseVersion as Version
 
 from barman import output, xlog
 from barman.cloud_providers import get_snapshot_interface_from_server_config
@@ -49,13 +49,13 @@ from barman.exceptions import (
     BackupException,
     CommandFailedException,
     DataTransferFailure,
+    FileNotFoundException,
     FsOperationFailed,
     PostgresConnectionError,
     PostgresConnectionLost,
     PostgresIsInRecovery,
     SnapshotBackupException,
     SshCommandException,
-    FileNotFoundException,
 )
 from barman.fs import UnixLocalCommand, UnixRemoteCommand, unix_command_factory
 from barman.infofile import BackupInfo

--- a/barman/backup_manifest.py
+++ b/barman/backup_manifest.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import json
+import os
 
 from barman.exceptions import BackupManifestException
 

--- a/barman/cli.py
+++ b/barman/cli.py
@@ -25,35 +25,17 @@ import json
 import logging
 import os
 import sys
-from argparse import (
-    SUPPRESS,
-    ArgumentTypeError,
-    ArgumentParser,
-    HelpFormatter,
-)
-
-from barman.lockfile import ConfigUpdateLock
-
-if sys.version_info.major < 3:
-    from argparse import Action, _SubParsersAction, _ActionsContainer
-try:
-    import argcomplete
-except ImportError:
-    argcomplete = None
+from argparse import SUPPRESS, ArgumentParser, ArgumentTypeError, HelpFormatter
 from collections import OrderedDict
 from contextlib import closing
-
 
 import barman.config
 import barman.diagnose
 import barman.utils
 from barman import output
 from barman.annotations import KeepManager
-from barman.config import (
-    ConfigChangesProcessor,
-    RecoveryOptions,
-    parse_staging_path,
-)
+from barman.backup_manifest import BackupManifest
+from barman.config import ConfigChangesProcessor, RecoveryOptions, parse_staging_path
 from barman.exceptions import (
     BadXlogSegmentName,
     LockFileBusy,
@@ -62,8 +44,12 @@ from barman.exceptions import (
     WalArchiveContentError,
 )
 from barman.infofile import BackupInfo, WalFileInfo
+from barman.lockfile import ConfigUpdateLock
 from barman.server import Server
+from barman.storage.local_file_manager import LocalFileManager
 from barman.utils import (
+    RESERVED_BACKUP_IDS,
+    SHA256,
     BarmanEncoder,
     check_backup_name,
     check_non_negative,
@@ -72,15 +58,19 @@ from barman.utils import (
     configure_logging,
     drop_privileges,
     force_str,
-    get_log_levels,
     get_backup_id_using_shortcut,
+    get_log_levels,
     parse_log_level,
-    RESERVED_BACKUP_IDS,
-    SHA256,
 )
 from barman.xlog import check_archive_usable
-from barman.backup_manifest import BackupManifest
-from barman.storage.local_file_manager import LocalFileManager
+
+if sys.version_info.major < 3:
+    from argparse import Action, _ActionsContainer, _SubParsersAction
+try:
+    import argcomplete
+except ImportError:
+    argcomplete = None
+
 
 _logger = logging.getLogger(__name__)
 

--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -24,17 +24,17 @@ from contextlib import closing
 from shutil import rmtree
 
 from barman.clients.cloud_cli import (
-    add_tag_argument,
-    create_argument_parser,
     GeneralErrorExit,
     NetworkErrorExit,
     OperationErrorExit,
     UrlArgumentType,
+    add_tag_argument,
+    create_argument_parser,
 )
 from barman.cloud import (
     CloudBackupSnapshot,
-    CloudBackupUploaderBarman,
     CloudBackupUploader,
+    CloudBackupUploaderBarman,
     configure_logging,
 )
 from barman.cloud_providers import get_cloud_interface, get_snapshot_interface

--- a/barman/clients/cloud_backup_delete.py
+++ b/barman/clients/cloud_backup_delete.py
@@ -21,13 +21,14 @@ import os
 from contextlib import closing
 from operator import attrgetter
 
+from barman import xlog
 from barman.backup import BackupManager
 from barman.clients.cloud_cli import (
-    create_argument_parser,
     CLIErrorExit,
     GeneralErrorExit,
     NetworkErrorExit,
     OperationErrorExit,
+    create_argument_parser,
 )
 from barman.cloud import CloudBackupCatalog, configure_logging
 from barman.cloud_providers import (
@@ -37,7 +38,6 @@ from barman.cloud_providers import (
 from barman.exceptions import BadXlogPrefix, InvalidRetentionPolicy
 from barman.retention_policies import RetentionPolicyFactory
 from barman.utils import check_non_negative, force_str
-from barman import xlog
 
 
 def _get_files_for_backup(catalog, backup_info):

--- a/barman/clients/cloud_backup_keep.py
+++ b/barman/clients/cloud_backup_keep.py
@@ -21,10 +21,10 @@ from contextlib import closing
 
 from barman.annotations import KeepManager
 from barman.clients.cloud_cli import (
-    create_argument_parser,
     GeneralErrorExit,
     NetworkErrorExit,
     OperationErrorExit,
+    create_argument_parser,
 )
 from barman.cloud import CloudBackupCatalog, configure_logging
 from barman.cloud_providers import get_cloud_interface

--- a/barman/clients/cloud_backup_list.py
+++ b/barman/clients/cloud_backup_list.py
@@ -21,10 +21,10 @@ import logging
 from contextlib import closing
 
 from barman.clients.cloud_cli import (
-    create_argument_parser,
     GeneralErrorExit,
     NetworkErrorExit,
     OperationErrorExit,
+    create_argument_parser,
 )
 from barman.cloud import CloudBackupCatalog, configure_logging
 from barman.cloud_providers import get_cloud_interface

--- a/barman/clients/cloud_backup_show.py
+++ b/barman/clients/cloud_backup_show.py
@@ -23,10 +23,10 @@ import logging
 from contextlib import closing
 
 from barman.clients.cloud_cli import (
-    create_argument_parser,
     GeneralErrorExit,
     NetworkErrorExit,
     OperationErrorExit,
+    create_argument_parser,
 )
 from barman.cloud import CloudBackupCatalog, configure_logging
 from barman.cloud_providers import get_cloud_interface

--- a/barman/clients/cloud_check_wal_archive.py
+++ b/barman/clients/cloud_check_wal_archive.py
@@ -19,16 +19,16 @@
 import logging
 
 from barman.clients.cloud_cli import (
-    create_argument_parser,
     GeneralErrorExit,
-    OperationErrorExit,
     NetworkErrorExit,
+    OperationErrorExit,
     UrlArgumentType,
+    create_argument_parser,
 )
-from barman.cloud import configure_logging, CloudBackupCatalog
+from barman.cloud import CloudBackupCatalog, configure_logging
 from barman.cloud_providers import get_cloud_interface
 from barman.exceptions import WalArchiveContentError
-from barman.utils import force_str, check_positive
+from barman.utils import check_positive, force_str
 from barman.xlog import check_archive_usable
 
 

--- a/barman/clients/cloud_cli.py
+++ b/barman/clients/cloud_cli.py
@@ -17,7 +17,6 @@
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
-
 import csv
 import logging
 

--- a/barman/clients/cloud_restore.py
+++ b/barman/clients/cloud_restore.py
@@ -15,17 +15,17 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
-from abc import ABCMeta, abstractmethod
 import logging
 import os
+from abc import ABCMeta, abstractmethod
 from contextlib import closing
 
 from barman.clients.cloud_cli import (
     CLIErrorExit,
-    create_argument_parser,
     GeneralErrorExit,
     NetworkErrorExit,
     OperationErrorExit,
+    create_argument_parser,
 )
 from barman.cloud import CloudBackupCatalog, configure_logging
 from barman.cloud_providers import (

--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -22,15 +22,15 @@ import os.path
 from contextlib import closing
 
 from barman.clients.cloud_cli import (
-    add_tag_argument,
-    create_argument_parser,
     CLIErrorExit,
     GeneralErrorExit,
     NetworkErrorExit,
     UrlArgumentType,
+    add_tag_argument,
+    create_argument_parser,
 )
-from barman.cloud import configure_logging
 from barman.clients.cloud_compression import compress
+from barman.cloud import configure_logging
 from barman.cloud_providers import get_cloud_interface
 from barman.exceptions import BarmanException
 from barman.utils import check_positive, check_size, force_str

--- a/barman/clients/cloud_walrestore.py
+++ b/barman/clients/cloud_walrestore.py
@@ -22,13 +22,13 @@ import sys
 from contextlib import closing
 
 from barman.clients.cloud_cli import (
-    create_argument_parser,
     CLIErrorExit,
     GeneralErrorExit,
     NetworkErrorExit,
     OperationErrorExit,
+    create_argument_parser,
 )
-from barman.cloud import configure_logging, ALLOWED_COMPRESSIONS
+from barman.cloud import ALLOWED_COMPRESSIONS, configure_logging
 from barman.cloud_providers import get_cloud_interface
 from barman.exceptions import BarmanException
 from barman.utils import force_str

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -34,14 +34,15 @@ from functools import partial
 from io import BytesIO, RawIOBase
 from tempfile import NamedTemporaryFile
 
+from barman import xlog
 from barman.annotations import KeepManagerMixinCloud
 from barman.backup_executor import ConcurrentBackupStrategy, SnapshotBackupExecutor
 from barman.clients import cloud_compression
 from barman.clients.cloud_cli import get_missing_attrs
 from barman.exceptions import (
+    BackupException,
     BackupPreconditionException,
     BarmanException,
-    BackupException,
     ConfigurationException,
 )
 from barman.fs import UnixLocalCommand, path_allowed
@@ -58,7 +59,6 @@ from barman.utils import (
     total_seconds,
     with_metaclass,
 )
-from barman import xlog
 
 try:
     # Python 3.x

--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -350,15 +350,11 @@ def snapshots_info_from_dict(snapshots_info):
 
         return GcpSnapshotsInfo.from_dict(snapshots_info)
     elif "provider" in snapshots_info and snapshots_info["provider"] == "azure":
-        from barman.cloud_providers.azure_blob_storage import (
-            AzureSnapshotsInfo,
-        )
+        from barman.cloud_providers.azure_blob_storage import AzureSnapshotsInfo
 
         return AzureSnapshotsInfo.from_dict(snapshots_info)
     elif "provider" in snapshots_info and snapshots_info["provider"] == "aws":
-        from barman.cloud_providers.aws_s3 import (
-            AwsSnapshotsInfo,
-        )
+        from barman.cloud_providers.aws_s3 import AwsSnapshotsInfo
 
         return AwsSnapshotsInfo.from_dict(snapshots_info)
     else:

--- a/barman/cloud_providers/aws_s3.py
+++ b/barman/cloud_providers/aws_s3.py
@@ -23,11 +23,11 @@ from io import RawIOBase
 
 from barman.clients.cloud_compression import decompress_to_file
 from barman.cloud import (
+    DEFAULT_DELIMITER,
     CloudInterface,
     CloudProviderError,
     CloudSnapshotInterface,
     DecompressingStreamingIO,
-    DEFAULT_DELIMITER,
     SnapshotMetadata,
     SnapshotsInfo,
     VolumeMetadata,
@@ -38,14 +38,14 @@ from barman.exceptions import (
     SnapshotInstanceNotFoundException,
 )
 
-
 try:
     # Python 3.x
     from urllib.parse import urlencode, urlparse
 except ImportError:
     # Python 2.x
-    from urlparse import urlparse
     from urllib import urlencode
+
+    from urlparse import urlparse
 
 try:
     import boto3

--- a/barman/cloud_providers/azure_blob_storage.py
+++ b/barman/cloud_providers/azure_blob_storage.py
@@ -19,16 +19,17 @@
 import logging
 import os
 import re
+from io import SEEK_END, BytesIO, RawIOBase
+
 import requests
-from io import BytesIO, RawIOBase, SEEK_END
 
 from barman.clients.cloud_compression import decompress_to_file
 from barman.cloud import (
+    DEFAULT_DELIMITER,
     CloudInterface,
     CloudProviderError,
     CloudSnapshotInterface,
     DecompressingStreamingIO,
-    DEFAULT_DELIMITER,
     SnapshotMetadata,
     SnapshotsInfo,
     VolumeMetadata,
@@ -43,15 +44,12 @@ except ImportError:
     from urlparse import urlparse
 
 try:
-    from azure.storage.blob import (
-        ContainerClient,
-        PartialBatchErrorException,
-    )
     from azure.core.exceptions import (
         HttpResponseError,
         ResourceNotFoundError,
         ServiceRequestError,
     )
+    from azure.storage.blob import ContainerClient, PartialBatchErrorException
 except ImportError:
     raise SystemExit("Missing required python module: azure-storage-blob")
 

--- a/barman/cloud_providers/google_cloud_storage.py
+++ b/barman/cloud_providers/google_cloud_storage.py
@@ -22,16 +22,15 @@ import posixpath
 
 from barman.clients.cloud_compression import decompress_to_file
 from barman.cloud import (
+    DEFAULT_DELIMITER,
     CloudInterface,
     CloudProviderError,
     CloudSnapshotInterface,
     DecompressingStreamingIO,
-    DEFAULT_DELIMITER,
     SnapshotMetadata,
     SnapshotsInfo,
     VolumeMetadata,
 )
-
 from barman.exceptions import CommandException, SnapshotBackupException
 
 try:
@@ -42,8 +41,8 @@ except ImportError:
     from urlparse import urlparse
 
 try:
+    from google.api_core.exceptions import Conflict, GoogleAPIError, NotFound
     from google.cloud import storage
-    from google.api_core.exceptions import GoogleAPIError, Conflict, NotFound
 except ImportError:
     raise SystemExit("Missing required python module: google-cloud-storage")
 

--- a/barman/command_wrappers.py
+++ b/barman/command_wrappers.py
@@ -32,7 +32,6 @@ import signal
 import subprocess
 import sys
 import time
-
 from distutils.version import LooseVersion as Version
 
 import barman.utils

--- a/barman/compression.py
+++ b/barman/compression.py
@@ -31,13 +31,13 @@ from distutils.version import LooseVersion as Version
 
 import barman.infofile
 from barman.command_wrappers import Command
-from barman.fs import unix_command_factory
 from barman.exceptions import (
     CommandFailedException,
     CompressionException,
     CompressionIncompatibility,
     FileNotFoundException,
 )
+from barman.fs import unix_command_factory
 from barman.utils import force_str, with_metaclass
 
 _logger = logging.getLogger(__name__)

--- a/barman/compression.py
+++ b/barman/compression.py
@@ -63,7 +63,7 @@ class CompressionManager(object):
             # If custom_compression_magic is set then we should not assume
             # unidentified files are custom compressed and should rely on the
             # magic for identification instead.
-            elif type(config.custom_compression_magic) == str:
+            elif isinstance(config.custom_compression_magic, str):
                 # Since we know the custom compression magic we can now add it
                 # to the class property.
                 compression_registry["custom"].MAGIC = binascii.unhexlify(
@@ -419,14 +419,12 @@ class CustomCompressor(CommandCompressor):
         :param compression: str compression name
         :param path: str|None
         """
-        if (
-            config.custom_compression_filter is None
-            or type(config.custom_compression_filter) != str
+        if config.custom_compression_filter is None or not isinstance(
+            config.custom_compression_filter, str
         ):
             raise CompressionIncompatibility("custom_compression_filter")
-        if (
-            config.custom_decompression_filter is None
-            or type(config.custom_decompression_filter) != str
+        if config.custom_decompression_filter is None or not isinstance(
+            config.custom_decompression_filter, str
         ):
             raise CompressionIncompatibility("custom_decompression_filter")
 

--- a/barman/config.py
+++ b/barman/config.py
@@ -21,7 +21,6 @@ This module is responsible for all the things related to
 Barman configuration, such as parsing configuration file.
 """
 
-from copy import deepcopy
 import collections
 import datetime
 import inspect
@@ -30,6 +29,7 @@ import logging.handlers
 import os
 import re
 import sys
+from copy import deepcopy
 from glob import iglob
 from typing import List
 

--- a/barman/diagnose.py
+++ b/barman/diagnose.py
@@ -21,9 +21,10 @@ This module represents the barman diagnostic tool.
 """
 
 import datetime
-from dateutil import tz
 import json
 import logging
+
+from dateutil import tz
 
 import barman
 from barman import fs, output

--- a/barman/fs.py
+++ b/barman/fs.py
@@ -16,10 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
 import logging
 import re
 import shutil
+import sys
 from abc import ABCMeta, abstractmethod
 
 from barman import output

--- a/barman/postgres.py
+++ b/barman/postgres.py
@@ -23,17 +23,12 @@ This module represents the interface towards a PostgreSQL server.
 import atexit
 import datetime
 import logging
-from abc import ABCMeta
-from multiprocessing import Process, Queue
 import os
 import signal
 import threading
 import time
-
-try:
-    from queue import Empty
-except ImportError:
-    from Queue import Empty
+from abc import ABCMeta
+from multiprocessing import Process, Queue
 
 import psycopg2
 from psycopg2.errorcodes import DUPLICATE_OBJECT, OBJECT_IN_USE, UNDEFINED_OBJECT
@@ -41,8 +36,10 @@ from psycopg2.extensions import STATUS_IN_TRANSACTION, STATUS_READY
 from psycopg2.extras import DictCursor, NamedTupleCursor
 
 from barman.exceptions import (
+    BackupFunctionsAccessRequired,
     ConninfoException,
     PostgresAppNameError,
+    PostgresCheckpointPrivilegesRequired,
     PostgresConnectionError,
     PostgresConnectionLost,
     PostgresDuplicateReplicationSlot,
@@ -52,14 +49,17 @@ from barman.exceptions import (
     PostgresObsoleteFeature,
     PostgresReplicationSlotInUse,
     PostgresReplicationSlotsFull,
-    BackupFunctionsAccessRequired,
-    PostgresCheckpointPrivilegesRequired,
     PostgresUnsupportedFeature,
 )
 from barman.infofile import Tablespace
 from barman.postgres_plumbing import function_name_map
 from barman.remote_status import RemoteStatusMixin
 from barman.utils import force_str, simplify_version, with_metaclass
+
+try:
+    from queue import Empty
+except ImportError:
+    from Queue import Empty
 
 # This is necessary because the CONFIGURATION_LIMIT_EXCEEDED constant
 # has been added in psycopg2 2.5, but Barman supports version 2.4.2+ so

--- a/barman/recovery_executor.py
+++ b/barman/recovery_executor.py
@@ -24,22 +24,28 @@ from __future__ import print_function
 
 import collections
 import datetime
-
-from functools import partial
 import logging
 import os
 import re
 import shutil
 import socket
 import tempfile
+from functools import partial
 from io import BytesIO
 
 import dateutil.parser
 import dateutil.tz
 
+import barman.fs as fs
 from barman import output, xlog
 from barman.cloud_providers import get_snapshot_interface_from_backup_info
 from barman.command_wrappers import PgCombineBackup, RsyncPgData
+from barman.compression import (
+    GZipCompression,
+    LZ4Compression,
+    NoneCompression,
+    ZSTDCompression,
+)
 from barman.config import RecoveryOptions
 from barman.copy_controller import RsyncCopyController
 from barman.exceptions import (
@@ -48,18 +54,11 @@ from barman.exceptions import (
     DataTransferFailure,
     FsOperationFailed,
     RecoveryInvalidTargetException,
+    RecoveryPreconditionException,
     RecoveryStandbyModeException,
     RecoveryTargetActionException,
-    RecoveryPreconditionException,
     SnapshotBackupException,
 )
-from barman.compression import (
-    GZipCompression,
-    LZ4Compression,
-    ZSTDCompression,
-    NoneCompression,
-)
-import barman.fs as fs
 from barman.infofile import BackupInfo, LocalBackupInfo, SyntheticBackupInfo
 from barman.utils import force_str, mkpath, total_seconds
 

--- a/barman/server.py
+++ b/barman/server.py
@@ -52,6 +52,7 @@ from barman.exceptions import (
     LockFileBusy,
     LockFileException,
     LockFilePermissionDenied,
+    PostgresCheckpointPrivilegesRequired,
     PostgresDuplicateReplicationSlot,
     PostgresException,
     PostgresInvalidReplicationSlot,
@@ -60,7 +61,6 @@ from barman.exceptions import (
     PostgresReplicationSlotInUse,
     PostgresReplicationSlotsFull,
     PostgresSuperuserRequired,
-    PostgresCheckpointPrivilegesRequired,
     PostgresUnsupportedFeature,
     SyncError,
     SyncNothingToDo,
@@ -80,14 +80,14 @@ from barman.lockfile import (
     ServerXLOGDBLock,
 )
 from barman.postgres import (
+    PostgreSQL,
     PostgreSQLConnection,
     StandbyPostgreSQLConnection,
     StreamingConnection,
-    PostgreSQL,
 )
 from barman.process import ProcessManager
 from barman.remote_status import RemoteStatusMixin
-from barman.retention_policies import RetentionPolicyFactory, RetentionPolicy
+from barman.retention_policies import RetentionPolicy, RetentionPolicyFactory
 from barman.utils import (
     BarmanEncoder,
     file_md5,

--- a/barman/storage/file_manager.py
+++ b/barman/storage/file_manager.py
@@ -17,6 +17,7 @@
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
 from abc import ABCMeta, abstractmethod
+
 from barman.utils import with_metaclass
 
 

--- a/barman/storage/local_file_manager.py
+++ b/barman/storage/local_file_manager.py
@@ -17,6 +17,7 @@
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+
 from .file_manager import FileManager
 from .file_stats import FileStats
 

--- a/barman/utils.py
+++ b/barman/utils.py
@@ -23,7 +23,6 @@ This module contains utility functions used in Barman.
 import datetime
 import decimal
 import errno
-from glob import glob
 import grp
 import hashlib
 import json
@@ -34,14 +33,15 @@ import pwd
 import re
 import signal
 import sys
-from argparse import ArgumentTypeError
 from abc import ABCMeta, abstractmethod
+from argparse import ArgumentTypeError
 from contextlib import contextmanager
+from distutils.version import Version
+from glob import glob
+
 from dateutil import tz
 
-from distutils.version import Version
 from barman import lockfile
-
 from barman.exceptions import TimeoutError
 
 _logger = logging.getLogger(__name__)

--- a/barman/wal_archiver.py
+++ b/barman/wal_archiver.py
@@ -24,9 +24,8 @@ import logging
 import os
 import shutil
 from abc import ABCMeta, abstractmethod
-from glob import glob
-
 from distutils.version import LooseVersion as Version
+from glob import glob
 
 from barman import output, xlog
 from barman.command_wrappers import CommandFailedException, PgReceiveXlog

--- a/scripts/prepare_snapshot_recovery.py
+++ b/scripts/prepare_snapshot_recovery.py
@@ -23,13 +23,13 @@ import re
 import sys
 from typing import Any, NamedTuple
 
-from barman.cli import get_server, global_config, parse_backup_id
-from barman.fs import unix_command_factory
-from barman.cloud_providers.google_cloud_storage import GcpCloudSnapshotInterface
-
-from google.api_core.exceptions import NotFound, GoogleAPICallError
+from google.api_core.exceptions import GoogleAPICallError, NotFound
 from google.api_core.extended_operation import ExtendedOperation
 from google.cloud import compute
+
+from barman.cli import get_server, global_config, parse_backup_id
+from barman.cloud_providers.google_cloud_storage import GcpCloudSnapshotInterface
+from barman.fs import unix_command_factory
 
 if sys.version_info.major < 3 or sys.version_info.minor < 7:
     print("Minimal python version is 3.7")

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -20,9 +20,10 @@
 import os
 import re
 import sys
+from distutils.version import LooseVersion
 
 import sphinx_bootstrap_theme
-from distutils.version import LooseVersion
+
 from sphinx import __version__ as sphinx_version
 
 # read barman_dir from the environment

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,10 @@
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+
+import mock
 import psycopg2
 import pytest
-import mock
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/storage/test_local_file_manager.py
+++ b/tests/storage/test_local_file_manager.py
@@ -18,6 +18,7 @@
 
 import pytest
 from mock import patch
+
 from barman.storage.local_file_manager import LocalFileManager
 
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -17,8 +17,9 @@
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
-import mock
 import os
+
+import mock
 import pytest
 
 from barman.annotations import (

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -26,21 +26,7 @@ import dateutil.parser
 import dateutil.tz
 import mock
 import pytest
-from mock import Mock, patch, call
-from barman.backup import BackupManager
-from barman.lockfile import ServerBackupIdLock
-
-import barman.utils
-from barman.annotations import KeepManager
-from barman.config import BackupOptions
-from barman.exceptions import (
-    BackupException,
-    CompressionIncompatibility,
-    RecoveryInvalidTargetException,
-    CommandFailedException,
-)
-from barman.infofile import BackupInfo
-from barman.retention_policies import RetentionPolicyFactory
+from mock import Mock, call, patch
 from testing_helpers import (
     build_backup_directories,
     build_backup_manager,
@@ -49,6 +35,20 @@ from testing_helpers import (
     caplog_reset,
     interpolate_wals,
 )
+
+import barman.utils
+from barman.annotations import KeepManager
+from barman.backup import BackupManager
+from barman.config import BackupOptions
+from barman.exceptions import (
+    BackupException,
+    CommandFailedException,
+    CompressionIncompatibility,
+    RecoveryInvalidTargetException,
+)
+from barman.infofile import BackupInfo
+from barman.lockfile import ServerBackupIdLock
+from barman.retention_policies import RetentionPolicyFactory
 
 
 # noinspection PyMethodMayBeStatic

--- a/tests/test_backup_manifest.py
+++ b/tests/test_backup_manifest.py
@@ -21,11 +21,11 @@ import os
 
 import pytest
 from mock import Mock, patch
+from testing_helpers import build_backup_manager
 
 from barman.backup_manifest import BackupManifest, FileIdentity
 from barman.exceptions import BackupManifestException
 from barman.utils import SHA256
-from testing_helpers import build_backup_manager
 
 
 class TestFileIdentity:

--- a/tests/test_backup_strategy.py
+++ b/tests/test_backup_strategy.py
@@ -16,23 +16,21 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
-import mock
 import os
-import pytest
-
 from io import BytesIO
 from tarfile import TarFile, TarInfo
 
+import mock
+import pytest
+from testing_helpers import build_mocked_server, get_compression_config
+
 from barman.backup_executor import PostgresBackupStrategy
 from barman.compression import (
-    PgBaseBackupCompression,
     GZipPgBaseBackupCompressionOption,
+    PgBaseBackupCompression,
 )
-from barman.exceptions import FileNotFoundException
-from barman.exceptions import BackupException
+from barman.exceptions import BackupException, FileNotFoundException
 from barman.infofile import LocalBackupInfo
-
-from testing_helpers import build_mocked_server, get_compression_config
 
 
 def _tar_file(items):

--- a/tests/test_barman_cloud_backup.py
+++ b/tests/test_barman_cloud_backup.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
-import mock
 import os
+
+import mock
 import pytest
 
 from barman.clients import cloud_backup

--- a/tests/test_barman_cloud_backup_delete.py
+++ b/tests/test_barman_cloud_backup_delete.py
@@ -17,16 +17,16 @@
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
+
 import mock
 import pytest
+from testing_helpers import interpolate_wals
 
 from barman.annotations import KeepManager
 from barman.clients import cloud_backup_delete
 from barman.clients.cloud_cli import OperationErrorExit
 from barman.cloud import CloudBackupCatalog
 from barman.utils import is_backup_id
-
-from testing_helpers import interpolate_wals
 
 
 class TestCloudBackupDeleteArguments(object):

--- a/tests/test_barman_cloud_backup_list.py
+++ b/tests/test_barman_cloud_backup_list.py
@@ -17,11 +17,12 @@
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
+
 import mock
+from testing_helpers import build_test_backup_info
 
 from barman.annotations import KeepManager
 from barman.clients import cloud_backup_list
-from testing_helpers import build_test_backup_info
 
 
 class TestCloudBackupList(object):

--- a/tests/test_barman_cloud_backup_show.py
+++ b/tests/test_barman_cloud_backup_show.py
@@ -18,8 +18,10 @@
 
 import datetime
 import json
+
 import mock
 import pytest
+from testing_helpers import build_test_backup_info
 
 from barman.clients import cloud_backup_show
 from barman.clients.cloud_cli import OperationErrorExit
@@ -27,7 +29,6 @@ from barman.cloud_providers.google_cloud_storage import (
     GcpSnapshotMetadata,
     GcpSnapshotsInfo,
 )
-from testing_helpers import build_test_backup_info
 
 
 class TestCloudBackupShow(object):

--- a/tests/test_barman_cloud_wal_archive.py
+++ b/tests/test_barman_cloud_wal_archive.py
@@ -20,10 +20,10 @@ import bz2
 import gzip
 import logging
 import os
-import snappy
 
 import mock
 import pytest
+import snappy
 
 from barman.clients import cloud_walarchive
 from barman.clients.cloud_walarchive import CloudWalUploader
@@ -31,7 +31,6 @@ from barman.cloud_providers.aws_s3 import S3CloudInterface
 from barman.cloud_providers.azure_blob_storage import AzureCloudInterface
 from barman.exceptions import BarmanException
 from barman.xlog import hash_dir
-
 
 EXAMPLE_WAL_PATH = "wal_dir/000000080000ABFF000000C1"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,42 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
-from argparse import ArgumentTypeError
-
 import json
 import os
-import pytest
 import sys
-from mock import MagicMock, Mock, patch
+from argparse import ArgumentTypeError
 
-import barman.config
-from barman import output
-from barman.cli import (
-    ArgumentParser,
-    argument,
-    backup,
-    check_target_action,
-    check_wal_archive,
-    command,
-    generate_manifest,
-    get_model,
-    get_models_list,
-    get_server,
-    get_server_list,
-    manage_model_command,
-    manage_server_command,
-    OrderedHelpFormatter,
-    parse_backup_id,
-    receive_wal,
-    recover,
-    replication_status,
-    keep,
-    show_servers,
-    config_switch,
-)
-from barman.exceptions import WalArchiveContentError
-from barman.infofile import BackupInfo
-from barman.server import Server
+import pytest
+from mock import MagicMock, Mock, patch
 from testing_helpers import (
     build_config_dictionary,
     build_config_from_dicts,
@@ -59,6 +30,35 @@ from testing_helpers import (
     build_real_server,
     build_test_backup_info,
 )
+
+import barman.config
+from barman import output
+from barman.cli import (
+    ArgumentParser,
+    OrderedHelpFormatter,
+    argument,
+    backup,
+    check_target_action,
+    check_wal_archive,
+    command,
+    config_switch,
+    generate_manifest,
+    get_model,
+    get_models_list,
+    get_server,
+    get_server_list,
+    keep,
+    manage_model_command,
+    manage_server_command,
+    parse_backup_id,
+    receive_wal,
+    recover,
+    replication_status,
+    show_servers,
+)
+from barman.exceptions import WalArchiveContentError
+from barman.infofile import BackupInfo
+from barman.server import Server
 
 
 # noinspection PyMethodMayBeStatic

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -28,26 +28,22 @@ from functools import partial
 from io import BytesIO
 from tarfile import TarFile, TarInfo
 from tarfile import open as open_tar
+from unittest import TestCase
+
+import mock
+import pytest
+import snappy
 from azure.core.exceptions import ResourceNotFoundError, ServiceRequestError
 from azure.identity import AzureCliCredential, ManagedIdentityCredential
 from azure.storage.blob import PartialBatchErrorException
-
-import mock
-from mock.mock import MagicMock
-import pytest
-import snappy
-
-from barman.exceptions import BackupPreconditionException
-from barman.infofile import BackupInfo
-
-if sys.version_info.major > 2:
-    from unittest.mock import patch as unittest_patch
-from unittest import TestCase
 from boto3.exceptions import Boto3Error
 from botocore.exceptions import ClientError, EndpointConnectionError
+from google.api_core.exceptions import Conflict, GoogleAPIError
+from mock.mock import MagicMock
 
 from barman.annotations import KeepManager
 from barman.cloud import (
+    DEFAULT_DELIMITER,
     CloudBackupCatalog,
     CloudBackupSnapshot,
     CloudBackupUploader,
@@ -57,7 +53,6 @@ from barman.cloud import (
     CloudUploadController,
     CloudUploadingError,
     FileUploadStatistics,
-    DEFAULT_DELIMITER,
 )
 from barman.cloud_providers import (
     CloudProviderOptionUnsupported,
@@ -67,8 +62,12 @@ from barman.cloud_providers import (
 from barman.cloud_providers.aws_s3 import S3CloudInterface
 from barman.cloud_providers.azure_blob_storage import AzureCloudInterface
 from barman.cloud_providers.google_cloud_storage import GoogleCloudInterface
+from barman.exceptions import BackupPreconditionException
+from barman.infofile import BackupInfo
 
-from google.api_core.exceptions import GoogleAPIError, Conflict
+if sys.version_info.major > 2:
+    from unittest.mock import patch as unittest_patch
+
 
 try:
     from queue import Queue

--- a/tests/test_cloud_snapshot_interface.py
+++ b/tests/test_cloud_snapshot_interface.py
@@ -17,15 +17,14 @@
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+
 import mock
 import pytest
-
 from azure.core.exceptions import ResourceNotFoundError
 from botocore.exceptions import ClientError
 from google.api_core.exceptions import NotFound
 
 from barman.cloud import CloudProviderError
-
 from barman.cloud_providers import (
     CloudProviderUnsupported,
     get_snapshot_interface,

--- a/tests/test_command_wrappers.py
+++ b/tests/test_command_wrappers.py
@@ -25,6 +25,7 @@ from subprocess import PIPE
 
 import mock
 import pytest
+from testing_helpers import u
 
 from barman import command_wrappers
 from barman.command_wrappers import (
@@ -34,7 +35,6 @@ from barman.command_wrappers import (
     shell_quote,
 )
 from barman.exceptions import CommandFailedException, CommandMaxRetryExceeded
-from testing_helpers import u
 
 
 def _mock_pipe(popen, pipe_processor_loop, ret=0, out="", err=""):

--- a/tests/test_compressor.py
+++ b/tests/test_compressor.py
@@ -17,39 +17,40 @@
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
 import base64
+import io
 import os
+import tarfile
 
 import mock
 import pytest
-import tarfile
-import io
+from testing_helpers import build_mocked_server, get_compression_config
+
 from barman.compression import (
     BZip2Compressor,
     CommandCompressor,
     CompressionManager,
     Compressor,
     CustomCompressor,
+    GZipCompression,
     GZipCompressor,
-    PyBZip2Compressor,
-    PyGZipCompressor,
-    get_pg_basebackup_compression,
+    GZipPgBaseBackupCompressionOption,
+    LZ4Compression,
+    LZ4PgBaseBackupCompressionOption,
+    NoneCompression,
+    NonePgBaseBackupCompressionOption,
     PgBaseBackupCompression,
     PgBaseBackupCompressionOption,
-    GZipPgBaseBackupCompressionOption,
-    GZipCompression,
-    LZ4PgBaseBackupCompressionOption,
-    LZ4Compression,
-    ZSTDPgBaseBackupCompressionOption,
+    PyBZip2Compressor,
+    PyGZipCompressor,
     ZSTDCompression,
-    NonePgBaseBackupCompressionOption,
-    NoneCompression,
+    ZSTDPgBaseBackupCompressionOption,
+    get_pg_basebackup_compression,
 )
 from barman.exceptions import (
+    CommandFailedException,
     CompressionException,
     FileNotFoundException,
-    CommandFailedException,
 )
-from testing_helpers import build_mocked_server, get_compression_config
 
 # Filename patterns used by the tests
 ZIP_FILE = "%s/zipfile.zip"

--- a/tests/test_compressor.py
+++ b/tests/test_compressor.py
@@ -454,11 +454,11 @@ class TestPgBaseBackupCompression(object):
         )
         base_backup_compression = get_pg_basebackup_compression(server)
 
-        assert type(base_backup_compression) == expected_class
+        assert type(base_backup_compression) is expected_class
         if base_backup_compression is not None:
-            assert type(base_backup_compression.options) == expected_option_class
+            assert type(base_backup_compression.options) is expected_option_class
             assert (
-                type(base_backup_compression.compression) == expected_compression_class
+                type(base_backup_compression.compression) is expected_compression_class
             )
 
     def test_get_pg_basebackup_compression_not_supported(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,12 +27,12 @@ from mock import MagicMock, Mock, call, mock_open, patch
 from barman.config import (
     BackupOptions,
     BaseConfig,
-    ConfigMapping,
     Config,
     ConfigChange,
     ConfigChangeSet,
     ConfigChangesProcessor,
     ConfigChangesQueue,
+    ConfigMapping,
     CsvOption,
     ModelConfig,
     RecoveryOptions,
@@ -40,9 +40,9 @@ from barman.config import (
     parse_backup_compression_format,
     parse_backup_compression_location,
     parse_si_suffix,
-    parse_staging_path,
     parse_slot_name,
     parse_snapshot_disks,
+    parse_staging_path,
     parse_time_interval,
 )
 

--- a/tests/test_copy_controller.py
+++ b/tests/test_copy_controller.py
@@ -18,13 +18,18 @@
 
 import multiprocessing.dummy
 import os
-from datetime import datetime
 import time
+from datetime import datetime
 
 import dateutil.tz
 import mock
 import pytest
 from mock import patch
+from testing_helpers import (
+    build_backup_manager,
+    build_real_server,
+    build_test_backup_info,
+)
 
 from barman.copy_controller import (
     BUCKET_SIZE,
@@ -33,11 +38,6 @@ from barman.copy_controller import (
     _RsyncCopyItem,
 )
 from barman.exceptions import CommandFailedException, RsyncListFilesFailure
-from testing_helpers import (
-    build_backup_manager,
-    build_real_server,
-    build_test_backup_info,
-)
 
 
 # noinspection PyMethodMayBeStatic

--- a/tests/test_diagnose.py
+++ b/tests/test_diagnose.py
@@ -19,11 +19,11 @@
 import json
 
 from mock import Mock, patch
+from testing_helpers import build_config_from_dicts
 
 import barman
 from barman.cli import diagnose
 from barman.utils import redact_passwords
-from testing_helpers import build_config_from_dicts
 
 
 class TestDiagnose(object):

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -17,14 +17,19 @@
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
-from functools import partial
 import logging
 import os
+from functools import partial
 
 import mock
 import pytest
 from dateutil import tz
-from mock import Mock, PropertyMock, patch, call
+from mock import Mock, PropertyMock, call, patch
+from testing_helpers import (
+    build_backup_manager,
+    build_mocked_server,
+    build_test_backup_info,
+)
 
 from barman.backup_executor import (
     ExclusiveBackupStrategy,
@@ -46,11 +51,6 @@ from barman.exceptions import (
 from barman.infofile import BackupInfo, LocalBackupInfo, Tablespace
 from barman.postgres_plumbing import EXCLUDE_LIST, PGDATA_EXCLUDE_LIST
 from barman.server import CheckOutputStrategy, CheckStrategy
-from testing_helpers import (
-    build_backup_manager,
-    build_mocked_server,
-    build_test_backup_info,
-)
 
 
 # noinspection PyMethodMayBeStatic

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -17,6 +17,7 @@
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+
 import pytest
 from mock import call, patch
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -20,11 +20,11 @@ import time
 
 import pytest
 from mock import MagicMock, patch
+from testing_helpers import build_backup_manager
 
 from barman.exceptions import AbortedRetryHookScript, UnknownBackupIdException
 from barman.hooks import HookScriptRunner, RetryHookScriptRunner
 from barman.version import __version__ as version
-from testing_helpers import build_backup_manager
 
 
 class TestHooks(object):

--- a/tests/test_infofile.py
+++ b/tests/test_infofile.py
@@ -26,6 +26,13 @@ import mock
 import pytest
 from dateutil.tz import tzlocal, tzoffset
 from mock import PropertyMock, patch
+from testing_helpers import (
+    build_backup_manager,
+    build_mocked_server,
+    build_real_server,
+    build_test_backup_info,
+)
+
 from barman.cloud_providers.aws_s3 import AwsSnapshotMetadata, AwsSnapshotsInfo
 from barman.cloud_providers.azure_blob_storage import (
     AzureSnapshotMetadata,
@@ -35,7 +42,6 @@ from barman.cloud_providers.google_cloud_storage import (
     GcpSnapshotMetadata,
     GcpSnapshotsInfo,
 )
-
 from barman.infofile import (
     BackupInfo,
     Field,
@@ -43,15 +49,9 @@ from barman.infofile import (
     LocalBackupInfo,
     SyntheticBackupInfo,
     WalFileInfo,
-    load_datetime_tz,
     dump_backup_ids,
     load_backup_ids,
-)
-from testing_helpers import (
-    build_backup_manager,
-    build_mocked_server,
-    build_real_server,
-    build_test_backup_info,
+    load_datetime_tz,
 )
 
 BASE_BACKUP_INFO = """backup_label=None

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -16,14 +16,19 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
+import datetime
 import json
 
 import mock
-from mock import PropertyMock
 import pytest
-
-import datetime
 from dateutil import tz
+from mock import PropertyMock
+from testing_helpers import (
+    build_backup_manager,
+    build_test_backup_info,
+    find_by_attr,
+    mock_backup_ext_info,
+)
 
 from barman import output
 from barman.cloud_providers.google_cloud_storage import (
@@ -32,12 +37,6 @@ from barman.cloud_providers.google_cloud_storage import (
 )
 from barman.infofile import BackupInfo
 from barman.utils import BarmanEncoder, human_readable_timedelta, pretty_size
-from testing_helpers import (
-    build_backup_manager,
-    build_test_backup_info,
-    find_by_attr,
-    mock_backup_ext_info,
-)
 
 # Color output constants
 RED = "\033[31m"

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -21,35 +21,35 @@ import time
 from multiprocessing import Queue
 from unittest.mock import MagicMock
 
-try:
-    from queue import Queue as SyncQueue
-except ImportError:
-    from Queue import Queue as SyncQueue
-
 import psycopg2
 import pytest
 from mock import Mock, PropertyMock, call, patch
 from psycopg2.errorcodes import DUPLICATE_OBJECT, UNDEFINED_OBJECT
+from testing_helpers import build_real_server
 
 from barman.exceptions import (
+    BackupFunctionsAccessRequired,
+    PostgresCheckpointPrivilegesRequired,
     PostgresConnectionError,
     PostgresConnectionLost,
     PostgresDuplicateReplicationSlot,
     PostgresException,
     PostgresInvalidReplicationSlot,
     PostgresIsInRecovery,
-    BackupFunctionsAccessRequired,
     PostgresObsoleteFeature,
-    PostgresCheckpointPrivilegesRequired,
     PostgresUnsupportedFeature,
 )
 from barman.postgres import (
-    PostgreSQLConnection,
     PostgresKeepAlive,
-    StandbyPostgreSQLConnection,
     PostgreSQL,
+    PostgreSQLConnection,
+    StandbyPostgreSQLConnection,
 )
-from testing_helpers import build_real_server
+
+try:
+    from queue import Queue as SyncQueue
+except ImportError:
+    from Queue import Queue as SyncQueue
 
 
 class MockProgrammingError(psycopg2.ProgrammingError):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -20,10 +20,10 @@ import errno
 import os
 
 import mock
+from testing_helpers import build_config_from_dicts
 
 from barman.lockfile import ServerWalReceiveLock
 from barman.process import ProcessInfo, ProcessManager
-from testing_helpers import build_config_from_dicts
 
 
 # noinspection PyMethodMayBeStatic

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -16,18 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with Barman.  If not, see <http://www.gnu.org/licenses/>.
 
-from functools import partial
 import os
 import shutil
 from contextlib import closing
+from functools import partial
 
 import dateutil
 import dateutil.tz
 import mock
 import pytest
+import testing_helpers
 from mock import MagicMock, Mock, call
 
-import testing_helpers
 from barman import xlog
 from barman.exceptions import (
     CommandFailedException,
@@ -38,20 +38,16 @@ from barman.exceptions import (
     RecoveryTargetActionException,
     SnapshotBackupException,
 )
-from barman.infofile import (
-    BackupInfo,
-    WalFileInfo,
-    SyntheticBackupInfo,
-)
+from barman.infofile import BackupInfo, SyntheticBackupInfo, WalFileInfo
 from barman.recovery_executor import (
     Assertion,
+    ConfigurationFileMangeler,
+    IncrementalRecoveryExecutor,
     RecoveryExecutor,
     RemoteConfigRecoveryExecutor,
     SnapshotRecoveryExecutor,
     TarballRecoveryExecutor,
-    ConfigurationFileMangeler,
     recovery_executor_factory,
-    IncrementalRecoveryExecutor,
 )
 
 

--- a/tests/test_retention_policies.py
+++ b/tests/test_retention_policies.py
@@ -24,6 +24,7 @@ from datetime import datetime, timedelta
 import mock
 import pytest
 from dateutil.tz import tzlocal
+from testing_helpers import build_mocked_server, build_test_backup_info
 
 from barman.annotations import KeepManager
 from barman.infofile import BackupInfo
@@ -32,7 +33,6 @@ from barman.retention_policies import (
     RedundancyRetentionPolicy,
     RetentionPolicyFactory,
 )
-from testing_helpers import build_mocked_server, build_test_backup_info
 
 
 class TestRetentionPolicies(object):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -23,13 +23,18 @@ import os
 import tarfile
 import time
 from collections import namedtuple
-import dateutil.tz
 from io import BytesIO
 
+import dateutil.tz
 import mock
 import pytest
 from mock import MagicMock, Mock, PropertyMock, patch
 from psycopg2.tz import FixedOffsetTimezone
+from testing_helpers import (
+    build_config_from_dicts,
+    build_real_server,
+    build_test_backup_info,
+)
 
 from barman import output
 from barman.exceptions import (
@@ -52,11 +57,6 @@ from barman.lockfile import (
 from barman.postgres import PostgreSQLConnection
 from barman.process import ProcessInfo
 from barman.server import CheckOutputStrategy, CheckStrategy, Server
-from testing_helpers import (
-    build_config_from_dicts,
-    build_real_server,
-    build_test_backup_info,
-)
 
 
 class ExceptionTest(Exception):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -23,6 +23,11 @@ import dateutil
 import mock
 import pytest
 from dateutil import tz
+from testing_helpers import (
+    build_config_from_dicts,
+    build_real_server,
+    build_test_backup_info,
+)
 
 import barman.server
 from barman.exceptions import (
@@ -33,11 +38,6 @@ from barman.exceptions import (
 )
 from barman.infofile import BackupInfo, LocalBackupInfo
 from barman.lockfile import LockFileBusy
-from testing_helpers import (
-    build_config_from_dicts,
-    build_real_server,
-    build_test_backup_info,
-)
 
 # expected result of the sync --status command
 EXPECTED_MINIMAL = {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,21 +19,20 @@
 import decimal
 import json
 import logging
+import os
+import re
 import signal
 import sys
-import re
-import os
 from argparse import ArgumentTypeError
 from datetime import datetime, timedelta
-from dateutil import tz
+from distutils.version import LooseVersion
 
 import mock
 import pytest
-from distutils.version import LooseVersion
-from barman.lockfile import LockFile
+from dateutil import tz
 
 import barman.utils
-
+from barman.lockfile import LockFile
 
 LOGFILE_NAME = "logfile.log"
 

--- a/tests/test_wal_archiver.py
+++ b/tests/test_wal_archiver.py
@@ -19,9 +19,10 @@ import os
 
 import pytest
 from mock import ANY, MagicMock, patch
+from testing_helpers import build_backup_manager, build_test_backup_info, caplog_reset
 
 import barman.xlog
-from barman.compression import PyGZipCompressor, CompressionManager
+from barman.compression import CompressionManager, PyGZipCompressor
 from barman.exceptions import (
     ArchiverFailure,
     CommandFailedException,
@@ -31,12 +32,7 @@ from barman.exceptions import (
 from barman.infofile import WalFileInfo
 from barman.process import ProcessInfo
 from barman.server import CheckOutputStrategy
-from barman.wal_archiver import (
-    FileWalArchiver,
-    StreamingWalArchiver,
-    WalArchiverQueue,
-)
-from testing_helpers import build_backup_manager, build_test_backup_info, caplog_reset
+from barman.wal_archiver import FileWalArchiver, StreamingWalArchiver, WalArchiverQueue
 
 
 # noinspection PyMethodMayBeStatic

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -24,8 +24,8 @@ import mock
 from dateutil import tz
 
 from barman.backup import BackupManager
-from barman.config import BackupOptions, Config
 from barman.compression import PgBaseBackupCompressionConfig
+from barman.config import BackupOptions, Config
 from barman.infofile import BackupInfo, LocalBackupInfo, Tablespace, WalFileInfo
 from barman.server import Server
 from barman.utils import mkpath


### PR DESCRIPTION
Execute isort on the whole projet cleaning up and sorting imports in both tests and code.

References: bar-429