### PR TITLE
Fix TypeError cannot pickle '_thread.lock' object

### DIFF
--- a/barman/command_wrappers.py
+++ b/barman/command_wrappers.py
@@ -31,7 +31,7 @@ import select
 import signal
 import subprocess
 import sys
-import threading
+import multiprocessing
 import time
 from distutils.version import LooseVersion as Version
 
@@ -238,7 +238,7 @@ class Command(object):
         self.out = None
         self.err = None
         # Lock to protect access to self.pipe after subprocess creation
-        self._pipe_lock = threading.Lock()
+        self._pipe_lock = multiprocessing.Lock()
         # If env_append has been provided use it or replace with an empty dict
         env_append = env_append or {}
         # If path has been provided, replace it in the environment


### PR DESCRIPTION
With the changes introduced in 3.18.0 to `command_wrappers.py`, recovery fails with the error:
barman.copy_controller INFO: Copy failed
barman.cli ERROR: cannot pickle '_thread.lock' object

And the following messages in the log:
TypeError: cannot pickle '_thread.lock' object
when serializing dict item '_pipe_lock'
when serializing barman.command_wrappers.RsyncPgData state
when serializing barman.command_wrappers.RsyncPgData object
[..]

This commit removes the use of the `threading.Lock()` which cannot be pickled by the `ForkingPickler()` class called from the function `dump()` in the `multiprocessing.reduction` module which in turn is a `pickle.Pickler()` subclass whose `dump()` function eventually calls the `pickle.dump()` function.

Instead `multiprocessing.Lock()` is used.

A Lock in the multiprocessing module seems to be a wrapper around a shared semaphore (a `SemLock` object in `multiprocessing/synchronize.py`), and since semaphores can be shared across process boundaries, no pickling is needed.