### PR TITLE
feat(cloud_providers/aws_s3): add support for configuring addressing style

### DIFF
--- a/barman/clients/cloud_cli.py
+++ b/barman/clients/cloud_cli.py
@@ -196,6 +196,13 @@ def create_argument_parser(description, source_or_destination=UrlArgumentType.so
         help="the time in seconds until a timeout is raised when waiting to "
         "read from a connection (defaults to 60 seconds)",
     )
+    s3_arguments.add_argument(
+        "--addressing-style",
+        choices=["auto", "virtual", "path"],
+        help="the addressing style to use for S3 requests. Valid values are "
+        "'auto' (default), 'virtual' (virtual-hosted-style), or 'path' "
+        "(path-style)",
+    )
     azure_arguments = parser.add_argument_group(
         "Extra options for the azure-blob-storage cloud provider"
     )

--- a/barman/cloud_providers/__init__.py
+++ b/barman/cloud_providers/__init__.py
@@ -64,6 +64,8 @@ def _make_s3_cloud_interface(config, cloud_interface_kwargs):
                 'Encryption type must be "aws:kms" if SSE KMS Key ID is specified'
             )
         cloud_interface_kwargs["sse_kms_key_id"] = config.sse_kms_key_id
+    if "addressing_style" in config:
+        cloud_interface_kwargs["addressing_style"] = config.addressing_style
     return S3CloudInterface(**cloud_interface_kwargs)
 
 

--- a/barman/cloud_providers/aws_s3.py
+++ b/barman/cloud_providers/aws_s3.py
@@ -123,6 +123,7 @@ class S3CloudInterface(CloudInterface):
         delete_batch_size=None,
         read_timeout=None,
         sse_kms_key_id=None,
+        addressing_style=None,
     ):
         """
         Create a new S3 interface given the S3 destination url and the profile
@@ -141,6 +142,8 @@ class S3CloudInterface(CloudInterface):
           raised when waiting to read from a connection
         :param str|None sse_kms_key_id: the AWS KMS key ID that should be used
           for encrypting uploaded data in S3
+        :param str|None addressing_style: the addressing style to use for S3
+          requests. Valid values are 'auto', 'virtual', or 'path'
         """
         super(S3CloudInterface, self).__init__(
             url=url,
@@ -153,6 +156,7 @@ class S3CloudInterface(CloudInterface):
         self.endpoint_url = endpoint_url
         self.read_timeout = read_timeout
         self.sse_kms_key_id = sse_kms_key_id
+        self.addressing_style = addressing_style
 
         # Extract information from the destination URL
         parsed_url = urlparse(url)
@@ -176,6 +180,8 @@ class S3CloudInterface(CloudInterface):
         config_kwargs = {}
         if self.read_timeout is not None:
             config_kwargs["read_timeout"] = self.read_timeout
+        if self.addressing_style is not None:
+            config_kwargs["s3"] = {"addressing_style": self.addressing_style}
         config = Config(**config_kwargs)
 
         session = boto3.Session(profile_name=self.profile_name)

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -570,6 +570,32 @@ class TestS3CloudInterface(object):
             config=config_mock.return_value,
         )
 
+    @mock.patch("barman.cloud_providers.aws_s3.Config")
+    @mock.patch("barman.cloud_providers.aws_s3.boto3")
+    def test_uploader_minimal_addressing_style(self, boto_mock, config_mock):
+        # GIVEN an s3 bucket url
+        bucket_url = "s3://bucket/path/to/dir"
+
+        # WHEN an S3CloudInterface with minimal arguments is created with
+        # a specified addressing_style
+        cloud_interface = S3CloudInterface(
+            url=bucket_url, encryption=None, addressing_style="path"
+        )
+
+        # THEN the cloud interface addressing_style property is set to the specified
+        # value
+        assert cloud_interface.addressing_style == "path"
+        # AND a Config is created with the specified addressing_style
+        config_mock.assert_called_once_with(s3={"addressing_style": "path"})
+        # AND the boto3 resource is created with no specified endpoint_url
+        # and the created Config object
+        session_mock = boto_mock.Session.return_value
+        session_mock.resource.assert_called_once_with(
+            "s3",
+            endpoint_url=None,
+            config=config_mock.return_value,
+        )
+
     @mock.patch("barman.cloud_providers.aws_s3.boto3")
     def test_invalid_uploader_minimal(self, boto_mock):
         """


### PR DESCRIPTION
botocore esentially forces path style addressing if the endpoint URL is not `amazonaws.com` https://github.com/boto/botocore/blob/4d3496f29af0e608e5954de43965b23734ad0964/botocore/args.py#L776-L788

For S3 compatible endpoints that require virtual host style, we should expose `boto3`'s `addressing_style` configuration: https://github.com/boto/boto3/blob/f3fe4845588855a9871cf8182597e2ab2e26eca9/docs/source/guide/configuration.rst?plain=1#L372-L384

Closes #879
