### PR TITLE
Change the S3 connectivity test to be done with ListObjectsV2 rather than HeadBucket to allow for more fine-grained permissions

### DIFF
--- a/barman/cloud_providers/aws_s3.py
+++ b/barman/cloud_providers/aws_s3.py
@@ -213,7 +213,7 @@ class S3CloudInterface(CloudInterface):
         """
         try:
             # Search the bucket on s3
-            self.s3.meta.client.head_bucket(Bucket=self.bucket_name)
+            self.s3.meta.client.list_objects_v2(Bucket=self.bucket_name, MaxKeys=1, Prefix=self.path)
             return True
         except ClientError as exc:
             # If a client error is thrown, then check the error code.

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -534,7 +534,7 @@ class TestS3CloudInterface(object):
         session_mock = boto_mock.Session.return_value
         s3_mock = session_mock.resource.return_value
         client_mock = s3_mock.meta.client
-        client_mock.head_bucket.assert_called_once_with(Bucket="bucket")
+        client_mock.list_objects_v2.assert_called_once_with(Bucket="bucket", MaxKeys=1, Prefix="path/to/dir")
 
     @mock.patch("barman.cloud_providers.aws_s3.boto3")
     def test_connectivity_failure(self, boto_mock):
@@ -546,7 +546,7 @@ class TestS3CloudInterface(object):
         s3_mock = session_mock.resource.return_value
         client_mock = s3_mock.meta.client
         # Raise the exception for the "I'm unable to reach amazon" event
-        client_mock.head_bucket.side_effect = EndpointConnectionError(
+        client_mock.list_objects_v2.side_effect = EndpointConnectionError(
             endpoint_url="bucket"
         )
         assert cloud_interface.test_connectivity() is False
@@ -561,9 +561,11 @@ class TestS3CloudInterface(object):
         session_mock = boto_mock.Session.return_value
         s3_mock = session_mock.resource.return_value
         s3_client = s3_mock.meta.client
-        # Expect a call on the head_bucket method of the s3 client.
-        s3_client.head_bucket.assert_called_once_with(
-            Bucket=cloud_interface.bucket_name
+        # Expect a call on the list_objects_v2 method of the s3 client.
+        s3_client.list_objects_v2.assert_called_once_with(
+            Bucket=cloud_interface.bucket_name,
+            MaxKeys=1,
+            Prefix=cloud_interface.path,
         )
 
     @mock.patch("barman.cloud_providers.aws_s3.boto3")
@@ -576,7 +578,7 @@ class TestS3CloudInterface(object):
         s3_mock = session_mock.resource.return_value
         s3_client = s3_mock.meta.client
         # Simulate a 404 error from amazon for 'bucket not found'
-        s3_client.head_bucket.side_effect = ClientError(
+        s3_client.list_objects_v2.side_effect = ClientError(
             error_response={"Error": {"Code": "404"}}, operation_name="load"
         )
         cloud_interface.setup_bucket()


### PR DESCRIPTION
In S3, there is no way to grant permissions to do the HeadBucket API call without also granting permissions to list directories at the root level of the S3 bucket.

For example, if your S3 bucket has the following structure:
- x/backups
- y/backups

and you want backups to be done to "x/backups/db_one" via an S3 user that only has permissions to read/write to "x/backups/*", it won't work because this S3 user can't HeadBucket or list the directories in the root of the bucket (so the connectivity test fails).

The directories in the root of the bucket might not be something you necessarily want to expose to S3 users that should only know about their particular subdirectory.

This PR changes the S3 connectivity test to be done via ListObjectsV2 rather than HeadBucket, which *does* work for S3 users that only have access to a particular subdirectory in the bucket without exposing what's in the root of the bucket.

I have updated the relevant tests, as well as ran manual tests in CNPG (that uses barman internally) to take backups to a subdirectory the S3 user has access to (works) and does not have access to, which fails with the following error:
```
ERROR: Barman cloud WAL archiver exception: An error occurred (AccessDenied) when calling the ListObjectsV2 operation: User: arn:aws:iam::... is not authorized to perform: s3:ListBucket on resource: "arn:aws:s3:::..." because no identity-based policy allows the s3:ListBucket action
```