### PR TITLE
Add --if-not-exists flag to receive-wal

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -1734,6 +1734,11 @@ def archive_wal(args):
             action="store_true",
         ),
         argument(
+            "--if-not-exists",
+            help="Do not error out when --create-slot is specified and a slot with the specified name already exists.",
+            action="store_true",
+        ),
+        argument(
             "--drop-slot",
             help="drop the replication slot, if it exists",
             action="store_true",
@@ -1764,7 +1769,7 @@ def receive_wal(args):
         server.kill("receive-wal")
     elif args.create_slot:
         with closing(server):
-            server.create_physical_repslot()
+            server.create_physical_repslot(ignore_duplicate=args.if_not_exists)
     elif args.drop_slot:
         with closing(server):
             server.drop_repslot()

--- a/barman/server.py
+++ b/barman/server.py
@@ -2908,7 +2908,7 @@ class Server(RemoteStatusMixin):
                 "on server %s. Skipping to the next server" % self.config.name
             )
 
-    def create_physical_repslot(self):
+    def create_physical_repslot(self, ignore_duplicate=False):
         """
         Create a physical replication slot using the streaming connection
         """
@@ -2951,7 +2951,13 @@ class Server(RemoteStatusMixin):
             self.streaming.create_physical_repslot(self.config.slot_name)
             output.info("Replication slot '%s' created", self.config.slot_name)
         except PostgresDuplicateReplicationSlot:
-            output.error("Replication slot '%s' already exists", self.config.slot_name)
+            if ignore_duplicate:
+                output.info(
+                    "Replication slot '%s' already exists and --if-not-exists was specified. Skipping creation",
+                    self.config.slot_name,
+                )
+            else:
+                output.error("Replication slot '%s' already exists", self.config.slot_name)
         except PostgresReplicationSlotsFull:
             output.error(
                 "All replication slots for server '%s' are in use\n"

--- a/docs/user_guide/commands/barman/receive_wal.inc.rst
+++ b/docs/user_guide/commands/barman/receive_wal.inc.rst
@@ -10,6 +10,7 @@ Synopsis
     
     receive-wal
         [ --create-slot ]
+        [ --if-not-exists ]
         [ --drop-slot ]
         [ { -h | --help } ]
         [ --reset ]
@@ -32,6 +33,10 @@ Parameters
 ``--create-slot``
     Create the physical replication slot configured with the ``slot_name`` configuration
     parameter.
+
+``--if-not-exists``
+    Do not error out when --create-slot is specified and a slot with the specified name
+    already exists.
 
 ``--drop-slot``
     Drop the physical replication slot configured with the ``slot_name`` configuration

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2228,6 +2228,14 @@ class TestServer(object):
         out, err = capsys.readouterr()
         assert "Replication slot 'test_repslot' already exists" in err
 
+        # If the replication slot was already created but duplicates are ignored
+        # check that no error is reported
+        create_physical_repslot.side_effect = PostgresDuplicateReplicationSlot
+        server.create_physical_repslot(ignore_duplicate=True)
+        create_physical_repslot.assert_called_with("test_repslot")
+        out, err = capsys.readouterr()
+        assert not err
+
         # Test the method failure if the replication slots
         # on the server are all taken
         create_physical_repslot.side_effect = PostgresReplicationSlotsFull


### PR DESCRIPTION
This flag prevents `receive-wal` from exiting with an error when a slot with the same name already exists. This is the same behavior as calling `pg_receivewal` with the same flag.

References: #1049.