### PR TITLE
Fix file descriptor leak in BarmanSubProcess.execute()

### DIFF
--- a/barman/command_wrappers.py
+++ b/barman/command_wrappers.py
@@ -1419,6 +1419,7 @@ class BarmanSubProcess(object):
             stdin=devnull,
             **additional_arguments,
         )
+        devnull.close()
         _logger.debug("BarmanSubProcess: subprocess started. pid: %s", proc.pid)
 
 


### PR DESCRIPTION
## Summary
- In `BarmanSubProcess.execute()` (barman/command_wrappers.py), the `devnull` file object opened with `open(os.devnull, "a+")` is never closed
- After `subprocess.Popen` is created, it inherits the file descriptor, but the parent process still holds it open
- This leaks a file descriptor on every invocation of `execute()`

## Bug details
```python
# Before (buggy) - devnull never closed:
devnull = open(os.devnull, "a+")
proc = subprocess.Popen(...)
_logger.debug(...)

# After (fixed) - close after Popen inherits the FD:
devnull = open(os.devnull, "a+")
proc = subprocess.Popen(...)
devnull.close()
_logger.debug(...)
```

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm no file descriptor leak when `BarmanSubProcess.execute()` is called repeatedly

🤖 Generated with [Claude Code](https://claude.com/claude-code)