### PR TITLE
Avoid excessive Azure blob listings during container existence checks

### DIFF
--- a/barman/cloud_providers/azure_blob_storage.py
+++ b/barman/cloud_providers/azure_blob_storage.py
@@ -275,6 +275,7 @@ class AzureCloudInterface(CloudInterface):
         try:
             self.container_client.list_blobs(
                 name_starts_with=self.path.strip("/"),
+                results_per_page=1,
             ).next()
         except ResourceNotFoundError:
             return False

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1926,7 +1926,7 @@ class TestAzureCloudInterface(object):
         # iterate the bucket contents
         container_client = container_client_mock.from_connection_string.return_value
         container_client.list_blobs.assert_called_once_with(
-            name_starts_with="path/to/blob",
+            name_starts_with="path/to/blob", results_per_page=1
         )
         blobs_iterator = container_client.list_blobs.return_value
         blobs_iterator.next.assert_called_once_with()
@@ -1964,7 +1964,7 @@ class TestAzureCloudInterface(object):
         cloud_interface.setup_bucket()
         container_client = container_client_mock.from_connection_string.return_value
         container_client.list_blobs.assert_called_once_with(
-            name_starts_with="path/to/blob",
+            name_starts_with="path/to/blob", results_per_page=1
         )
         blobs_iterator = container_client.list_blobs.return_value
         blobs_iterator.next.assert_called_once_with()
@@ -1985,7 +1985,7 @@ class TestAzureCloudInterface(object):
         blobs_iterator.next.side_effect = ResourceNotFoundError()
         cloud_interface.setup_bucket()
         container_client.list_blobs.assert_called_once_with(
-            name_starts_with="path/to/blob",
+            name_starts_with="path/to/blob", results_per_page=1
         )
         blobs_iterator.next.assert_called_once_with()
         container_client.create_container.assert_called_once_with()


### PR DESCRIPTION
## Summary

Apply a result limit to Azure list_blobs calls used for container (bucket) existence checks.

## Details

Barman checks whether an Azure Blob Storage container exists by calling list_blobs.
This check only needs to validate container accessibility, but on large containers an unrestricted listing can return an excessive number of objects, inflating response payload size and network traffic.

This change adds a listing limit only for the list_blobs usage in the container existence check path, ensuring that the check returns a minimal number of objects while preserving correct behavior.

## Experiment

In our production environment, we operate 58 databases using CNPG, all sharing a single Azure Blob Storage container as WAL object storage.

Before this change, the container existence check generated approximately 135 GiB of network traffic per hour.
After applying the limit, traffic dropped to around 12 MiB per hour, resulting in roughly a 10,000× reduction in network usage.