### PR TITLE
Fix manage_server_command only showing first error for disabled servers

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -2745,7 +2745,7 @@ def manage_server_command(
         if disabled_is_error:
             for message in server.config.msg_list:
                 output.error(message)
-                return False
+            return False
         if skip_disabled:
             return False
 


### PR DESCRIPTION
## Summary
- In `manage_server_command` (barman/cli.py), when a disabled server has multiple error messages in `msg_list`, only the first message is shown before returning `False`
- The `return False` was inside the `for` loop instead of after it, so subsequent error messages were never displayed

## Bug details
```python
# Before (buggy) - return inside loop:
if disabled_is_error:
    for message in server.config.msg_list:
        output.error(message)
        return False  # Only first message shown!

# After (fixed) - return after loop:
if disabled_is_error:
    for message in server.config.msg_list:
        output.error(message)
    return False  # All messages shown before returning
```

## Test plan
- [ ] Verify that when a server has multiple configuration errors, all error messages are displayed
- [ ] Confirm the function still returns `False` as expected for disabled servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)