### PR TITLE
Fix TypeError on snapshot restore: forward copy_partial through SnapshotRecoveryExecutor

### DIFF
--- a/src/barman/recovery_executor.py
+++ b/src/barman/recovery_executor.py
@@ -1893,6 +1893,7 @@ class SnapshotRecoveryExecutor(RemoteConfigRecoveryExecutor):
         recovery_conf_filename=None,
         recovery_option_port=None,
         custom_restore_command=None,
+        copy_partial=False,
         recovery_instance=None,
     ):
         """
@@ -1926,6 +1927,9 @@ class SnapshotRecoveryExecutor(RemoteConfigRecoveryExecutor):
             when invoking ``barman-wal-restore``
         :param str|None custom_restore_command: Custom command to use for the
             restore command (only works when get-wal is enabled)
+        :param bool copy_partial: when ``True``, ``.partial`` WAL files are copied to
+            the recovery destination with the ``.partial`` suffix stripped. Defaults
+            to ``False``.
         :param str|None recovery_instance: The name of the recovery node as it
             is known by the cloud provider
         """
@@ -1963,6 +1967,7 @@ class SnapshotRecoveryExecutor(RemoteConfigRecoveryExecutor):
             recovery_conf_filename=recovery_conf_filename,
             recovery_option_port=recovery_option_port,
             custom_restore_command=custom_restore_command,
+            copy_partial=copy_partial,
         )
 
     def _start_backup_copy_message(self):

--- a/tests/test_recovery_executor.py
+++ b/tests/test_recovery_executor.py
@@ -2739,7 +2739,59 @@ class TestSnapshotRecoveryExecutor(object):
             recovery_conf_filename=None,
             recovery_option_port=None,
             custom_restore_command=None,
+            copy_partial=False,
         )
+
+    @mock.patch("barman.recovery_executor.RecoveryExecutor.recover")
+    @mock.patch("barman.recovery_executor.fs")
+    @mock.patch("barman.recovery_executor.get_snapshot_interface_from_backup_info")
+    def test_recover_copy_partial_forwarded(
+        self,
+        mock_get_snapshot_interface,
+        _mock_fs,
+        mock_superclass_recover,
+    ):
+        """Verify that copy_partial is accepted and forwarded to the superclass."""
+        # GIVEN a SnapshotRecoveryExecutor
+        mock_backup_manager = mock.Mock()
+        executor = SnapshotRecoveryExecutor(mock_backup_manager)
+        # AND a mock backup_info with snapshots
+        backup_info = mock.Mock(
+            snapshots_info=mock.Mock(
+                snapshots=[
+                    mock.Mock(
+                        identifier="snapshot0",
+                        device="/dev/dev0",
+                        mount_point="/opt/disk0",
+                        mount_options="rw,noatime",
+                    ),
+                ]
+            )
+        )
+        # AND the correct volume is attached
+        attached_volumes = {"disk0": mock.Mock(source_snapshot="snapshot0")}
+
+        def mock_resolve_mounted_volume(_cmd):
+            attached_volumes["disk0"].mount_point = "/opt/disk0"
+            attached_volumes["disk0"].mount_options = "rw,noatime"
+
+        attached_volumes[
+            "disk0"
+        ].resolve_mounted_volume.side_effect = mock_resolve_mounted_volume
+        mock_get_snapshot_interface.return_value.get_attached_volumes.return_value = (
+            attached_volumes
+        )
+
+        # WHEN recover is called with copy_partial=True
+        executor.recover(
+            backup_info,
+            "/path/to/dest",
+            recovery_instance="test_instance",
+            copy_partial=True,
+        )
+
+        # THEN the superclass recovery method was called with copy_partial=True
+        assert mock_superclass_recover.call_args.kwargs["copy_partial"] is True
 
     @pytest.mark.parametrize(
         (


### PR DESCRIPTION
## Problem

Every snapshot restore fails with:

```
TypeError: recover() got an unexpected keyword argument 'copy_partial'
```

`SnapshotRecoveryExecutor.recover()` overrides the base `RecoveryExecutor.recover()`, but its signature was never updated when `copy_partial` was added to the base method. Because `restore` always passes `copy_partial` down the call chain (`cli.py` → `server.recover` → `backup_manager.recover` → `executor.recover`, all via `**kwargs`), the argument lands on the snapshot executor, which doesn't accept it — raising the `TypeError` for any backup whose `snapshots_info` is set.

The non-snapshot path (`MainRecoveryExecutor`) is unaffected because it inherits the base `recover()` unchanged.

## Fix

- Add `copy_partial=False` to `SnapshotRecoveryExecutor.recover()`'s signature (plus docstring).
- Forward `copy_partial=copy_partial` to `super().recover(...)`. Without this, even after accepting the kwarg the `.partial` WAL handling would be silently dropped for snapshot recoveries.

## Tests

- Added `test_recover_copy_partial_forwarded` asserting a truthy `copy_partial` reaches `super().recover()`.
- Updated `test_recover_success`'s superclass-call assertion to include the now-forwarded `copy_partial=False`.

Full `tests/test_recovery_executor.py` suite passes (196 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)