### PR TITLE
Fix missing staging_dir in CloudTarUploader created on archive split

### DIFF
--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -448,6 +448,7 @@ class CloudUploadController(object):
                 chunk_size=self.chunk_size,
                 compression=self.compression,
                 max_bandwidth=self.max_bandwidth,
+                staging_dir=self.staging_dir,
             )
             self.tar_list[name].append(uploader)
         return uploader.tar


### PR DESCRIPTION
## Summary
- In `CloudUploadController._get_tar()` (barman/cloud.py), when a tar archive exceeds `max_archive_size` and needs to be split into parts, the newly created `CloudTarUploader` is missing the `staging_dir` parameter
- The initial uploader (created at line 428-436) correctly passes `staging_dir=self.staging_dir`, but the split uploader (line 442-451) does not
- This causes split archives to use the system default temp directory instead of the explicitly configured staging directory, which can lead to failures if the staging dir was configured on a specific volume with sufficient space

## Bug details
The initial uploader creation passes `staging_dir`:
```python
CloudTarUploader(
    ...
    staging_dir=self.staging_dir,  # Present ✓
)
```

But the split uploader does not:
```python
CloudTarUploader(
    ...
    # staging_dir=self.staging_dir  # Missing! ✗
)
```

## Test plan
- [ ] Confirm split archive uploads use the configured staging directory
- [ ] Verify existing cloud upload tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)