### PR TITLE
Add missing .zst extension for ZSTD compression in _build_dest_name

### DIFF
--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -414,6 +414,8 @@ class CloudUploadController(object):
             components.append(".snappy")
         elif self.compression == "lz4":
             components.append(".lz4")
+        elif self.compression == "zstd":
+            components.append(".zst")
         return "".join(components)
 
     def _get_tar(self, name):


### PR DESCRIPTION
## Summary
- The `_build_dest_name` method in `CloudUploadController` (barman/cloud.py) handles compression extensions for `gz`, `bz2`, `snappy`, and `lz4`, but was missing `zstd`
- When ZSTD compression is used, the resulting tar archives are created without the `.zst` extension, which can confuse downstream decompression logic that relies on file extensions
- The `ALLOWED_COMPRESSIONS` dict at line 86 already maps `.zst` to `zstd`, confirming this extension should be used

## Bug details
```python
# Before (missing zstd):
elif self.compression == "lz4":
    components.append(".lz4")
return "".join(components)

# After (fixed):
elif self.compression == "lz4":
    components.append(".lz4")
elif self.compression == "zstd":
    components.append(".zst")
return "".join(components)
```

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm ZSTD-compressed archives get the `.zst` extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)