### PR TITLE
Fix Azure snapshot create payload for azure-mgmt-compute 38+

### DIFF
--- a/barman/cloud_providers/azure_blob_storage.py
+++ b/barman/cloud_providers/azure_blob_storage.py
@@ -658,14 +658,24 @@ class AzureCloudSnapshotInterface(CloudSnapshotInterface):
         """
         snapshot_name = "%s-%s" % (disk_name, backup_info.backup_id.lower())
         _logger.info("Taking snapshot '%s' of disk '%s'", snapshot_name, disk_name)
+        # azure-mgmt-compute 38.0.0 tightened its request deserializer and rejects
+        # the flat-dict payload barman previously sent: `incremental` and
+        # `creation_data` live under `properties.*` in the wire format. Build the
+        # request with the Snapshot/CreationData model objects so it works on both
+        # the lenient and strict deserializer tracks. See issue #1186.
+        compute = import_azure_mgmt_compute()
+        snapshot_model = compute.models.Snapshot(
+            location=location,
+            incremental=True,
+            creation_data=compute.models.CreationData(
+                create_option="Copy",
+                source_uri=disk_id,
+            ),
+        )
         resp = self.client.snapshots.begin_create_or_update(
             resource_group,
             snapshot_name,
-            {
-                "location": location,
-                "incremental": True,
-                "creation_data": {"create_option": "Copy", "source_uri": disk_id},
-            },
+            snapshot_model,
         )
 
         _logger.info("Waiting for snapshot '%s' completion", snapshot_name)

--- a/tests/test_cloud_snapshot_interface.py
+++ b/tests/test_cloud_snapshot_interface.py
@@ -1649,22 +1649,28 @@ class TestAzureCloudSnapshotInterface(object):
         )
 
         # THEN begin_create_or_update is called on the SnapshotsOperations with the
-        # expected args
+        # expected args. The payload is built with the azure-mgmt-compute model
+        # objects (Snapshot / CreationData) so the strict deserializer in
+        # azure-mgmt-compute 38+ accepts it.
         expected_disk_id = self.azure_disks[0]["id"]
         expected_disk_name = self.azure_disks[0]["name"]
         expected_location = self.azure_disks[0]["location"]
         expected_snapshot_name = self._get_snapshot_name(expected_disk_name)
+        mock_snapshot_model = self._mock_azure_mgmt_compute.models.Snapshot
+        mock_creation_data_model = self._mock_azure_mgmt_compute.models.CreationData
+        mock_creation_data_model.assert_called_once_with(
+            create_option="Copy",
+            source_uri=expected_disk_id,
+        )
+        mock_snapshot_model.assert_called_once_with(
+            location=expected_location,
+            incremental=True,
+            creation_data=mock_creation_data_model.return_value,
+        )
         mock_snapshot_operations.begin_create_or_update.assert_called_once_with(
             self.azure_resource_group,
             expected_snapshot_name,
-            {
-                "location": expected_location,
-                "incremental": True,
-                "creation_data": {
-                    "create_option": "Copy",
-                    "source_uri": expected_disk_id,
-                },
-            },
+            mock_snapshot_model.return_value,
         )
         # AND wait() was called on the response to await completion of the snapshot
         mock_resp.wait.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes #1186 — `barman-cloud-backup --cloud-provider azure-blob-storage --snapshot-instance ...` fails immediately on a fresh install because `azure-mgmt-compute>=38.0.0` ships a stricter request deserializer that rejects the flat dict barman passes to `snapshots.begin_create_or_update`:

```
ERROR: Backup failed uploading data ((InvalidRequestContent) The request content was invalid
and could not be deserialized: 'Could not find member 'incremental' on object of type
'ResourceDefinition'. Path 'incremental', line 1, position 45.'.)
```

`Snapshot._attribute_map` puts `incremental` and `creation_data` under `properties.*` on the wire, so the flat dict is neither a `Snapshot` model instance nor wire-format JSON. Older azure-mgmt-compute releases accepted it leniently; 38.0.0 does not.

## Change

Build the request payload with the `Snapshot`/`CreationData` model objects from `azure.mgmt.compute.models` instead of a flat dict. Model objects are unambiguous regardless of the SDK's deserializer mode and work on both old and new `azure-mgmt-compute` releases.

The model classes are resolved via the existing `import_azure_mgmt_compute()` helper to preserve the deferred-import pattern this module already uses.

## Test plan

- [x] `pytest tests/test_cloud_snapshot_interface.py` — 172 passed (locally, Python 3.11)
- [x] `pytest tests/test_cloud_snapshot_interface.py::TestAzureCloudSnapshotInterface` — 29 passed
- [x] Manual verification against Azure with `azure-mgmt-compute==38.0.0` — installing this branch alongside `azure-mgmt-compute==38.0.0` and re-running the original `barman-cloud-backup` command produces a successful snapshot.

## Related

- Issue: #1186
- Reporter has also flagged that `setup.py`'s `azure-snapshots` extra has no upper bound on `azure-mgmt-compute`, so a fresh `pip install` auto-picks the broken version. With this fix applied that pin is no longer strictly required, but a documented lower bound (or short-term upper bound until this lands in a release) may still be worth considering — happy to open a follow-up if you'd like.

cc @didorgas @martinmarques

