### PR TITLE
Resolve Python 3.13 functools.partial warning with staticmethod

### DIFF
--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -175,8 +175,10 @@ class CloudTarUploader(object):
     # This is the method we use to create new buffers
     # We use named temporary files, so we can pass them by name to
     # other processes
-    _buffer = partial(
-        NamedTemporaryFile, delete=False, prefix="barman-upload-", suffix=".part"
+    _buffer = staticmethod(
+        partial(
+            NamedTemporaryFile, delete=False, prefix="barman-upload-", suffix=".part"
+        )
     )
 
     def __init__(


### PR DESCRIPTION
Resolve Python 3.13 warning:

FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in staticmethod() if you want to preserve the old behavior

I ran into this as a user of CloudNative Postgres, however its also visible in CI logs within this repo, e.g. https://github.com/EnterpriseDB/barman/actions/runs/16815312469/job/47630556427#step:6:157 