### PR TITLE
Fix negative file_count when streaming WAL directory is empty

### DIFF
--- a/barman/server.py
+++ b/barman/server.py
@@ -826,7 +826,7 @@ class Server(RemoteStatusMixin):
 
         # Subtract one from the count because of .partial file inside the
         # streaming directory
-        if dir_name == "streaming":
+        if dir_name == "streaming" and file_count > 0:
             file_count -= 1
 
         # If this archiver is disabled, check the number of files in the


### PR DESCRIPTION
## Summary
- In `_check_wal_queue` (barman/server.py), `file_count` is decremented by 1 when `dir_name == "streaming"` to account for the `.partial` file
- If the streaming directory is empty (0 files), `file_count` becomes `-1`, which can lead to incorrect comparison results
- The `file_count > 0` check at line 838 will correctly skip for `-1`, but `file_count > max_incoming_wal` at line 854 could produce confusing negative values in error messages

## Bug details
```python
# Before (buggy) - can go negative:
if dir_name == "streaming":
    file_count -= 1  # -1 when directory is empty!

# After (fixed) - guard against negative:
if dir_name == "streaming" and file_count > 0:
    file_count -= 1
```

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm that an empty streaming directory results in `file_count == 0` instead of `-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)