### PR TITLE
docs(user_guide,retention_policies.rst): fix small rendering issue

### DIFF
--- a/docs/user_guide/retention_policies.rst
+++ b/docs/user_guide/retention_policies.rst
@@ -239,7 +239,7 @@ When retention policy is applied:
 * If the root backup is marked as ``KEEP:FULL``, all associated incremental backups are
   marked as ``VALID``, regardless of whether the root backup is within the retention
   policy.
-* If the root backup is marked as ``KEEP:STANDALONE``and is still within the retention
+* If the root backup is marked as ``KEEP:STANDALONE`` and is still within the retention
   policy, all associated incremental backups are marked as ``VALID``. However, if the
   root backup is outside the retention policy, all associated incremental backups are
   marked as ``OBSOLETE``.


### PR DESCRIPTION
I noticed this small issue with rendering the documentation.

<img width="681" height="115" alt="grafik" src="https://github.com/user-attachments/assets/4fff1883-125e-4532-97ce-178497103573" />

This PR should fix this.
I did not create an issue for this, because I don't think it's necessary.