### PR TITLE
Fix uid incorrectly assigned to gid in CloudUploadController.add_fileobj

### DIFF
--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -515,7 +515,7 @@ class CloudUploadController(object):
         if mode is not None:
             tarinfo.mode = mode
         if uid is not None:
-            tarinfo.gid = uid
+            tarinfo.uid = uid
         if gid is not None:
             tarinfo.gid = gid
         fileobj.seek(0, os.SEEK_SET)


### PR DESCRIPTION
## Summary
- In `barman/cloud.py`, the `add_fileobj` method has a bug where the `uid` parameter is incorrectly assigned to `tarinfo.gid` instead of `tarinfo.uid` (line 518)
- This causes uploaded tar entries to have incorrect ownership metadata — the user ID would be missing and the group ID would be wrong

## Bug details
```python
# Before (buggy):
if uid is not None:
    tarinfo.gid = uid  # <-- should be tarinfo.uid
if gid is not None:
    tarinfo.gid = gid

# After (fixed):
if uid is not None:
    tarinfo.uid = uid
if gid is not None:
    tarinfo.gid = gid
```

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm `tarinfo.uid` is correctly set when `uid` parameter is provided to `add_fileobj`

🤖 Generated with [Claude Code](https://claude.com/claude-code)