### PR TITLE
fix(cloud): emit fixed-size multipart upload parts for R2 compatibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Keep image build contexts lean; setup.py needs barman/ plus the prebuilt
+# man pages under docs/_build/man (data_files), so docs stays in context.
+.git
+.github
+.venv
+.pytest_cache
+build
+tests
+barman.egg-info

--- a/.github/workflows/cnpg-image.yml
+++ b/.github/workflows/cnpg-image.yml
@@ -1,0 +1,45 @@
+---
+name: CNPG operand image
+
+# Publishes the CloudNativePG postgres operand image with the forked barman
+# overlaid (R2 multipart fix). Consumed by misfits-postgres clusters via
+# cluster.imageName in the canton monorepo.
+on:
+  push:
+    branches:
+      - bb/fix-r2-multipart-uniform-parts
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    name: Build and push ghcr.io/0xsend/cnpg-postgresql
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.cnpg
+          push: true
+          # Swiss cluster nodes are amd64-only Hetzner machines.
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/0xsend/cnpg-postgresql:18-r2
+            ghcr.io/0xsend/cnpg-postgresql:18-r2-${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.12-slim AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    libsnappy-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /src
+RUN pip install --no-cache-dir --no-deps /src && \
+    pip install --no-cache-dir boto3 python-dateutil python-snappy cramjam setuptools psycopg2-binary
+
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.source="https://github.com/0xsend/barman"
+LABEL org.opencontainers.image.description="Barman cloud tools with R2-compatible multipart uploads (snappy+gzip)"
+LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libsnappy1v5 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder /usr/local/bin/barman-cloud-* /usr/local/bin/
+
+ENTRYPOINT ["barman-cloud-backup"]

--- a/Dockerfile.cnpg
+++ b/Dockerfile.cnpg
@@ -1,0 +1,36 @@
+# CNPG operand image carrying the 0xsend barman fork.
+#
+# CloudNativePG's in-tree barmanObjectStore method executes barman-cloud-backup
+# from inside the postgres operand image, so shipping the R2 multipart fix
+# (uniform part sizes, EnterpriseDB/barman#954) requires overlaying the fork
+# onto the upstream operand image — there is no knob to point in-tree backups
+# at a separate barman container.
+#
+# barman is pure python, so build the wheel on a modern interpreter and
+# force-reinstall it over the stock barman (same 3.17.0 base version) in the
+# operand's python 3.9 environment.
+
+FROM python:3.12-slim AS builder
+
+COPY . /src
+RUN pip wheel --no-cache-dir --no-deps --wheel-dir /wheels /src
+
+# Pin the operand base by digest: rebuilds must deliberately track upstream
+# postgresql:18 updates, not silently absorb whatever the tag points at.
+FROM ghcr.io/cloudnative-pg/postgresql:18@sha256:afbcd2ca3827991317113ba8a90348f321b13a9698c39aaac8c089837a4e07f3
+
+LABEL org.opencontainers.image.source="https://github.com/0xsend/barman"
+LABEL org.opencontainers.image.description="CloudNativePG PostgreSQL 18 operand with R2-compatible barman multipart uploads"
+LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
+
+USER root
+COPY --from=builder /wheels /tmp/wheels
+# --force-reinstall: the fork shares upstream's 3.17.0 version number, so a
+# plain install would be a no-op against the preinstalled barman.
+# The import assert fails the build if the fork didn't replace stock barman.
+RUN python3 -m pip install --no-cache-dir --no-deps --force-reinstall /tmp/wheels/barman-*.whl \
+    && rm -rf /tmp/wheels \
+    && python3 -c "from barman.cloud import CloudTarUploader; assert hasattr(CloudTarUploader, '_upload_part_buffer'), 'barman fork not installed'"
+
+# CNPG operand images run postgres as uid 26; restore it after the root install.
+USER 26

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -199,6 +199,10 @@ class CloudTarUploader(object):
         :param int max_bandwidth: the maximum amount of data per second that
           should be uploaded by this tar uploader
         """
+        if not isinstance(chunk_size, int) or chunk_size <= 0:
+            raise ValueError(
+                "chunk_size must be a positive integer, got: %s" % chunk_size
+            )
         self.cloud_interface = cloud_interface
         self.key = key
         self.chunk_size = chunk_size
@@ -272,11 +276,6 @@ class CloudTarUploader(object):
         if not data:
             return
 
-        if not self.chunk_size or self.chunk_size <= 0:
-            raise ValueError(
-                "chunk_size must be a positive integer, got: %s" % self.chunk_size
-            )
-
         offset = 0
         data_len = len(data)
         while offset < data_len:
@@ -290,44 +289,57 @@ class CloudTarUploader(object):
             if self.buffer.tell() == self.chunk_size:
                 self._upload_part_buffer()
 
-    def _upload_part_buffer(self):
+    def _upload_part_buffer(self, is_final=False):
         """
         Upload the current part buffer as one multipart upload part.
         """
         if not self.buffer or self.buffer.tell() == 0:
             return
 
+        part_size = self.buffer.tell()
+        if not is_final and part_size != self.chunk_size:
+            raise RuntimeError(
+                "Cannot upload non-final multipart part with size %s (expected %s)"
+                % (part_size, self.chunk_size)
+            )
+
         if not self.upload_metadata:
             self.upload_metadata = self.cloud_interface.create_multipart_upload(
                 self.key
             )
 
-        part_size = self.buffer.tell()
         self.buffer.flush()
         self.buffer.seek(0, os.SEEK_SET)
-        self.counter += 1
+        part_number = self.counter + 1
         if self.max_bandwidth:
             # Upload throttling is applied just before uploading the next part so that
             # compression and flushing have already happened before we start waiting.
             self._throttle_upload(part_size)
-        self.cloud_interface.async_upload_part(
-            upload_metadata=self.upload_metadata,
-            key=self.key,
-            body=self.buffer,
-            part_number=self.counter,
-        )
+        try:
+            self.cloud_interface.async_upload_part(
+                upload_metadata=self.upload_metadata,
+                key=self.key,
+                body=self.buffer,
+                part_number=part_number,
+            )
+        except Exception:
+            # Keep the full part in memory for retry callers and preserve the part
+            # number sequence by not incrementing self.counter on failure.
+            self.buffer.seek(part_size, os.SEEK_SET)
+            raise
+        self.counter = part_number
         self.buffer.close()
         self.buffer = None
 
-    def flush(self):
-        # Maintained for compatibility — close() still calls it to drain the
-        # remaining data as the final (potentially smaller) trailing part.
-        self._upload_part_buffer()
+    def flush(self, is_final=False):
+        # Kept for compatibility. Non-final flushes require full chunk_size parts
+        # while final flushes may upload the trailing short part.
+        self._upload_part_buffer(is_final=is_final)
 
     def close(self):
         if self.tar:
             self.tar.close()
-        self.flush()
+        self.flush(is_final=True)
         self.cloud_interface.async_complete_multipart_upload(
             upload_metadata=self.upload_metadata,
             key=self.key,

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -225,21 +225,17 @@ class CloudTarUploader(object):
         self.size_of_last_upload = None
 
     def write(self, buf):
-        if self.buffer and self.buffer.tell() > self.chunk_size:
-            self.flush()
-        if not self.buffer:
-            self.buffer = self._buffer()
         if self.compressor:
             # If we have a custom compressor we must use it here
-            compressed_buf = self.compressor.add_chunk(buf)
-            self.buffer.write(compressed_buf)
-            self.size += len(compressed_buf)
+            data = self.compressor.add_chunk(buf)
+            self.size += len(data)
         else:
             # If there is no custom compressor then we are either not using
             # compression or tar has already compressed it - in either case we
-            # just write the data to the buffer
-            self.buffer.write(buf)
-            self.size += len(buf)
+            # just write the data to the multipart upload parts
+            data = buf
+            self.size += len(data)
+        self._write_data(data)
 
     def _throttle_upload(self, part_size):
         """
@@ -268,7 +264,39 @@ class CloudTarUploader(object):
         self.time_of_last_upload = datetime.datetime.now()
         self.size_of_last_upload = part_size
 
-    def flush(self):
+    def _write_data(self, data):
+        """
+        Write bytes into the current disk-backed part buffer and upload full
+        chunk_size parts as they are filled.
+        """
+        if not data:
+            return
+
+        if not self.chunk_size or self.chunk_size <= 0:
+            raise ValueError(
+                "chunk_size must be a positive integer, got: %s" % self.chunk_size
+            )
+
+        offset = 0
+        data_len = len(data)
+        while offset < data_len:
+            if not self.buffer:
+                self.buffer = self._buffer()
+            current_part_size = self.buffer.tell()
+            bytes_to_fill_part = self.chunk_size - current_part_size
+            bytes_to_write = min(bytes_to_fill_part, data_len - offset)
+            self.buffer.write(data[offset : offset + bytes_to_write])
+            offset += bytes_to_write
+            if self.buffer.tell() == self.chunk_size:
+                self._upload_part_buffer()
+
+    def _upload_part_buffer(self):
+        """
+        Upload the current part buffer as one multipart upload part.
+        """
+        if not self.buffer or self.buffer.tell() == 0:
+            return
+
         if not self.upload_metadata:
             self.upload_metadata = self.cloud_interface.create_multipart_upload(
                 self.key
@@ -290,6 +318,11 @@ class CloudTarUploader(object):
         )
         self.buffer.close()
         self.buffer = None
+
+    def flush(self):
+        # Maintained for compatibility — close() still calls it to drain the
+        # remaining data as the final (potentially smaller) trailing part.
+        self._upload_part_buffer()
 
     def close(self):
         if self.tar:

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -3878,6 +3878,55 @@ end_time=2022-11-09 12:05:00
 class TestCloudTarUploader(object):
     """Tests CloudTarUploader creates valid tar files."""
 
+    @mock.patch("barman.cloud.CloudInterface")
+    def test_write_uses_disk_buffer_for_partial_data(self, mock_cloud_interface):
+        """
+        Verifies write keeps partial upload data in the disk-backed temp
+        buffer, not an in-memory accumulator.
+        """
+        uploader = CloudTarUploader(mock_cloud_interface, "key", chunk_size=1 << 40)
+        uploader.write(b"abc")
+
+        assert uploader.buffer is not None
+        assert uploader.buffer.tell() == 3
+        mock_cloud_interface.async_upload_part.assert_not_called()
+
+        buffer_name = uploader.buffer.name
+        uploader.buffer.close()
+        os.unlink(buffer_name)
+
+    @mock.patch("barman.cloud.CloudInterface")
+    def test_write_emits_fixed_size_parts_and_retains_tail(self, mock_cloud_interface):
+        """
+        Verifies write emits fixed-size parts and leaves only trailing bytes in
+        the buffer until flush uploads the final short part.
+        """
+        uploader = CloudTarUploader(mock_cloud_interface, "key", chunk_size=4)
+        uploader.write(b"abcdefghij")
+
+        assert mock_cloud_interface.async_upload_part.call_count == 2
+        uploaded_bodies = [
+            call_args[1]["body"]
+            for call_args in mock_cloud_interface.async_upload_part.call_args_list
+        ]
+        uploaded_sizes = [os.path.getsize(body.name) for body in uploaded_bodies]
+        assert uploaded_sizes == [4, 4]
+        assert uploader.buffer is not None
+        assert uploader.buffer.tell() == 2
+
+        uploader.flush()
+        assert mock_cloud_interface.async_upload_part.call_count == 3
+        final_body = mock_cloud_interface.async_upload_part.call_args_list[-1][1]["body"]
+        assert os.path.getsize(final_body.name) == 2
+        assert uploader.buffer is None
+
+        for body in [
+            call_args[1]["body"]
+            for call_args in mock_cloud_interface.async_upload_part.call_args_list
+        ]:
+            if os.path.exists(body.name):
+                os.unlink(body.name)
+
     @pytest.mark.parametrize(
         "compression",
         # The CloudTarUploader expects the short form compression args set by the
@@ -4101,7 +4150,9 @@ class TestCloudTarUploader(object):
             None,
             max_bandwidth,
         )
+        # Put some data in the disk buffer so flush has something to upload
         uploader.buffer = MagicMock()
+        uploader.buffer.tell.return_value = 1024
         # WHEN flush is called
         with mock.patch(
             "barman.cloud.CloudTarUploader._throttle_upload"

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -3914,7 +3914,7 @@ class TestCloudTarUploader(object):
         assert uploader.buffer is not None
         assert uploader.buffer.tell() == 2
 
-        uploader.flush()
+        uploader.flush(is_final=True)
         assert mock_cloud_interface.async_upload_part.call_count == 3
         final_body = mock_cloud_interface.async_upload_part.call_args_list[-1][1]["body"]
         assert os.path.getsize(final_body.name) == 2
@@ -3926,6 +3926,123 @@ class TestCloudTarUploader(object):
         ]:
             if os.path.exists(body.name):
                 os.unlink(body.name)
+
+    @mock.patch("barman.cloud.CloudInterface")
+    def test_write_across_calls_emits_fixed_size_parts_and_retains_tail(
+        self, mock_cloud_interface
+    ):
+        """
+        Verifies multiple writes are coalesced into fixed-size parts and retain
+        only trailing bytes in the buffer.
+        """
+        uploader = CloudTarUploader(mock_cloud_interface, "key", chunk_size=4)
+        uploader.write(b"ab")
+        uploader.write(b"cdefg")
+
+        assert mock_cloud_interface.async_upload_part.call_count == 1
+        uploaded_body = mock_cloud_interface.async_upload_part.call_args_list[0][1]["body"]
+        assert os.path.getsize(uploaded_body.name) == 4
+        assert uploader.buffer is not None
+        assert uploader.buffer.tell() == 3
+
+        uploader.flush(is_final=True)
+        assert mock_cloud_interface.async_upload_part.call_count == 2
+        final_body = mock_cloud_interface.async_upload_part.call_args_list[-1][1]["body"]
+        assert os.path.getsize(final_body.name) == 3
+        assert uploader.buffer is None
+
+        for body in [
+            call_args[1]["body"]
+            for call_args in mock_cloud_interface.async_upload_part.call_args_list
+        ]:
+            if os.path.exists(body.name):
+                os.unlink(body.name)
+
+    @mock.patch("barman.cloud.CloudInterface")
+    def test_write_exact_chunk_multiples_emit_no_trailing_part_on_flush(
+        self, mock_cloud_interface
+    ):
+        """Verifies exact chunk multiples do not produce an extra empty tail part."""
+        uploader = CloudTarUploader(mock_cloud_interface, "key", chunk_size=4)
+        uploader.write(b"abcdefgh")
+
+        assert mock_cloud_interface.async_upload_part.call_count == 2
+        uploaded_sizes = [
+            os.path.getsize(call_args[1]["body"].name)
+            for call_args in mock_cloud_interface.async_upload_part.call_args_list
+        ]
+        assert uploaded_sizes == [4, 4]
+        assert uploader.buffer is None
+
+        uploader.flush()
+        assert mock_cloud_interface.async_upload_part.call_count == 2
+
+        for body in [
+            call_args[1]["body"]
+            for call_args in mock_cloud_interface.async_upload_part.call_args_list
+        ]:
+            if os.path.exists(body.name):
+                os.unlink(body.name)
+
+    @mock.patch("barman.cloud.CloudInterface")
+    def test_flush_rejects_non_final_partial_part(self, mock_cloud_interface):
+        """Verifies non-final flush cannot upload a short multipart part."""
+        uploader = CloudTarUploader(mock_cloud_interface, "key", chunk_size=4)
+        uploader.write(b"abc")
+
+        with pytest.raises(RuntimeError):
+            uploader.flush()
+        assert mock_cloud_interface.async_upload_part.call_count == 0
+        assert uploader.buffer is not None
+        assert uploader.buffer.tell() == 3
+
+        buffer_name = uploader.buffer.name
+        uploader.buffer.close()
+        os.unlink(buffer_name)
+
+    @mock.patch("barman.cloud.CloudInterface")
+    def test_upload_part_failure_keeps_counter_and_buffer_for_retry(
+        self, mock_cloud_interface
+    ):
+        """
+        Verifies upload failures do not consume part numbers and preserve the
+        current full part buffer for retry.
+        """
+        mock_cloud_interface.async_upload_part.side_effect = RuntimeError("upload failed")
+        uploader = CloudTarUploader(mock_cloud_interface, "key", chunk_size=4)
+        uploader.buffer = uploader._buffer()
+        uploader.buffer.write(b"abcd")
+
+        with pytest.raises(RuntimeError):
+            uploader._upload_part_buffer()
+
+        assert uploader.counter == 0
+        assert uploader.buffer is not None
+        assert uploader.buffer.tell() == 4
+
+        mock_cloud_interface.async_upload_part.side_effect = None
+        uploader._upload_part_buffer()
+        assert uploader.counter == 1
+        assert uploader.buffer is None
+        part_numbers = [
+            call_args[1]["part_number"]
+            for call_args in mock_cloud_interface.async_upload_part.call_args_list
+        ]
+        assert part_numbers == [1, 1]
+
+        for body in [
+            call_args[1]["body"]
+            for call_args in mock_cloud_interface.async_upload_part.call_args_list
+        ]:
+            if os.path.exists(body.name):
+                os.unlink(body.name)
+
+    @pytest.mark.parametrize("chunk_size", (None, 0, -1))
+    @mock.patch("barman.cloud.CloudInterface")
+    def test_init_rejects_invalid_chunk_size(self, mock_cloud_interface, chunk_size):
+        """Verifies chunk_size is validated at initialization."""
+        with pytest.raises(ValueError):
+            CloudTarUploader(mock_cloud_interface, "key", chunk_size=chunk_size)
 
     @pytest.mark.parametrize(
         "compression",
@@ -4034,7 +4151,7 @@ class TestCloudTarUploader(object):
         uploader = CloudTarUploader(
             None,
             None,
-            None,
+            4,
             None,
             max_bandwidth,
         )
@@ -4113,7 +4230,7 @@ class TestCloudTarUploader(object):
         uploader = CloudTarUploader(
             None,
             None,
-            None,
+            4,
             None,
             max_bandwidth,
         )
@@ -4146,7 +4263,7 @@ class TestCloudTarUploader(object):
         uploader = CloudTarUploader(
             mock_cloud_interface,
             None,
-            None,
+            1024,
             None,
             max_bandwidth,
         )


### PR DESCRIPTION
## Summary

- Refactor `CloudTarUploader` to fill each disk-backed temp file to exactly `chunk_size` bytes before uploading, so every non-trailing multipart part is uniform in size
- Cloudflare R2 requires all non-trailing parts to have identical sizes; the previous implementation flushed whenever the buffer exceeded `chunk_size`, producing variable-sized parts
- The trailing part (uploaded via `flush`/`close`) may be smaller, which is allowed by the multipart upload spec
- Backward compatible with AWS S3 and other providers

## Changes

- `barman/cloud.py`: Extract `_write_data()` (fills fixed-size part buffers) and `_upload_part_buffer()` (uploads a single part) from the existing `write()`/`flush()` methods
- `tests/test_cloud.py`: Add two new tests verifying partial-buffer behavior and fixed-size part emission; fix existing throttle test to set up buffer state correctly

## Test plan

- [ ] `test_write_uses_disk_buffer_for_partial_data` — partial writes stay in buffer, no upload triggered
- [ ] `test_write_emits_fixed_size_parts_and_retains_tail` — 10 bytes at chunk_size=4 produces two 4-byte parts + 2-byte tail
- [ ] Existing `TestCloudTarUploader` tests continue to pass

Fixes: EnterpriseDB/barman#954