### PR TITLE
feat: add flag to disable bucket-level actions (e.g. HeadBucket) when checking WAL archive

### DIFF
--- a/barman/clients/cloud_check_wal_archive.py
+++ b/barman/clients/cloud_check_wal_archive.py
@@ -47,15 +47,20 @@ def main(args=None):
 
     try:
         cloud_interface = get_cloud_interface(config)
-        if not cloud_interface.test_connectivity():
-            # Deliberately raise an error if we cannot connect
-            raise NetworkErrorExit()
-        # If test is requested, just exit after connectivity test
+        if not config.assume_bucket_exists:
+            if not cloud_interface.test_connectivity():
+                # Deliberately raise an error if we cannot connect
+                raise NetworkErrorExit()
+            # If test is requested, just exit after connectivity test
+            elif config.test:
+                raise SystemExit(0)
         elif config.test:
+            _logger.warning("--test has no effect when --assume-bucket-exists is set")
             raise SystemExit(0)
 
         with closing(cloud_interface):
-            cloud_interface.setup_bucket()
+            if not config.assume_bucket_exists:
+                cloud_interface.setup_bucket()
 
             catalog = CloudBackupCatalog(cloud_interface, config.server_name)
             wals = list(catalog.get_wal_paths().keys())
@@ -92,6 +97,12 @@ def parse_arguments(args=None):
         "--timeline",
         help="The earliest timeline whose WALs should cause the check to fail",
         type=check_positive,
+    )
+    parser.add_argument(
+        "--assume-bucket-exists",
+        help="Assumes the bucket exists and can be accessed by the executing principal, skipping connectivity test and bucket creation.",
+        action="store_true",
+        default=False,
     )
     return parser.parse_args(args=args)
 

--- a/docs/user_guide/commands/barman_cloud/check_wal_archive.inc.rst
+++ b/docs/user_guide/commands/barman_cloud/check_wal_archive.inc.rst
@@ -12,6 +12,7 @@
                   [ --help ]
                   [ { { -v | --verbose } | { -q | --quiet } } ]
                   [ { -t | --test } ]
+                  [ --skip-bucket-checks ]
                   [ --cloud-provider { aws-s3 | azure-blob-storage | google-cloud-storage } ]
                   [ --endpoint-url ENDPOINT_URL ]
                   [ { -P | --aws-profile } AWS_PROFILE ]
@@ -30,12 +31,12 @@ Postgres cluster. By default, the check will succeed if the WAL archive is empty
 the target bucket is not found. Any other conditions will result in a failure.
 
 .. note::
-  The ``barman-cloud-check-wal-archive`` command performs an initial ``HeadBucket`` call
+  By default, the ``barman-cloud-check-wal-archive`` command performs an initial ``HeadBucket`` call
   to verify whether the target bucket already exists in the S3 storage. If the bucket
   does not exist, the command will attempt to automatically create it.
 
   This is the only Barman command that performs these operations (bucket existence check
-  and automatic creation).
+  and automatic creation). These operations can be skipped using the ``--skip-bucket-checks`` flag.
 
 .. note::
   For GCP, only authentication with ``GOOGLE_APPLICATION_CREDENTIALS`` env is supported.
@@ -64,6 +65,10 @@ the target bucket is not found. Any other conditions will result in a failure.
 
 ``-t`` / ``--test``
   Test cloud connectivity and exit.
+
+``--assume-bucket-exists``
+  Assumes the bucket exists and can be accessed by the executing principal, skipping 
+  connectivity test and bucket creation.
 
 ``--cloud-provider``
   The cloud provider to use as a storage backend.

--- a/docs/user_guide/commands/barman_cloud/check_wal_archive.inc.rst
+++ b/docs/user_guide/commands/barman_cloud/check_wal_archive.inc.rst
@@ -12,7 +12,7 @@
                   [ --help ]
                   [ { { -v | --verbose } | { -q | --quiet } } ]
                   [ { -t | --test } ]
-                  [ --skip-bucket-checks ]
+                  [ --assume-bucket-exists ]
                   [ --cloud-provider { aws-s3 | azure-blob-storage | google-cloud-storage } ]
                   [ --endpoint-url ENDPOINT_URL ]
                   [ { -P | --aws-profile } AWS_PROFILE ]
@@ -36,7 +36,7 @@ the target bucket is not found. Any other conditions will result in a failure.
   does not exist, the command will attempt to automatically create it.
 
   This is the only Barman command that performs these operations (bucket existence check
-  and automatic creation). These operations can be skipped using the ``--skip-bucket-checks`` flag.
+  and automatic creation). These operations can be skipped using the ``--assume-bucket-exists`` flag.
 
 .. note::
   For GCP, only authentication with ``GOOGLE_APPLICATION_CREDENTIALS`` env is supported.

--- a/docs/user_guide/commands/barman_cloud/check_wal_archive.inc.rst
+++ b/docs/user_guide/commands/barman_cloud/check_wal_archive.inc.rst
@@ -12,6 +12,7 @@
                   [ --help ]
                   [ { { -v | --verbose } | { -q | --quiet } } ]
                   [ { -t | --test } ]
+                  [ --assume-bucket-exists ]
                   [ --cloud-provider { aws-s3 | azure-blob-storage | google-cloud-storage } ]
                   [ --endpoint-url ENDPOINT_URL ]
                   [ { -P | --aws-profile } AWS_PROFILE ]
@@ -31,13 +32,14 @@ any WAL files are present in the archive, the check will fail, unless the ``--ti
 option is used and all existing WALs are from timelines earlier than the specified value.
 
 .. note::
-  The ``barman-cloud-check-wal-archive`` command performs an initial ``HeadBucket`` call
-  to verify whether the target bucket already exists in the S3 storage. If the bucket
-  does not exist, the command will attempt to automatically create it before performing
-  the WAL archive check.
+  By default, the ``barman-cloud-check-wal-archive`` command performs an initial
+  ``HeadBucket`` call to verify whether the target bucket already exists in the S3
+  storage. If the bucket does not exist, the command will attempt to automatically
+  create it before performing the WAL archive check.
 
   This is the only Barman command that performs these operations (bucket existence check
-  and automatic creation).
+  and automatic creation). These operations can be skipped using the
+  ``--assume-bucket-exists`` flag.
 
 .. note::
   For GCP, only authentication with ``GOOGLE_APPLICATION_CREDENTIALS`` env is supported.
@@ -66,6 +68,10 @@ option is used and all existing WALs are from timelines earlier than the specifi
 
 ``-t`` / ``--test``
   Test cloud connectivity and exit.
+
+``--assume-bucket-exists``
+  Assumes the bucket exists and can be accessed by the executing principal, skipping
+  connectivity test and bucket creation.
 
 ``--cloud-provider``
   The cloud provider to use as a storage backend.

--- a/src/barman/clients/cloud_check_wal_archive.py
+++ b/src/barman/clients/cloud_check_wal_archive.py
@@ -47,15 +47,20 @@ def main(args=None):
 
     try:
         cloud_interface = get_cloud_interface(config)
-        if not cloud_interface.test_connectivity():
-            # Deliberately raise an error if we cannot connect
-            raise NetworkErrorExit()
-        # If test is requested, just exit after connectivity test
+        if not config.assume_bucket_exists:
+            if not cloud_interface.test_connectivity():
+                # Deliberately raise an error if we cannot connect
+                raise NetworkErrorExit()
+            # If test is requested, just exit after connectivity test
+            elif config.test:
+                raise SystemExit(0)
         elif config.test:
+            _logger.warning("--test has no effect when --assume-bucket-exists is set")
             raise SystemExit(0)
 
         with closing(cloud_interface):
-            cloud_interface.setup_bucket()
+            if not config.assume_bucket_exists:
+                cloud_interface.setup_bucket()
 
             catalog = CloudBackupCatalog(cloud_interface, config.server_name)
             wals = list(catalog.get_wal_paths().keys())
@@ -92,6 +97,13 @@ def parse_arguments(args=None):
         "--timeline",
         help="The earliest timeline whose WALs should cause the check to fail",
         type=check_positive,
+    )
+    parser.add_argument(
+        "--assume-bucket-exists",
+        help="Assumes the bucket exists and can be accessed by the executing "
+        "principal, skipping connectivity test and bucket creation.",
+        action="store_true",
+        default=False,
     )
     return parser.parse_args(args=args)
 

--- a/tests/test_barman_cloud_check_wal_archive.py
+++ b/tests/test_barman_cloud_check_wal_archive.py
@@ -149,6 +149,47 @@ class TestCloudCheckWalArchive(object):
         assert 4 == exc.value.code
         assert "Barman cloud WAL archive check exception: oh dear" in caplog.text
 
+    @mock.patch("barman.clients.cloud_check_wal_archive.check_archive_usable")
+    @mock.patch("barman.clients.cloud_check_wal_archive.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_check_wal_archive.get_cloud_interface")
+    def test_check_wal_archive_assume_bucket_exists(
+        self,
+        mock_cloud_interface,
+        mock_cloud_backup_catalog,
+        mock_check_archive_usable,
+        cloud_backup_catalog,
+    ):
+        """Verify --assume-bucket-exists skips connectivity test and bucket setup"""
+        cloud_object_interface_mock = mock_cloud_interface.return_value
+        mock_cloud_backup_catalog.return_value = cloud_backup_catalog
+        cloud_check_wal_archive.main(
+            ["cloud_storage_url", "test_server", "--assume-bucket-exists"]
+        )
+        cloud_object_interface_mock.test_connectivity.assert_not_called()
+        cloud_object_interface_mock.setup_bucket.assert_not_called()
+        mock_check_archive_usable.assert_called_once_with(
+            ["000000010000000000000001"],
+            timeline=None,
+        )
+
+    @mock.patch("barman.clients.cloud_check_wal_archive.get_cloud_interface")
+    def test_check_wal_archive_assume_bucket_exists_with_test_warns(
+        self, mock_cloud_interface, caplog
+    ):
+        """Verify -t/--test is a no-op and outputs a warning when --assume-bucket-exists is set"""
+        with pytest.raises(SystemExit) as exc:
+            cloud_check_wal_archive.main(
+                [
+                    "cloud_storage_url",
+                    "test_server",
+                    "-t",
+                    "--assume-bucket-exists",
+                ]
+            )
+        assert 0 == exc.value.code
+        mock_cloud_interface.return_value.test_connectivity.assert_not_called()
+        assert "--test has no effect when --assume-bucket-exists is set" in caplog.text
+
     @mock.patch("barman.clients.cloud_check_wal_archive.get_cloud_interface")
     def test_check_wal_archive_failed_connectivity(self, mock_cloud_interface, caplog):
         """Verify the check errors if we cannot connect to the cloud provider"""

--- a/tests/test_barman_cloud_check_wal_archive.py
+++ b/tests/test_barman_cloud_check_wal_archive.py
@@ -149,6 +149,48 @@ class TestCloudCheckWalArchive(object):
         assert 4 == exc.value.code
         assert "Barman cloud WAL archive check exception: oh dear" in caplog.text
 
+    @mock.patch("barman.clients.cloud_check_wal_archive.check_archive_usable")
+    @mock.patch("barman.clients.cloud_check_wal_archive.CloudBackupCatalog")
+    @mock.patch("barman.clients.cloud_check_wal_archive.get_cloud_interface")
+    def test_check_wal_archive_assume_bucket_exists(
+        self,
+        mock_cloud_interface,
+        mock_cloud_backup_catalog,
+        mock_check_archive_usable,
+        cloud_backup_catalog,
+    ):
+        """Verify --assume-bucket-exists skips connectivity test and bucket setup"""
+        cloud_object_interface_mock = mock_cloud_interface.return_value
+        mock_cloud_backup_catalog.return_value = cloud_backup_catalog
+        cloud_check_wal_archive.main(
+            ["cloud_storage_url", "test_server", "--assume-bucket-exists"]
+        )
+        cloud_object_interface_mock.test_connectivity.assert_not_called()
+        cloud_object_interface_mock.setup_bucket.assert_not_called()
+        mock_check_archive_usable.assert_called_once_with(
+            ["000000010000000000000001"],
+            timeline=None,
+        )
+
+    @mock.patch("barman.clients.cloud_check_wal_archive.get_cloud_interface")
+    def test_check_wal_archive_assume_bucket_exists_with_test_warns(
+        self, mock_cloud_interface, caplog
+    ):
+        """Verify -t/--test is a no-op and outputs a warning when
+        --assume-bucket-exists is set"""
+        with pytest.raises(SystemExit) as exc:
+            cloud_check_wal_archive.main(
+                [
+                    "cloud_storage_url",
+                    "test_server",
+                    "-t",
+                    "--assume-bucket-exists",
+                ]
+            )
+        assert 0 == exc.value.code
+        mock_cloud_interface.return_value.test_connectivity.assert_not_called()
+        assert "--test has no effect when --assume-bucket-exists is set" in caplog.text
+
     @mock.patch("barman.clients.cloud_check_wal_archive.get_cloud_interface")
     def test_check_wal_archive_failed_connectivity(self, mock_cloud_interface, caplog):
         """Verify the check errors if we cannot connect to the cloud provider"""


### PR DESCRIPTION
## What?
I've added a simple CLI flag for the `barman-cloud-check-wal-archive` command that allows disabling the bucket-level actions (e.g. HeadBucket and CreateBucket) that require bucket-level permissions. This change would also be a first step towards fixing #929, which was previously fixed and then reverted due to #1101 considerations.

## Why?
When dealing with strict security requirements, or multi-tenant buckets, this flag can be used to have the aforementioned command skip the `test_connectivity` and `setup_bucket` calls, which would require bucket-level access from the executing principal (e.g. unprefixed ListBucket). Removing these actions would allow plugins, such as CNPG barman cloud plugin, to skip such checks, while retaining safety (check if bucket path is empty) and security (allowing only prefixed ListBucket calls).

## How?
I think the implementation is straightforward. However, I would point out that specifying `--test` and `--assume-bucket-exists` together would now result in `--test` being a no-op. I personally think this is fine since `--assume-bucket-exists` is disabled by default, thus making the change non-breaking with existing users of this project.

## Testing
I've added a couple of test cases that should cover the new branches I've created. The first ensures that, when the flag is enabled, that no bucket-level operation is called. The latter verifies the behavior when `-t/--test` and `--assume-bucket-exists` are both passed.

## Docs
I've also added the CLI flag to the docs. Please let me know if more work shall be done there.