### PR TITLE
Fix breaking change in python 3.14

### DIFF
--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -182,9 +182,13 @@ class CloudTarUploader(object):
     # This is the method we use to create new buffers
     # We use named temporary files, so we can pass them by name to
     # other processes
-    _buffer = partial(
-        NamedTemporaryFile, delete=False, prefix="barman-upload-", suffix=".part"
-    )
+    # 20251223 pvbiesen: partial broke in 3.14, this could fix it with staticmethod :
+    #_buffer = staticmethod(partial(
+    #    NamedTemporaryFile, delete=False, prefix="barman-upload-", suffix=".part"
+    #))
+    # 20251223 pvbiesen: or, just for readability :
+    def _buffer(self):
+      return NamedTemporaryFile(delete=False, prefix="barman-upload-", suffix=".part")
 
     def __init__(
         self, cloud_interface, key, chunk_size, compression=None, max_bandwidth=None


### PR DESCRIPTION
From the release notes:
  functools.partial is now a method descriptor. Wrap it in staticmethod()
  if you want to preserve the old behavior.
  (Contributed by Serhiy Storchaka and Dominykas Grigonis in gh-121027.)

Converted _buffer to a real method for readality.