### PR TITLE
Clarify WAL retention policy documentation

### DIFF
--- a/docs/faq/index.rst
+++ b/docs/faq/index.rst
@@ -46,11 +46,17 @@ less invasive than what is required for high availability.
 
 **Can I define retention policies for my backups?**
 
-Yes. Barman 1.2.0 introduced support for retention policies both for base backups and
-WAL segments, for every server you have. You can specify a retention policy in the
-server configuration file. Retention policies can be based on time
-(e.g. ``RECOVERY WINDOW OF 30 DAYS``) or number of base backups
-(e.g. ``REDUNDANCY 3``).
+Yes. You can specify a retention policy in the server configuration file. The
+``retention_policy`` option controls which base backups, and which WAL files required
+by those backups, Barman retains. Retention policies can be based on time
+(for example, ``RECOVERY WINDOW OF 30 DAYS``) or number of base backups
+(for example, ``REDUNDANCY 3``).
+
+Barman doesn't currently support an independent retention policy for WAL files. The
+``wal_retention_policy`` option only supports ``main``, which means WAL retention
+follows the main ``retention_policy`` setting. To keep WAL files for a longer
+point-in-time recovery window, configure ``retention_policy`` for that window or manage
+the extra WAL archive outside Barman.
 
 **Does Barman guarantee data protection and security?**
 
@@ -240,6 +246,5 @@ Requirements
 
 Barman can take backups of your Postgres servers on Windows. The recovery part 
 is not supported. Additionally, Barman will have to run on a UNIX box.
-
 
 

--- a/docs/user_guide/configuration.rst
+++ b/docs/user_guide/configuration.rst
@@ -1574,7 +1574,9 @@ Scope: Global / Server / Model.
 
 **wal_retention_policy**
 
-Policy for retaining WAL files. Currently only ``main`` is available.
+Policy for retaining WAL files. Currently only ``main`` is available. With ``main``,
+WAL retention follows the main ``retention_policy`` setting. Barman doesn't support a
+separate WAL retention policy.
 
 Scope: Global / Server / Model.
 


### PR DESCRIPTION
## Summary
- update the FAQ so it no longer implies that WAL files can have an independent retention policy
- clarify that `wal_retention_policy = main` follows the main `retention_policy` setting

Closes #1183.

## Validation
- `git diff --check`
- `PYTHONPATH=. uvx --from sphinx --with sphinx-github-style --with sphinxcontrib-apidoc --with pydata-sphinx-theme --with myst_parser --with python-dateutil --with psycopg2-binary sphinx-build -b html docs /tmp/barman-docs-html -q --keep-going` exited 0; the log still contains existing unrelated documentation warnings, with none for the touched files
- `uvx tox -e docs -- html` could not complete locally because the tox env tried to build `psycopg2` and `pg_config` is not installed

Assisted-by: OpenAI GPT-5