### PR TITLE
Exit with network error code on cloud-wal-restore connectivity loss

### DIFF
--- a/barman/clients/cloud_walrestore.py
+++ b/barman/clients/cloud_walrestore.py
@@ -22,6 +22,7 @@ from contextlib import closing
 from barman.clients.cloud_cli import (
     CLIErrorExit,
     GeneralErrorExit,
+    NetworkErrorExit,
     create_argument_parser,
 )
 from barman.cloud import CloudWalDownloader, configure_logging
@@ -47,6 +48,7 @@ def main(args=None):
         _logger.error("%s is an invalid name for a WAL file" % config.wal_name)
         raise CLIErrorExit()
 
+    cloud_interface = None
     try:
         cloud_interface = get_cloud_interface(config)
 
@@ -68,6 +70,11 @@ def main(args=None):
     except Exception as exc:
         _logger.error("Barman cloud WAL restore exception: %s", force_str(exc))
         _logger.debug("Exception details:", exc_info=exc)
+        # If the failure was caused by loss of connectivity to the cloud
+        # provider, surface it as a dedicated network error (exit code 2)
+        # rather than a generic one.
+        if cloud_interface is not None and cloud_interface.is_connectivity_error(exc):
+            raise NetworkErrorExit()
         raise GeneralErrorExit()
 
 

--- a/barman/cloud.py
+++ b/barman/cloud.py
@@ -1144,6 +1144,17 @@ class CloudInterface(with_metaclass(ABCMeta)):
         """
 
     @abstractmethod
+    def is_connectivity_error(self, exc):
+        """
+        Determine whether the given exception was caused by a loss of
+        connectivity to the cloud provider.
+
+        :param Exception exc: the exception to inspect
+        :return: True if the exception denotes a network/connectivity error
+        :rtype: bool
+        """
+
+    @abstractmethod
     def _check_bucket_existence(self):
         """
         Check cloud storage for the target bucket

--- a/barman/cloud_providers/aws_s3.py
+++ b/barman/cloud_providers/aws_s3.py
@@ -218,9 +218,21 @@ class S3CloudInterface(CloudInterface):
             # we just want to try if aws is reachable
             self.bucket_exists = self._check_bucket_existence()
             return True
-        except EndpointConnectionError as exc:
-            _logger.error("Can't connect to cloud provider: %s", exc)
-            return False
+        except Exception as exc:
+            if self.is_connectivity_error(exc):
+                _logger.error("Can't connect to cloud provider: %s", exc)
+                return False
+            raise
+
+    def is_connectivity_error(self, exc):
+        """
+        Determine whether the given exception denotes a loss of connectivity
+        to AWS.
+
+        :param Exception exc: the exception to inspect
+        :rtype: bool
+        """
+        return isinstance(exc, EndpointConnectionError)
 
     def _check_bucket_existence(self):
         """

--- a/barman/cloud_providers/azure_blob_storage.py
+++ b/barman/cloud_providers/azure_blob_storage.py
@@ -257,9 +257,21 @@ class AzureCloudInterface(CloudInterface):
             # we just want to see if Azure blob service is reachable.
             self.bucket_exists = self._check_bucket_existence()
             return True
-        except (HttpResponseError, ServiceRequestError) as exc:
-            _logger.error("Can't connect to cloud provider: %s", exc)
-            return False
+        except Exception as exc:
+            if self.is_connectivity_error(exc):
+                _logger.error("Can't connect to cloud provider: %s", exc)
+                return False
+            raise
+
+    def is_connectivity_error(self, exc):
+        """
+        Determine whether the given exception denotes a loss of connectivity
+        to Azure.
+
+        :param Exception exc: the exception to inspect
+        :rtype: bool
+        """
+        return isinstance(exc, (HttpResponseError, ServiceRequestError))
 
     def _check_bucket_existence(self):
         """

--- a/barman/cloud_providers/google_cloud_storage.py
+++ b/barman/cloud_providers/google_cloud_storage.py
@@ -148,9 +148,21 @@ class GoogleCloudInterface(CloudInterface):
             # we just want to see if google cloud storage is reachable.
             self.bucket_exists = self._check_bucket_existence()
             return True
-        except GoogleAPIError as exc:
-            _logger.error("Can't connect to cloud provider: %s", exc)
-            return False
+        except Exception as exc:
+            if self.is_connectivity_error(exc):
+                _logger.error("Can't connect to cloud provider: %s", exc)
+                return False
+            raise
+
+    def is_connectivity_error(self, exc):
+        """
+        Determine whether the given exception denotes a loss of connectivity
+        to Google Cloud Storage.
+
+        :param Exception exc: the exception to inspect
+        :rtype: bool
+        """
+        return isinstance(exc, GoogleAPIError)
 
     def _check_bucket_existence(self):
         """

--- a/tests/test_barman_cloud_wal_restore.py
+++ b/tests/test_barman_cloud_wal_restore.py
@@ -159,6 +159,9 @@ class TestMain(object):
         cloud_interface_mock.download_file.side_effect = Exception(
             "something went wrong"
         )
+        # The exception is not a connectivity error, so it must be reported
+        # as a generic error (exit code 4).
+        cloud_interface_mock.is_connectivity_error.return_value = False
         with pytest.raises(SystemExit) as exc:
             cloud_walrestore.main(
                 [
@@ -171,4 +174,35 @@ class TestMain(object):
         assert exc.value.code == 4
         assert (
             "Barman cloud WAL restore exception: something went wrong\n" in caplog.text
+        )
+
+    @mock.patch("barman.clients.cloud_walrestore.get_cloud_interface")
+    def test_fails_on_network_error_during_download(
+        self, get_cloud_interface_mock, caplog
+    ):
+        """If a download fails and connectivity is lost we exit with status 2."""
+        cloud_interface_mock = get_cloud_interface_mock.return_value
+        cloud_interface_mock.path = "testfolder/"
+        cloud_interface_mock.list_bucket.return_value = [
+            "testfolder/test-server/wals/000000080000ABFF/000000080000ABFF000000C1"
+        ]
+        cloud_interface_mock.download_file.side_effect = Exception(
+            "connection reset by peer"
+        )
+        # The exception is a connectivity error, so the failure must be
+        # reported as a network error (exit code 2).
+        cloud_interface_mock.is_connectivity_error.return_value = True
+        with pytest.raises(SystemExit) as exc:
+            cloud_walrestore.main(
+                [
+                    "s3://test-bucket/testfolder/",
+                    "test-server",
+                    "000000080000ABFF000000C1",
+                    "/tmp/000000080000ABFF000000C1",
+                ]
+            )
+        assert exc.value.code == 2
+        assert (
+            "Barman cloud WAL restore exception: connection reset by peer\n"
+            in caplog.text
         )


### PR DESCRIPTION
## Description

When a WAL download fails, `barman-cloud-wal-restore` always exited with the generic code `4` (`GeneralErrorExit`), regardless of the cause. This prevented callers such as PostgreSQL's `restore_command` from telling a transient loss of connectivity apart from a genuine failure.

This change classifies the **original** exception rather than re-probing connectivity after the fact:

- Adds an `is_connectivity_error(exc)` method to `CloudInterface`, implemented by each provider in terms of the connectivity exceptions it already recognises:
  - AWS: `EndpointConnectionError`
  - Azure: `HttpResponseError`, `ServiceRequestError`
  - GCS: `GoogleAPIError`
- Refactors each provider's existing `test_connectivity()` to reuse the same predicate (DRY).
- In the `cloud-wal-restore` error path, if the original exception is a connectivity error it exits with code `2` (`NetworkErrorExit`); otherwise it keeps exiting with code `4`.

This brings `barman-cloud-wal-restore` in line with `barman-cloud-check-wal-archive`, which already distinguishes network failures, and lets automation apply different retry policies for transient network issues versus permanent errors.

## Testing

- `test_fails_on_network_error_during_download`: a connectivity error exits with code `2`.
- `test_fails_on_download_exception`: a non-connectivity failure exits with code `4`.
- Existing `tests/test_cloud.py` provider tests continue to pass.

Closes #1193