### PR TITLE
Update pre_requisites.rst

### DIFF
--- a/docs/user_guide/pre_requisites.rst
+++ b/docs/user_guide/pre_requisites.rst
@@ -55,6 +55,7 @@ Or, in case you opt for a user with only the required priviledges, follow these 
     GRANT EXECUTE ON FUNCTION pg_backup_stop(boolean) to barman;
     GRANT EXECUTE ON FUNCTION pg_switch_wal() to barman;
     GRANT EXECUTE ON FUNCTION pg_create_restore_point(text) to barman;
+    GRANT pg_checkpoint TO barman;
     GRANT pg_read_all_settings TO barman;
     GRANT pg_read_all_stats TO barman;
 


### PR DESCRIPTION
Hi team,
Greetings. Hope you are doing well and healthy.

Prerequisite for user privilege seems to lack granting pg_checkpoint. Or you will receive this error:
[barman@edbsup04 ~]$ barman switch-wal --force --archive barman-test
ERROR: Barman switch-wal --force requires superuser rights or the 'pg_checkpoint' role

Kind Regards,
Yuki Tei