### PR TITLE
Logging Improvement

### DIFF
--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -1700,7 +1700,7 @@ class SnapshotBackupExecutor(ExternalBackupExecutor):
                 # Ignore disks which were not attached
                 continue
             except SnapshotBackupException as exc:
-                logging.warn("Error resolving mount point: {}".format(exc))
+                _logger.warning("Error resolving mount point: {}".format(exc))
                 mount_point = None
             if mount_point is None:
                 unmounted_disks.append(disk)

--- a/barman/cli.py
+++ b/barman/cli.py
@@ -2089,7 +2089,7 @@ def check_wal_archive(args):
                 server.config.name,
                 force_str(err),
             )
-            logging.error(msg)
+            _logger.error(msg)
             output.error(msg)
             output.close_and_exit()
 

--- a/barman/clients/cloud_backup.py
+++ b/barman/clients/cloud_backup.py
@@ -55,6 +55,10 @@ from barman.utils import (
     force_str,
 )
 
+
+_logger = logging.getLogger(__name__)
+
+
 _find_space = re.compile(r"[\s]").search
 
 
@@ -212,8 +216,8 @@ def main(args=None):
                 try:
                     postgres.connect()
                 except PostgresConnectionError as exc:
-                    logging.error("Cannot connect to postgres: %s", force_str(exc))
-                    logging.debug("Exception details:", exc_info=exc)
+                    _logger.error("Cannot connect to postgres: %s", force_str(exc))
+                    _logger.debug("Exception details:", exc_info=exc)
                     raise OperationErrorExit()
 
                 with closing(postgres):
@@ -241,16 +245,16 @@ def main(args=None):
                         uploader.backup()
 
     except KeyboardInterrupt as exc:
-        logging.error("Barman cloud backup was interrupted by the user")
-        logging.debug("Exception details:", exc_info=exc)
+        _logger.error("Barman cloud backup was interrupted by the user")
+        _logger.debug("Exception details:", exc_info=exc)
         raise OperationErrorExit()
     except UnrecoverableHookScriptError as exc:
-        logging.error("Barman cloud backup exception: %s", force_str(exc))
-        logging.debug("Exception details:", exc_info=exc)
+        _logger.error("Barman cloud backup exception: %s", force_str(exc))
+        _logger.debug("Exception details:", exc_info=exc)
         raise SystemExit(63)
     except Exception as exc:
-        logging.error("Barman cloud backup exception: %s", force_str(exc))
-        logging.debug("Exception details:", exc_info=exc)
+        _logger.error("Barman cloud backup exception: %s", force_str(exc))
+        _logger.debug("Exception details:", exc_info=exc)
         raise GeneralErrorExit()
     finally:
         # Remove the temporary directory and all the contained files

--- a/barman/clients/cloud_backup_keep.py
+++ b/barman/clients/cloud_backup_keep.py
@@ -32,6 +32,9 @@ from barman.infofile import BackupInfo
 from barman.utils import force_str
 
 
+_logger = logging.getLogger(__name__)
+
+
 def main(args=None):
     """
     The main script entry point.
@@ -53,7 +56,7 @@ def main(args=None):
                 raise SystemExit(0)
 
             if not cloud_interface.bucket_exists:
-                logging.error("Bucket %s does not exist", cloud_interface.bucket_name)
+                _logger.error("Bucket %s does not exist", cloud_interface.bucket_name)
                 raise OperationErrorExit()
 
             catalog = CloudBackupCatalog(cloud_interface, config.server_name)
@@ -71,7 +74,7 @@ def main(args=None):
                 if backup_info.status == BackupInfo.DONE:
                     catalog.keep_backup(backup_id, config.target)
                 else:
-                    logging.error(
+                    _logger.error(
                         "Cannot add keep to backup %s because it has status %s. "
                         "Only backups with status DONE can be kept.",
                         backup_id,
@@ -80,8 +83,8 @@ def main(args=None):
                     raise OperationErrorExit()
 
     except Exception as exc:
-        logging.error("Barman cloud keep exception: %s", force_str(exc))
-        logging.debug("Exception details:", exc_info=exc)
+        _logger.error("Barman cloud keep exception: %s", force_str(exc))
+        _logger.debug("Exception details:", exc_info=exc)
         raise GeneralErrorExit()
 
 

--- a/barman/clients/cloud_backup_list.py
+++ b/barman/clients/cloud_backup_list.py
@@ -32,6 +32,9 @@ from barman.infofile import BackupInfo
 from barman.utils import force_str
 
 
+_logger = logging.getLogger(__name__)
+
+
 def main(args=None):
     """
     The main script entry point
@@ -57,7 +60,7 @@ def main(args=None):
                 raise SystemExit(0)
 
             if not cloud_interface.bucket_exists:
-                logging.error("Bucket %s does not exist", cloud_interface.bucket_name)
+                _logger.error("Bucket %s does not exist", cloud_interface.bucket_name)
                 raise OperationErrorExit()
 
             backup_list = catalog.get_backup_list()
@@ -103,8 +106,8 @@ def main(args=None):
                 )
 
     except Exception as exc:
-        logging.error("Barman cloud backup list exception: %s", force_str(exc))
-        logging.debug("Exception details:", exc_info=exc)
+        _logger.error("Barman cloud backup list exception: %s", force_str(exc))
+        _logger.debug("Exception details:", exc_info=exc)
         raise GeneralErrorExit()
 
 

--- a/barman/clients/cloud_backup_show.py
+++ b/barman/clients/cloud_backup_show.py
@@ -34,6 +34,9 @@ from barman.output import ConsoleOutputWriter
 from barman.utils import force_str
 
 
+_logger = logging.getLogger(__name__)
+
+
 def main(args=None):
     """
     The main script entry point
@@ -59,14 +62,14 @@ def main(args=None):
                 raise SystemExit(0)
 
             if not cloud_interface.bucket_exists:
-                logging.error("Bucket %s does not exist", cloud_interface.bucket_name)
+                _logger.error("Bucket %s does not exist", cloud_interface.bucket_name)
                 raise OperationErrorExit()
 
             backup_id = catalog.parse_backup_id(config.backup_id)
             backup_info = catalog.get_backup_info(backup_id)
 
             if not backup_info:
-                logging.error(
+                _logger.error(
                     "Backup %s for server %s does not exist",
                     backup_id,
                     config.server_name,
@@ -82,8 +85,8 @@ def main(args=None):
                 print(json.dumps(json_output))
 
     except Exception as exc:
-        logging.error("Barman cloud backup show exception: %s", force_str(exc))
-        logging.debug("Exception details:", exc_info=exc)
+        _logger.error("Barman cloud backup show exception: %s", force_str(exc))
+        _logger.debug("Exception details:", exc_info=exc)
         raise GeneralErrorExit()
 
 

--- a/barman/clients/cloud_check_wal_archive.py
+++ b/barman/clients/cloud_check_wal_archive.py
@@ -32,6 +32,9 @@ from barman.utils import check_positive, force_str
 from barman.xlog import check_archive_usable
 
 
+_logger = logging.getLogger(__name__)
+
+
 def main(args=None):
     """
     The main script entry point
@@ -60,15 +63,15 @@ def main(args=None):
             timeline=config.timeline,
         )
     except WalArchiveContentError as err:
-        logging.error(
+        _logger.error(
             "WAL archive check failed for server %s: %s",
             config.server_name,
             force_str(err),
         )
         raise OperationErrorExit()
     except Exception as exc:
-        logging.error("Barman cloud WAL archive check exception: %s", force_str(exc))
-        logging.debug("Exception details:", exc_info=exc)
+        _logger.error("Barman cloud WAL archive check exception: %s", force_str(exc))
+        _logger.debug("Exception details:", exc_info=exc)
         raise GeneralErrorExit()
 
 

--- a/barman/clients/cloud_cli.py
+++ b/barman/clients/cloud_cli.py
@@ -24,6 +24,9 @@ import barman
 from barman.utils import force_str
 
 
+_logger = logging.getLogger(__name__)
+
+
 class OperationErrorExit(SystemExit):
     """
     Dedicated exit code for errors where connectivity to the cloud provider was ok
@@ -81,14 +84,14 @@ def __parse_tag(tag):
     try:
         rows = list(csv.reader([tag], delimiter=","))
     except csv.Error as exc:
-        logging.error(
+        _logger.error(
             "Error parsing tag %s: %s",
             tag,
             force_str(exc),
         )
         raise CLIErrorExit()
     if len(rows) != 1 or len(rows[0]) != 2:
-        logging.error(
+        _logger.error(
             "Invalid tag format: %s",
             tag,
         )

--- a/barman/clients/cloud_restore.py
+++ b/barman/clients/cloud_restore.py
@@ -47,6 +47,9 @@ from barman.utils import (
 )
 
 
+_logger = logging.getLogger(__name__)
+
+
 def _validate_config(config, backup_info):
     """
     Additional validation for config such as mutually inclusive options.
@@ -85,7 +88,7 @@ def main(args=None):
                 raise SystemExit(0)
 
             if not cloud_interface.bucket_exists:
-                logging.error("Bucket %s does not exist", cloud_interface.bucket_name)
+                _logger.error("Bucket %s does not exist", cloud_interface.bucket_name)
                 raise OperationErrorExit()
 
             catalog = CloudBackupCatalog(cloud_interface, config.server_name)
@@ -123,13 +126,13 @@ def main(args=None):
                     )
                 # If no candidate backup_id is found, error out.
                 if backup_id is None:
-                    logging.error("Cannot find any candidate backup for recovery.")
+                    _logger.error("Cannot find any candidate backup for recovery.")
                     raise OperationErrorExit()
 
             backup_info = catalog.get_backup_info(backup_id)
-            logging.info("Restoring from backup_id: %s" % backup_id)
+            _logger.info("Restoring from backup_id: %s" % backup_id)
             if not backup_info:
-                logging.error(
+                _logger.error(
                     "Backup %s for server %s does not exists",
                     backup_id,
                     config.server_name,
@@ -160,12 +163,12 @@ def main(args=None):
                 )
 
     except KeyboardInterrupt as exc:
-        logging.error("Barman cloud restore was interrupted by the user")
-        logging.debug("Exception details:", exc_info=exc)
+        _logger.error("Barman cloud restore was interrupted by the user")
+        _logger.debug("Exception details:", exc_info=exc)
         raise OperationErrorExit()
     except Exception as exc:
-        logging.error("Barman cloud restore exception: %s", force_str(exc))
-        logging.debug("Exception details:", exc_info=exc)
+        _logger.error("Barman cloud restore exception: %s", force_str(exc))
+        _logger.debug("Exception details:", exc_info=exc)
         raise GeneralErrorExit()
 
 
@@ -241,7 +244,7 @@ def tablespace_map(rules):
         try:
             tablespaces.update([rule.split(":", 1)])
         except ValueError:
-            logging.error(
+            _logger.error(
                 "Invalid tablespace relocation rule '%s'\n"
                 "HINT: The valid syntax for a relocation rule is "
                 "NAME:LOCATION",
@@ -292,7 +295,7 @@ class CloudBackupDownloaderObjectStore(CloudBackupDownloader):
         """
         # Validate the destination directory before starting recovery
         if os.path.exists(destination_dir) and os.listdir(destination_dir):
-            logging.error(
+            _logger.error(
                 "Destination %s already exists and it is not empty", destination_dir
             )
             raise OperationErrorExit()
@@ -320,7 +323,7 @@ class CloudBackupDownloaderObjectStore(CloudBackupDownloader):
                         target_dir = tblspc.location
                         if tblspc.name in tablespaces:
                             target_dir = os.path.realpath(tablespaces[tblspc.name])
-                        logging.debug(
+                        _logger.debug(
                             "Tablespace %s (oid=%s) will be located at %s",
                             tblspc.name,
                             oid,
@@ -338,7 +341,7 @@ class CloudBackupDownloaderObjectStore(CloudBackupDownloader):
 
             # Validate the destination directory before starting recovery
             if os.path.exists(target_dir) and os.listdir(target_dir):
-                logging.error(
+                _logger.error(
                     "Destination %s already exists and it is not empty", target_dir
                 )
                 raise OperationErrorExit()
@@ -349,7 +352,7 @@ class CloudBackupDownloaderObjectStore(CloudBackupDownloader):
         # Now it's time to download the files
         for file_info, target_dir in copy_jobs:
             # Download the file
-            logging.debug(
+            _logger.debug(
                 "Extracting %s to %s (%s)",
                 file_info.path,
                 target_dir,

--- a/barman/clients/cloud_walarchive.py
+++ b/barman/clients/cloud_walarchive.py
@@ -38,6 +38,9 @@ from barman.utils import check_positive, check_size, force_str
 from barman.xlog import hash_dir, is_any_xlog_file, is_history_file
 
 
+_logger = logging.getLogger(__name__)
+
+
 def __is_hook_script():
     """Check the environment and determine if we are running as a hook script"""
     if "BARMAN_HOOK" in os.environ and "BARMAN_PHASE" in os.environ:
@@ -76,7 +79,7 @@ def main(args=None):
 
     # Validate the WAL file name before uploading it
     if not is_any_xlog_file(config.wal_path):
-        logging.error("%s is an invalid name for a WAL file" % config.wal_path)
+        _logger.error("%s is an invalid name for a WAL file" % config.wal_path)
         raise CLIErrorExit()
 
     try:
@@ -106,8 +109,8 @@ def main(args=None):
             uploader.upload_wal(config.wal_path, **upload_kwargs)
 
     except Exception as exc:
-        logging.error("Barman cloud WAL archiver exception: %s", force_str(exc))
-        logging.debug("Exception details:", exc_info=exc)
+        _logger.error("Barman cloud WAL archiver exception: %s", force_str(exc))
+        _logger.debug("Exception details:", exc_info=exc)
         raise GeneralErrorExit()
 
 

--- a/barman/cloud_providers/azure_blob_storage.py
+++ b/barman/cloud_providers/azure_blob_storage.py
@@ -36,6 +36,10 @@ from barman.cloud import (
 )
 from barman.exceptions import CommandException, SnapshotBackupException
 
+
+_logger = logging.getLogger(__name__)
+
+
 try:
     # Python 3.x
     from urllib.parse import urlparse
@@ -180,7 +184,7 @@ class AzureCloudInterface(CloudInterface):
         else:
             # We are dealing with emulated storage so we use the following form:
             # http://<local-machine-address>:<port>/<account-name>/<resource-path>
-            logging.info("Using emulated storage URL: %s " % url)
+            _logger.info("Using emulated storage URL: %s " % url)
             if "AZURE_STORAGE_CONNECTION_STRING" not in os.environ:
                 raise ValueError(
                     "A connection string must be provided when using emulated storage"
@@ -204,7 +208,7 @@ class AzureCloudInterface(CloudInterface):
             # Any supplied credential takes precedence over the environment
             credential = self.credential
         elif "AZURE_STORAGE_CONNECTION_STRING" in os.environ:
-            logging.info("Authenticating to Azure with connection string")
+            _logger.info("Authenticating to Azure with connection string")
             self.container_client = ContainerClient.from_connection_string(
                 conn_str=os.getenv("AZURE_STORAGE_CONNECTION_STRING"),
                 container_name=self.bucket_name,
@@ -212,13 +216,13 @@ class AzureCloudInterface(CloudInterface):
             return
         else:
             if "AZURE_STORAGE_SAS_TOKEN" in os.environ:
-                logging.info("Authenticating to Azure with SAS token")
+                _logger.info("Authenticating to Azure with SAS token")
                 credential = os.getenv("AZURE_STORAGE_SAS_TOKEN")
             elif "AZURE_STORAGE_KEY" in os.environ:
-                logging.info("Authenticating to Azure with shared key")
+                _logger.info("Authenticating to Azure with shared key")
                 credential = os.getenv("AZURE_STORAGE_KEY")
             else:
-                logging.info("Authenticating to Azure with default credentials")
+                _logger.info("Authenticating to Azure with default credentials")
                 # azure-identity is not part of azure-storage-blob so only import
                 # it if needed
                 try:
@@ -255,7 +259,7 @@ class AzureCloudInterface(CloudInterface):
             self.bucket_exists = self._check_bucket_existence()
             return True
         except (HttpResponseError, ServiceRequestError) as exc:
-            logging.error("Can't connect to cloud provider: %s", exc)
+            _logger.error("Can't connect to cloud provider: %s", exc)
             return False
 
     def _check_bucket_existence(self):
@@ -461,7 +465,7 @@ class AzureCloudInterface(CloudInterface):
             # the response objects in its `parts` attribute.
             # We therefore set responses to reference the response in the exception and
             # treat it the same way we would a regular response.
-            logging.warning(
+            _logger.warning(
                 "PartialBatchErrorException received from Azure: %s" % exc.message
             )
             responses = exc.parts
@@ -471,13 +475,13 @@ class AzureCloudInterface(CloudInterface):
         errors = False
         for resp in responses:
             if resp.status_code == 404:
-                logging.warning(
+                _logger.warning(
                     "Deletion of object %s failed because it could not be found"
                     % resp.request.url
                 )
             elif resp.status_code != 202:
                 errors = True
-                logging.error(
+                _logger.error(
                     'Deletion of object %s failed with error code: "%s"'
                     % (resp.request.url, resp.status_code)
                 )
@@ -630,7 +634,7 @@ class AzureCloudSnapshotInterface(CloudSnapshotInterface):
         :return: The name used to reference the snapshot with Azure.
         """
         snapshot_name = "%s-%s" % (disk_name, backup_info.backup_id.lower())
-        logging.info("Taking snapshot '%s' of disk '%s'", snapshot_name, disk_name)
+        _logger.info("Taking snapshot '%s' of disk '%s'", snapshot_name, disk_name)
         resp = self.client.snapshots.begin_create_or_update(
             resource_group,
             snapshot_name,
@@ -641,7 +645,7 @@ class AzureCloudSnapshotInterface(CloudSnapshotInterface):
             },
         )
 
-        logging.info("Waiting for snapshot '%s' completion", snapshot_name)
+        _logger.info("Waiting for snapshot '%s' completion", snapshot_name)
         resp.wait()
 
         if (
@@ -653,7 +657,7 @@ class AzureCloudSnapshotInterface(CloudSnapshotInterface):
                 % (snapshot_name, resp.status(), resp.result())
             )
 
-        logging.info("Snapshot '%s' completed", snapshot_name)
+        _logger.info("Snapshot '%s' completed", snapshot_name)
         return snapshot_name
 
     def take_snapshot_backup(self, backup_info, instance_name, volumes):
@@ -732,7 +736,7 @@ class AzureCloudSnapshotInterface(CloudSnapshotInterface):
                 % (snapshot_name, resp.status(), resp.result())
             )
 
-        logging.info("Snapshot %s deleted", snapshot_name)
+        _logger.info("Snapshot %s deleted", snapshot_name)
 
     def delete_snapshot_backup(self, backup_info):
         """
@@ -741,7 +745,7 @@ class AzureCloudSnapshotInterface(CloudSnapshotInterface):
         :param barman.infofile.LocalBackupInfo backup_info: Backup information.
         """
         for snapshot in backup_info.snapshots_info.snapshots:
-            logging.info(
+            _logger.info(
                 "Deleting snapshot '%s' for backup %s",
                 snapshot.identifier,
                 backup_info.backup_id,

--- a/barman/config.py
+++ b/barman/config.py
@@ -1482,7 +1482,7 @@ class Config(object):
             return
 
         if not os.path.isdir(os.path.expanduser(config_files_directory)):
-            _logger.warn(
+            _logger.warning(
                 'Ignoring the "configuration_files_directory" option as "%s" '
                 "is not a directory",
                 config_files_directory,
@@ -1510,10 +1510,10 @@ class Config(object):
                     raise SystemExit("FATAL: %s" % msg)
             else:
                 # Add an warning message that a file has been discarded
-                _logger.warn("Discarding configuration file: %s (not a file)", filename)
+                _logger.warning("Discarding configuration file: %s (not a file)", filename)
         else:
             # Add an warning message that a file has been discarded
-            _logger.warn("Discarding configuration file: %s (not found)", filename)
+            _logger.warning("Discarding configuration file: %s (not found)", filename)
 
     def _is_model(self, name):
         """

--- a/barman/copy_controller.py
+++ b/barman/copy_controller.py
@@ -885,8 +885,8 @@ class RsyncCopyController(object):
         :param CommandFailedException exc: the exception which caused the
             failure
         """
-        _logger.warn("Failure executing rsync on %s (attempt %s)", item, attempt)
-        _logger.warn("Retrying in %s seconds", self.retry_sleep)
+        _logger.warning("Failure executing rsync on %s (attempt %s)", item, attempt)
+        _logger.warning("Retrying in %s seconds", self.retry_sleep)
 
     def _analyze_directory(self, item):
         """

--- a/barman/fs.py
+++ b/barman/fs.py
@@ -421,7 +421,7 @@ def unix_command_factory(remote_command=None, path=None):
     if remote_command:
         try:
             cmd = UnixRemoteCommand(remote_command, path=path)
-            logging.debug("Created a UnixRemoteCommand")
+            _logger.debug("Created a UnixRemoteCommand")
             return cmd
         except FsOperationFailed:
             output.error(
@@ -431,7 +431,7 @@ def unix_command_factory(remote_command=None, path=None):
             output.close_and_exit()
     else:
         cmd = UnixLocalCommand()
-        logging.debug("Created a UnixLocalCommand")
+        _logger.debug("Created a UnixLocalCommand")
         return cmd
 
 

--- a/barman/utils.py
+++ b/barman/utils.py
@@ -132,7 +132,7 @@ def configure_logging(
     logging.root.addHandler(handler)
     if warn:
         # this will be always displayed because the default level is WARNING
-        _logger.warn(warn)
+        _logger.warning(warn)
     logging.root.setLevel(log_level)
 
 

--- a/tests/test_barman_cloud_restore.py
+++ b/tests/test_barman_cloud_restore.py
@@ -531,7 +531,7 @@ class TestCloudRestore(object):
 
         cloud_backup_catalog.get_backup_info.assert_called_once_with(expected_backup_id)
 
-    @mock.patch("logging.error")
+    @mock.patch("barman.clients.cloud_restore._logger.error")
     @mock.patch("barman.clients.cloud_restore.get_backup_id_from_target_time")
     @mock.patch("barman.clients.cloud_restore.CloudBackupCatalog")
     @mock.patch("barman.clients.cloud_restore.get_cloud_interface")

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -2292,7 +2292,7 @@ class TestGoogleCloudInterface(TestCase):
         container_client_mock.exists.assert_called_once_with()
         service_client_mock.create_bucket.assert_called_once_with(container_client_mock)
 
-    @mock.patch("barman.cloud_providers.google_cloud_storage.logging")
+    @mock.patch("barman.cloud_providers.google_cloud_storage._logger")
     @mock.patch("barman.cloud_providers.google_cloud_storage.storage.Client")
     def test_setup_bucket_create_conflict_error(self, gcs_client_mock, logging_mock):
         """
@@ -2511,7 +2511,7 @@ class TestGoogleCloudInterface(TestCase):
         mock_calls = list(map(lambda x: mock.call(x), mock_keys))
         container_client_mock.blob.assert_has_calls(mock_calls, any_order=True)
 
-    @mock.patch("barman.cloud_providers.google_cloud_storage.logging")
+    @mock.patch("barman.cloud_providers.google_cloud_storage._logger")
     @mock.patch("barman.cloud_providers.google_cloud_storage.storage.Client")
     def test_delete_objects_with_error(self, gcs_client_mock, logging_mock):
         mock_blob1 = mock.MagicMock()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -269,7 +269,7 @@ class TestConfigureLogging(object):
         handler_mock.setFormatter.assert_called_with(mock.ANY)
 
         # check if a warning has been raised
-        mocks["_logger"].warn.assert_called_with(mock.ANY)
+        mocks["_logger"].warning.assert_called_with(mock.ANY)
 
     def test_file_error_file(self, **mocks):
         test_file = "/test/log/file.log"
@@ -291,7 +291,7 @@ class TestConfigureLogging(object):
         handler_mock.setFormatter.assert_called_with(mock.ANY)
 
         # check if a warning has been raised
-        mocks["_logger"].warn.assert_called_with(mock.ANY)
+        mocks["_logger"].warning.assert_called_with(mock.ANY)
 
 
 # noinspection PyMethodMayBeStatic


### PR DESCRIPTION
Ensured that all barman code uses file-specific loggers instead of the root logger.
Some code was already compliant, but some was not and still used:
```python
logging.info("Something happened")
```

All this code was replaced by:
```python
_logger = logging.getLogger(__name__)
...
_logger.info("Something happened")
```

Unit tests were updated accordingly.

All unit tests were run and passing except 3, which were previously failing on my machine (a Mac) as it didn't have expected filesystems and `rsync` didn't support the `-s` option.