### PR TITLE
Warn instead of raising when a WAL directory is already gone

### DIFF
--- a/src/barman/wal_archiver.py
+++ b/src/barman/wal_archiver.py
@@ -457,6 +457,21 @@ class LocalWalStorageStrategy(WalStorageStrategy):
     def delete(self, wals_to_delete):
         wals_deleted = []
         for wal_dir, wal_list in wals_to_delete.items():
+            if not os.path.isdir(wal_dir):
+                # The directory has already gone, so there is nothing to unlink.
+                # Warn and carry on rather than aborting the whole delete, which
+                # would leave the backup half removed. This mirrors how
+                # _delete_wal_file() treats an OSError on an individual file.
+                error = (
+                    "Ignoring deletion of WAL directory %s for server %s: "
+                    "directory does not exist" % (wal_dir, self.config.name)
+                )
+                output.warning(error)
+                for wal_info in wal_list:
+                    self._run_pre_delete_wal_scripts(wal_info)
+                    self._run_post_delete_wal_scripts(wal_info, error)
+                    wals_deleted.append(wal_info.name)
+                continue
             delete_directory = False
             # Each directory can contain up to 256 WAL files. If the deletion list
             # contains 256 entries, the entire directory can be safely deleted

--- a/tests/test_wal_archiver.py
+++ b/tests/test_wal_archiver.py
@@ -1944,7 +1944,10 @@ class TestLocalWalStorageStrategy:
 
     @patch("barman.wal_archiver.LocalWalStorageStrategy._delete_wal_file")
     @patch("barman.wal_archiver.os.listdir")
-    def test_delete_wal_files_individually(self, mock_listdir, mock_delete_file):
+    @patch("barman.wal_archiver.os.path.isdir", return_value=True)
+    def test_delete_wal_files_individually(
+        self, _mock_isdir, mock_listdir, mock_delete_file
+    ):
         """
         Test that :meth:`delete` correctly deletes specified WAL files individually
         when the whole WAL directory can not be deleted altogether.
@@ -1968,9 +1971,60 @@ class TestLocalWalStorageStrategy:
         # THEN delete_wal_file is called for each requested WAL file
         mock_delete_file.assert_has_calls([call(wal_info1), call(wal_info2)])
 
+    @patch("barman.wal_archiver.LocalWalStorageStrategy._run_post_delete_wal_scripts")
+    @patch("barman.wal_archiver.LocalWalStorageStrategy._run_pre_delete_wal_scripts")
+    @patch("barman.wal_archiver.LocalWalStorageStrategy._delete_wal_directory")
+    @patch("barman.wal_archiver.LocalWalStorageStrategy._delete_wal_file")
+    @patch("barman.wal_archiver.os.listdir")
+    @patch("barman.wal_archiver.os.path.isdir", return_value=False)
+    def test_delete_missing_directory(
+        self,
+        _mock_isdir,
+        mock_listdir,
+        mock_delete_file,
+        mock_delete_directory,
+        mock_pre_scripts,
+        mock_post_scripts,
+        capsys,
+    ):
+        """
+        Test that :meth:`delete` warns and carries on when the WAL directory has
+        already been removed by other means, instead of raising (GH-1213).
+        """
+        # GIVEN two WALs whose directory no longer exists
+        wal_info1, wal_info2 = MagicMock(), MagicMock()
+        wal_info1.name = "000000010000000000000001"
+        wal_info2.name = "000000010000000000000002"
+        wals_to_delete = {"/server/wals/0000000100000001": [wal_info1, wal_info2]}
+        wal_storage = LocalWalStorageStrategy(
+            build_backup_manager(name="TestServer"), None
+        )
+
+        # WHEN delete is called
+        wals_deleted = wal_storage.delete(wals_to_delete)
+
+        # THEN the directory is never listed or removed, and no file is unlinked
+        mock_listdir.assert_not_called()
+        mock_delete_directory.assert_not_called()
+        mock_delete_file.assert_not_called()
+        # AND both WALs are reported as deleted, as they are already gone
+        assert wals_deleted == [wal_info1.name, wal_info2.name]
+        # AND a warning names the directory
+        _, err = capsys.readouterr()
+        assert "/server/wals/0000000100000001" in err
+        assert "directory does not exist" in err
+        # AND the hook scripts still run for every WAL, with the error passed on
+        mock_pre_scripts.assert_has_calls([call(wal_info1), call(wal_info2)])
+        assert mock_post_scripts.call_count == 2
+        for mock_call in mock_post_scripts.call_args_list:
+            assert mock_call.args[1] is not None
+
     @patch("barman.wal_archiver.LocalWalStorageStrategy._delete_wal_directory")
     @patch("barman.wal_archiver.os.listdir")
-    def test_delete_whole_directory(self, mock_listdir, mock_delete_directory):
+    @patch("barman.wal_archiver.os.path.isdir", return_value=True)
+    def test_delete_whole_directory(
+        self, _mock_isdir, mock_listdir, mock_delete_directory
+    ):
         """
         Test that :meth:`delete` correctly deletes the whole wal directory
         when suitable.


### PR DESCRIPTION
Closes #1213

## The cause

The traceback in #1213 names a *directory*, not a file:

```
EXCEPTION: [Errno 2] No such file or directory: /opt/barman/backups/pg/wals/0000000900003E12
```

That comes from `os.listdir(wal_dir)` in `LocalWalStorageStrategy.delete()`. The listing happens before the choice between removing the hash directory wholesale and unlinking files one by one, so if the directory has been removed outside Barman the delete aborts there — after the WALs are dropped from the xlogdb but before `delete_basebackup()` and `delete_backupinfo_file()`. The backup is left half removed, which is why the reporter resorted to re-running `barman delete` in a loop and `mkdir`-ing the missing directories back.

## The change

`delete()` now checks the directory first. A missing one is warned about and its WALs are reported as deleted, since they are in fact gone.

@martinmarques said on the issue:

> My feeling is that that should be a WARNING and not an exception

and the reporter agreed, so that is what this does. The wording and structure follow `_delete_wal_file()`, which already swallows an `OSError` on an individual file, warns with `Ignoring deletion of WAL file ...`, and lets the caller count it as deleted. Hook scripts still run for every WAL, and the post-delete script receives the error, matching the file-level path.

## Tests

`test_delete_missing_directory` covers the new branch: nothing is listed, no directory or file removal is attempted, both WALs come back in the return value, the warning names the directory, and both hook scripts run with the error passed on.

Two existing tests, `test_delete_wal_files_individually` and `test_delete_whole_directory`, use fictional paths like `/server/wals/0000000100000001` and patch only `os.listdir`. They tripped the new `os.path.isdir` check and failed, so they now patch it too. Flagging that explicitly since it is a change to existing tests rather than only additions.

## Verification

- `pytest tests/test_wal_archiver.py -k delete` — 11 passed
- `pytest tests/test_wal_archiver.py tests/test_backup.py` — 283 passed, 2 failed
- Those 2 failures are **pre-existing**: `test_delete_cloud_backup_data_check_object_lock[True]` and `test_delete_cloud_backup_data_check_object_lock_non_s3_warning` fail identically with my changes stashed on a clean checkout
- Reverting only `src/barman/wal_archiver.py` and keeping the tests fails exactly one test, `test_delete_missing_directory`
- `ruff check` and `ruff format --check` clean on both files. The `E501` lines a stray `flake8` run reports in that file are pre-existing and untouched

I could not install the project with its pinned `psycopg2` (no `pg_config` on this machine), so I ran the suite against `src/` with `--no-deps`. Nothing in this change touches the PostgreSQL client path.

## AI disclosure

Prepared with Claude Opus 5 in Claude Code: it traced the traceback to the `os.listdir` call, wrote the guard and the test, and drafted this description. I reviewed the diff and ran everything listed above. Per the AI policy in this repository, I can explain the change and stand behind it.