### PR TITLE
Add options for s3 verification

### DIFF
--- a/barman/clients/cloud_cli.py
+++ b/barman/clients/cloud_cli.py
@@ -178,6 +178,18 @@ def create_argument_parser(description, source_or_destination=UrlArgumentType.so
         help="Override default S3 endpoint URL with the given one",
     )
     s3_arguments.add_argument(
+        "--verify-ssl",
+        help="Explicitly specify whether to use SSL verification. Verification is enabled by default.",
+        default=True,
+        action='store_true',
+    )
+    s3_arguments.add_argument(
+        "--no-verify-ssl",
+        help="Explicitly specify whether to use SSL verification. Verification is enabled by default.",
+        dest='verify-ssl',
+        action='store_false',
+    )
+    s3_arguments.add_argument(
         "-P",
         "--aws-profile",
         help="profile name (e.g. INI section in AWS credentials file)",

--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -54,6 +54,8 @@ def _make_s3_cloud_interface(config, cloud_interface_kwargs):
     )
     if "encryption" in config:
         cloud_interface_kwargs["encryption"] = config.encryption
+    if "verify_ssl" in config and config.verify_ssl is False:
+        cloud_interface_kwargs["verify"] = False
     if "sse_kms_key_id" in config:
         if (
             config.sse_kms_key_id is not None
@@ -201,7 +203,9 @@ def get_snapshot_interface(config):
         )
     elif config.cloud_provider == "aws-s3":
         from barman.cloud_providers.aws_s3 import AwsCloudSnapshotInterface
-
+        verify = None
+        if "verify_ssl" in config and config.verify_ssl is False:
+            verify = False
         args = [
             config.aws_profile,
             config.aws_region,
@@ -211,6 +215,7 @@ def get_snapshot_interface(config):
             config.aws_snapshot_lock_cool_off_period,
             config.aws_snapshot_lock_expiration_date,
             config.tags,
+            verify,
         ]
         return AwsCloudSnapshotInterface(*args)
     else:
@@ -259,6 +264,9 @@ def get_snapshot_interface_from_server_config(server_config):
     elif server_config.snapshot_provider == "aws":
         from barman.cloud_providers.aws_s3 import AwsCloudSnapshotInterface
 
+        verify = None
+        if "verify_ssl" in server_config and server_config.verify_ssl is False:
+            verify = False
         return AwsCloudSnapshotInterface(
             server_config.aws_profile,
             server_config.aws_region,
@@ -267,6 +275,7 @@ def get_snapshot_interface_from_server_config(server_config):
             server_config.aws_snapshot_lock_duration,
             server_config.aws_snapshot_lock_cool_off_period,
             server_config.aws_snapshot_lock_expiration_date,
+            verify,
         )
     else:
         raise CloudProviderUnsupported(


### PR DESCRIPTION
Internals wise, this allows the S3 classes to be constructed with the same verify argument as in boto3, which allows to disable SSL verification or to pass a path to a cert bundle separate from the one obtained from environment variables.

User experience wise, having a `None | bool | str` type for an argument is awful API design, so I only exposed a boolean flag to allow users to explicitly request or disable SSL verification, with a clear statement that it is on by default. I had the factory functions do the conversion between the argument formats. A path to a certs folder is trivial to add if needed, but env variables are still a standard way to pass them.

The main usecase for this is to handle self-hosted S3 endpoints with self-signed certificates until you have proper certs management set up.