### PR TITLE
Support alternative GCP universes

### DIFF
--- a/barman/cloud_providers/google_cloud_storage.py
+++ b/barman/cloud_providers/google_cloud_storage.py
@@ -134,7 +134,7 @@ class GoogleCloudInterface(CloudInterface):
         client_options = None
         universe_domain = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
         if universe_domain:
-            client_options={"universe_domain": universe_domain}
+            client_options = {"universe_domain": universe_domain}
 
         self.client = storage.Client(client_options=client_options)
         self.container_client = self.client.bucket(self.bucket_name)

--- a/barman/cloud_providers/google_cloud_storage.py
+++ b/barman/cloud_providers/google_cloud_storage.py
@@ -131,7 +131,12 @@ class GoogleCloudInterface(CloudInterface):
         Creates a client using "GOOGLE_APPLICATION_CREDENTIALS" env.
         An error will be raised if the variable is missing.
         """
-        self.client = storage.Client()
+        client_options = None
+        universe_domain = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
+        if universe_domain:
+            client_options={"universe_domain": universe_domain}
+
+        self.client = storage.Client(client_options=client_options)
         self.container_client = self.client.bucket(self.bucket_name)
 
     def test_connectivity(self):

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -2658,7 +2658,9 @@ class TestGoogleCloudInterface(TestCase):
         container_client_mock.exists.side_effect = GoogleAPIError("error")
         assert cloud_interface.test_connectivity() is False
 
-    @mock.patch.dict(os.environ, {"GOOGLE_CLOUD_UNIVERSE_DOMAIN": "custom.universe.domain"})
+    @mock.patch.dict(
+        os.environ, {"GOOGLE_CLOUD_UNIVERSE_DOMAIN": "custom.universe.domain"}
+    )
     @mock.patch("barman.cloud_providers.google_cloud_storage.storage.Client")
     def test_universe_domain_from_environment(self, gcs_client_mock):
         """
@@ -2677,7 +2679,10 @@ class TestGoogleCloudInterface(TestCase):
 
         # AND the cloud interface should be properly initialized
         assert cloud_interface.client == gcs_client_mock.return_value
-        assert cloud_interface.container_client == gcs_client_mock.return_value.bucket.return_value
+        assert (
+            cloud_interface.container_client
+            == gcs_client_mock.return_value.bucket.return_value
+        )
 
     @mock.patch("barman.cloud_providers.google_cloud_storage.storage.Client")
     def test_no_universe_domain_environment(self, gcs_client_mock):
@@ -2695,7 +2700,10 @@ class TestGoogleCloudInterface(TestCase):
 
         # AND the cloud interface should be properly initialized
         assert cloud_interface.client == gcs_client_mock.return_value
-        assert cloud_interface.container_client == gcs_client_mock.return_value.bucket.return_value
+        assert (
+            cloud_interface.container_client
+            == gcs_client_mock.return_value.bucket.return_value
+        )
 
     @mock.patch("barman.cloud_providers.google_cloud_storage.storage.Client")
     def test_setup_bucket(self, gcs_client_mock):

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -2658,6 +2658,45 @@ class TestGoogleCloudInterface(TestCase):
         container_client_mock.exists.side_effect = GoogleAPIError("error")
         assert cloud_interface.test_connectivity() is False
 
+    @mock.patch.dict(os.environ, {"GOOGLE_CLOUD_UNIVERSE_DOMAIN": "custom.universe.domain"})
+    @mock.patch("barman.cloud_providers.google_cloud_storage.storage.Client")
+    def test_universe_domain_from_environment(self, gcs_client_mock):
+        """
+        Test that the universe domain is properly loaded from GOOGLE_CLOUD_UNIVERSE_DOMAIN
+        environment variable and passed to the storage client
+        """
+        # GIVEN a GoogleCloudInterface instance is created
+        cloud_interface = GoogleCloudInterface(
+            "https://console.cloud.google.com/storage/browser/barman-test/test"
+        )
+
+        # THEN the storage.Client should be called with the universe_domain in client_options
+        gcs_client_mock.assert_called_once_with(
+            client_options={"universe_domain": "custom.universe.domain"}
+        )
+
+        # AND the cloud interface should be properly initialized
+        assert cloud_interface.client == gcs_client_mock.return_value
+        assert cloud_interface.container_client == gcs_client_mock.return_value.bucket.return_value
+
+    @mock.patch("barman.cloud_providers.google_cloud_storage.storage.Client")
+    def test_no_universe_domain_environment(self, gcs_client_mock):
+        """
+        Test that when GOOGLE_CLOUD_UNIVERSE_DOMAIN is not set, the storage client
+        is created without client_options
+        """
+        # GIVEN a GoogleCloudInterface instance is created without universe domain env var
+        cloud_interface = GoogleCloudInterface(
+            "https://console.cloud.google.com/storage/browser/barman-test/test"
+        )
+
+        # THEN the storage.Client should be called with client_options=None
+        gcs_client_mock.assert_called_once_with(client_options=None)
+
+        # AND the cloud interface should be properly initialized
+        assert cloud_interface.client == gcs_client_mock.return_value
+        assert cloud_interface.container_client == gcs_client_mock.return_value.bucket.return_value
+
     @mock.patch("barman.cloud_providers.google_cloud_storage.storage.Client")
     def test_setup_bucket(self, gcs_client_mock):
         """


### PR DESCRIPTION
In multiple countries, local hosting companies are partnering with GCP to offer EU-sovereign GCP-like environments. Such partnerships include [one with T-Systems in Germany](https://www.t-systems.com/de/en/sovereign-cloud/solutions/sovereign-cloud-powered-by-google-cloud) or one with Thales in France: [S3NS](https://www.s3ns.io/en).

For that, Google introduced the notion of `universe` in their SDKs and CLI tools, to basically point them at non-Google infrastructure.

We're currently porting our platform to S3NS, which includes CNPG with the Barman Cloud plugin for backups, which doesn't work there right now because we can't configure the Google universe.

To connect to other universes, official clients need to be configured with a universe value, that overrides the base API domain. GOOGLE_CLOUD_UNIVERSE_DOMAIN is the official environment variable used to target non-GCP universes: https://documentation.s3ns.fr/docs/overview/tpc-key-differences#key_differences_for_developers

Unfortunately Barman uses the v1 client that doesn't read this variable, and only accepts the universe as part of the `client_options` field in the constructor, so we have to pass it in like this.