### PR TITLE
Fix cloud-wal-restore on compressed WAL + sibling backup label

### DIFF
--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -3002,20 +3002,44 @@ class CloudWalDownloader(object):
 
         wals_to_download = []
         count = 0
+        found_requested = False
         for path in sorted(self.cloud_interface.list_bucket(prefix)):
-            is_requested_wal = path.startswith(requested_wal_path)
+            # Match the requested WAL by basename (after stripping any
+            # compression extension) rather than by raw prefix. A prefix
+            # match would also catch the related ``<wal>.<offset>.backup``
+            # label file, and the label sorts before the WAL's compressed
+            # form (``.0`` < ``.g``), so the loop would treat the label as
+            # ``is_requested_wal``, fail validation, and (under the legacy
+            # break-on-invalid behavior) exit before ever reaching the real
+            # compressed WAL — preventing recovery from fetching the
+            # start-checkpoint WAL. The ``.partial`` form is also accepted
+            # so a not-yet-archived WAL can still satisfy the request.
+            basename_no_compression = self._remove_compression_suffix(
+                os.path.basename(path)
+            )
+            is_requested_wal = basename_no_compression in (
+                wal_name,
+                wal_name + ".partial",
+            )
             if is_requested_wal or (path > requested_wal_path and count < parallel):
                 if not self._validate_wal_path(path, no_partial):
-                    if is_requested_wal:
-                        # If the requested WAL itself is not valid we can exit immediately
-                        break
                     continue
+                if is_requested_wal:
+                    found_requested = True
                 filename = os.path.basename(path)
                 _logger.info(
                     "Found WAL %s for server %s as %s", filename, self.server_name, path
                 )
                 wals_to_download.append(path)
                 count += 1
+
+        # Preserve the semantic introduced by the early-break in the previous
+        # implementation: if the requested WAL itself does not exist in the
+        # bucket, do not return prefetched siblings — recovery cannot use
+        # later WALs without the requested one anyway, and returning them
+        # would mislead the caller into thinking the request succeeded.
+        if not found_requested:
+            return []
 
         return wals_to_download
 

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -6094,6 +6094,42 @@ class TestCloudWalDownloader:
         # THEN an empty list is returned
         assert result == []
 
+    def test_get_wals_to_download_finds_compressed_wal_with_backup_label(self):
+        """
+        Test that _get_wals_to_download finds the requested compressed WAL even
+        when a sibling ``<wal>.<offset>.backup`` label file lives next to it in
+        the bucket.
+
+        Example scenario:
+            A user requests 00000001000000030000001A. The bucket holds both
+            00000001000000030000001A.gz (the actual WAL) and
+            00000001000000030000001A.00000028.backup.gz (the backup label).
+            S3 list_bucket returns them sorted, and the backup label sorts
+            before the WAL because ``.0`` < ``.g`` in ASCII. The downloader
+            must still return the real WAL.
+        """
+        # GIVEN a cloud bucket holding both the WAL and its sibling .backup label
+        mock_cloud_interface = MagicMock()
+        mock_cloud_interface.path = "bucket/barman"
+        wal_dir = "0000000100000003"
+        source_dir = "bucket/barman/test_server/wals/{}/".format(wal_dir)
+        # sorted() order — the .backup label appears before the .gz WAL
+        mock_cloud_interface.list_bucket.return_value = [
+            source_dir + "00000001000000030000001A.00000028.backup.gz",
+            source_dir + "00000001000000030000001A.gz",
+        ]
+
+        # AND a CloudWalDownloader
+        downloader = CloudWalDownloader(mock_cloud_interface, "test_server")
+
+        # WHEN _get_wals_to_download is called for the WAL
+        result = downloader._get_wals_to_download(
+            "00000001000000030000001A", no_partial=False, parallel=1
+        )
+
+        # THEN the actual WAL is returned, not skipped because of the label
+        assert result == [source_dir + "00000001000000030000001A.gz"]
+
     @mock.patch(
         "barman.cloud.CloudWalDownloader._validate_wal_path",
         new=lambda self, x, no_partial: False,  # always returns false


### PR DESCRIPTION
- `CloudWalDownloader._get_wals_to_download` matched the requested WAL by `path.startswith(requested_wal_path)`, which also matched the sibling `<wal>.<offset>.backup` label file. Combined with the early-break introduced in 5625881a, recovery against a compressed backup would exit the iteration on the `.backup.gz` entry (which sorts before `.gz` lexicographically) and never reach the real WAL — `FATAL: could not locate required checkpoint record`.
- Match by basename equality after stripping any compression suffix; accept both `<wal>` and `<wal>.partial`. Sibling `.backup` files are now harmlessly skipped via `_validate_wal_path`. The "requested WAL missing → return `[]`" invariant from 5625881a is preserved via a `found_requested` flag enforced after the loop.
- Adds a regression test covering the compressed-WAL + sibling-backup-label case.

References: BAR-1305.